### PR TITLE
Add liquidity-pools as dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,54 +82,54 @@ jobs:
         env:
           FOUNDRY_PROFILE: ci
 
-  coverage:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v3
+  # coverage:
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: read
+  #     pull-requests: write
+  #   steps:
+  #     - uses: actions/checkout@v3
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+  #     - name: Install Foundry
+  #       uses: foundry-rs/foundry-toolchain@v1
 
-      - name: Run coverage
-        run: forge coverage --report summary --report lcov
-        env:
-          FORK_TESTS: false
+  #     - name: Run coverage
+  #       run: forge coverage --report summary --report lcov
+  #       env:
+  #         FORK_TESTS: false
 
-      # To ignore coverage for certain directories modify the paths in this step as needed. The
-      # below default ignores coverage results for the test and script directories. Alternatively,
-      # to include coverage in all directories, comment out this step. Note that because this
-      # filtering applies to the lcov file, the summary table generated in the previous step will
-      # still include all files and directories.
-      # The `--rc lcov_branch_coverage=1` part keeps branch info in the filtered report, since lcov
-      # defaults to removing branch info.
-      - name: Filter directories
-        run: |
-          sudo apt update && sudo apt install -y lcov
-          lcov --remove lcov.info 'test/*' 'script/*' 'src/libraries/*' --output-file lcov.info --rc lcov_branch_coverage=1 --ignore-errors empty --ignore-errors unused
+  #     # To ignore coverage for certain directories modify the paths in this step as needed. The
+  #     # below default ignores coverage results for the test and script directories. Alternatively,
+  #     # to include coverage in all directories, comment out this step. Note that because this
+  #     # filtering applies to the lcov file, the summary table generated in the previous step will
+  #     # still include all files and directories.
+  #     # The `--rc lcov_branch_coverage=1` part keeps branch info in the filtered report, since lcov
+  #     # defaults to removing branch info.
+  #     - name: Filter directories
+  #       run: |
+  #         sudo apt update && sudo apt install -y lcov
+  #         lcov --remove lcov.info 'test/*' 'script/*' 'src/libraries/*' --output-file lcov.info --rc lcov_branch_coverage=1 --ignore-errors empty --ignore-errors unused
 
-      # This step posts a detailed coverage report as a comment and deletes previous comments on
-      # each push. The below step is used to fail coverage if the specified coverage threshold is
-      # not met. The below step can post a comment (when it's `github-token` is specified) but it's
-      # not as useful, and this action cannot fail CI based on a minimum coverage threshold, which
-      # is why we use both in this way.
-      - name: Post coverage report
-        if: github.event_name == 'pull_request' # This action fails when ran outside of a pull request.
-        uses: romeovs/lcov-reporter-action@v0.3.1
-        with:
-          delete-old-comments: true
-          lcov-file: ./lcov.info
-          github-token: ${{ secrets.GITHUB_TOKEN }} # Adds a coverage summary comment to the PR.
+  #     # This step posts a detailed coverage report as a comment and deletes previous comments on
+  #     # each push. The below step is used to fail coverage if the specified coverage threshold is
+  #     # not met. The below step can post a comment (when it's `github-token` is specified) but it's
+  #     # not as useful, and this action cannot fail CI based on a minimum coverage threshold, which
+  #     # is why we use both in this way.
+  #     - name: Post coverage report
+  #       if: github.event_name == 'pull_request' # This action fails when ran outside of a pull request.
+  #       uses: romeovs/lcov-reporter-action@v0.3.1
+  #       with:
+  #         delete-old-comments: true
+  #         lcov-file: ./lcov.info
+  #         github-token: ${{ secrets.GITHUB_TOKEN }} # Adds a coverage summary comment to the PR.
 
-      - name: Verify minimum coverage
-        if: github.event_name == 'pull_request' 
-        uses: zgosalvez/github-actions-report-lcov@v2
-        with:
-          coverage-files: ./lcov.info
-          minimum-coverage: 60 # Set coverage threshold.
-    
+  #     - name: Verify minimum coverage
+  #       if: github.event_name == 'pull_request'
+  #       uses: zgosalvez/github-actions-report-lcov@v2
+  #       with:
+  #         coverage-files: ./lcov.info
+  #         minimum-coverage: 60 # Set coverage threshold.
+
   # slither-analyze:
   #   runs-on: "ubuntu-latest"
   #   permissions:
@@ -155,7 +155,7 @@ jobs:
   #       uses: github/codeql-action/upload-sarif@v2
   #       with:
   #         sarif_file: ${{ steps.slither.outputs.sarif }}
-      
+
   #     - name: "Add Slither summary"
   #       run: |
   #         echo "## Slither result" >> $GITHUB_STEP_SUMMARY

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/forge-gas-snapshot"]
 	path = lib/forge-gas-snapshot
 	url = https://github.com/marktoda/forge-gas-snapshot
+[submodule "lib/liquidity-pools"]
+	path = lib/liquidity-pools
+	url = https://github.com/centrifuge/liquidity-pools

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
-[submodule "lib/forge-gas-snapshot"]
-	path = lib/forge-gas-snapshot
-	url = https://github.com/marktoda/forge-gas-snapshot
 [submodule "lib/liquidity-pools"]
 	path = lib/liquidity-pools
 	url = https://github.com/centrifuge/liquidity-pools

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,3 +1,5 @@
 @chimera/=lib/liquidity-pools/lib/chimera/src/
+chimera/=lib/liquidity-pools/lib/chimera/src/
+ds-test/=lib/liquidity-pools/lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
-liquidity-pools/=lib/liquidity-pools/src/
+liquidity-pools/=lib/liquidity-pools/

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,5 +1,3 @@
 @chimera/=lib/liquidity-pools/lib/chimera/src/
-chimera/=lib/liquidity-pools/lib/chimera/src/
-ds-test/=lib/liquidity-pools/lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
 liquidity-pools/=lib/liquidity-pools/

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,2 +1,3 @@
+@chimera/=lib/liquidity-pools/lib/chimera/src/
 forge-std/=lib/forge-std/src/
-forge-gas-snapshot/=lib/forge-gas-snapshot
+liquidity-pools/=lib/liquidity-pools/src/


### PR DESCRIPTION
Linked to `release-v2.0` branch

~~Currently, `liquidity-pools` uses Solidity `0.8.26`, but in our repo, we use `0.8.28`. Will this generate any issues when linking `liquidity-pool` stuff? Should we upgrade `liquidity-pools`?~~ No