### PR TITLE
fix: Ubuntu-latest doesn't resolve to the latest lts (24.04). Explicitly specified until supported.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Filter directories
         run: |
           sudo apt update && sudo apt install -y lcov
-          lcov --remove lcov.info 'test/*' 'script/*' 'src/libraries/*' --output-file lcov.info --rc lcov_branch_coverage=1 --ignore-errors empty --ignore-errors unused
+          lcov --remove lcov.info 'test/*' 'script/*' 'src/libraries/*' --output-file lcov.info --rc branch_coverage=1 --ignore-errors empty --ignore-errors unused
 
       # This step posts a detailed coverage report as a comment and deletes previous comments on
       # each push. The below step is used to fail coverage if the specified coverage threshold is
@@ -125,9 +125,9 @@ jobs:
 
       - name: Verify minimum coverage
         if: github.event_name == 'pull_request' 
-        uses: zgosalvez/github-actions-report-lcov@v2
+        uses: zgosalvez/github-actions-report-lcov@v3
         with:
-          coverage-files: ./lcov.info
+          coverage-files: ./lcov.info --ignore-errors empty --ignore-errors unused
           minimum-coverage: 60 # Set coverage threshold.
     
   # slither-analyze:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           FOUNDRY_PROFILE: ci
 
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Github tried to roll out the newest image but something has happened and the `ubuntu-latest` doesn't resolve to ubuntu 24.04 LTS. 
Read more [here](https://github.com/actions/runner-images/issues/10636#issuecomment-2401625371)