### PR TITLE
Oracle Contract implementation

### DIFF
--- a/src/Oracle.sol
+++ b/src/Oracle.sol
@@ -5,6 +5,7 @@ import {IERC7726, IERC7726} from "src/interfaces/IERC7726.sol";
 import {IERC20} from "forge-std/interfaces/IERC20.sol";
 import {MathLib} from "src/libraries/MathLib.sol";
 
+/// @notice Quote value representation value representation
 struct Quote {
     /// @notice Price of one base in quote denomination
     uint256 amount;
@@ -86,15 +87,16 @@ contract OracleFactory {
     /// @param salt Extra bytes to generate different address for the same feeder.
     function deploy(address feeder, bytes32 salt) external returns (Oracle) {
         Oracle deployed = new Oracle{salt: salt}(feeder);
+
         emit NewOracleDeployed(address(deployed));
 
         return deployed;
     }
 
-    /// Retuns the deterministic contract address for a feeder.
+    /// @notice Retuns the deterministic contract address for a feeder.
     /// @param feeder The account that will be able to fed values in the contract.
     /// @param salt Extra bytes to generate different address for the same feeder.
-    function oracleAddress(address feeder, bytes32 salt) public view returns (address) {
+    function getAddress(address feeder, bytes32 salt) public view returns (address) {
         bytes memory bytecode = abi.encodePacked(type(Oracle).creationCode, abi.encode(feeder));
 
         return address(

--- a/src/Oracle.sol
+++ b/src/Oracle.sol
@@ -6,6 +6,8 @@ import {IERC20} from "forge-std/interfaces/IERC20.sol";
 import {MathLib} from "src/libraries/MathLib.sol";
 
 contract Oracle is IERC7726 {
+    uint8 public constant DEFAULT_DECIMALS = 18;
+
     /// @notice Dispatched when the action is not performed by the required feeder.
     error NotValidFeeder();
 
@@ -63,13 +65,13 @@ contract Oracle is IERC7726 {
     /// - Otherwise we assume 18 decimals
     function _extractDecimals(address assetId) internal view returns (uint8) {
         if (assetId.code.length == 0) {
-            return 18;
+            return DEFAULT_DECIMALS;
         } else {
             (bool ok, bytes memory data) = assetId.staticcall(abi.encodeWithSelector(IERC20.decimals.selector));
             if (ok) {
                 return abi.decode(data, (uint8));
             } else {
-                return 18;
+                return DEFAULT_DECIMALS;
             }
         }
     }

--- a/src/Oracle.sol
+++ b/src/Oracle.sol
@@ -17,7 +17,7 @@ contract Oracle is IERC7726 {
     /// @notice Emitted when the contract is feed with a new quote amount.
     event Fed(address indexed base, address indexed quote, uint256 quoteAmount, uint64 referenceTime);
 
-    struct Value {
+    struct Quote {
         /// @notice Price of one base in quote denomination
         uint256 amount;
         /// @notice Timestamp when the value was fed
@@ -25,10 +25,10 @@ contract Oracle is IERC7726 {
     }
 
     /// @notice Owner of the contract able to feed new values
-    address feeder;
+    address public feeder;
 
     /// @notice All fed values.
-    mapping(address base => mapping(address quote => Value)) public values;
+    mapping(address base => mapping(address quote => Quote)) public values;
 
     /// @dev check that only the feeder perform the action
     modifier onlyFeeder() {
@@ -47,14 +47,14 @@ contract Oracle is IERC7726 {
     /// @param quoteAmount The amount of 1 wei of base amount represented as quote units.
     function setQuote(address base, address quote, uint256 quoteAmount) external onlyFeeder {
         uint64 referenceTime = uint64(block.timestamp);
-        values[base][quote] = Value(quoteAmount, referenceTime);
+        values[base][quote] = Quote(quoteAmount, referenceTime);
 
         emit Fed(base, quote, quoteAmount, referenceTime);
     }
 
     /// @inheritdoc IERC7726
     function getQuote(uint256 baseAmount, address base, address quote) external view returns (uint256 quoteAmount) {
-        Value storage quoteValue = values[base][quote];
+        Quote storage quoteValue = values[base][quote];
         require(quoteValue.referenceTime > 0, NeverFed());
 
         return MathLib.mulDiv(baseAmount, quoteValue.amount, 10 ** _extractDecimals(base));

--- a/src/Oracle.sol
+++ b/src/Oracle.sol
@@ -55,12 +55,14 @@ contract Oracle is IOracle {
     /// - Otherwise we assume 18 decimals
     function _extractDecimals(address assetId) internal view returns (uint8) {
         if (assetId.code.length == 0) {
+            // It means, it is not an contract address
             return DEFAULT_DECIMALS;
         } else {
             (bool ok, bytes memory data) = assetId.staticcall(abi.encodeWithSelector(IERC20.decimals.selector));
             if (ok) {
                 return abi.decode(data, (uint8));
             } else {
+                // It means, it is no an ERC20 address or the static call reverted
                 return DEFAULT_DECIMALS;
             }
         }

--- a/src/Oracle.sol
+++ b/src/Oracle.sol
@@ -3,6 +3,7 @@ pragma solidity = 0.8.28;
 
 import {IERC7726, IERC7726} from "src/interfaces/IERC7726.sol";
 import {IERC20} from "forge-std/interfaces/IERC20.sol";
+import {IOracle, IOracleFactory} from "src/interfaces/IOracle.sol";
 import {MathLib} from "src/libraries/MathLib.sol";
 
 /// @notice Quote value representation value representation
@@ -13,7 +14,8 @@ struct Quote {
     uint64 referenceTime;
 }
 
-contract Oracle is IERC7726 {
+contract Oracle is IOracle {
+    /// @notice Default decimal representation when `base` is not an ERC20.
     uint8 public constant DEFAULT_DECIMALS = 18;
 
     /// @notice Owner of the contract able to feed new values
@@ -21,15 +23,6 @@ contract Oracle is IERC7726 {
 
     /// @notice All fed values.
     mapping(address base => mapping(address quote => Quote)) public values;
-
-    /// @notice Dispatched when the action is not performed by the required feeder.
-    error NotValidFeeder();
-
-    /// @notice Dispatched when the base/quote pair has never been fed.
-    error NoQuote();
-
-    /// @notice Emitted when the contract is fed with a new quote amount.
-    event NewQuoteSet(address indexed base, address indexed quote, uint256 quoteAmount, uint64 referenceTime);
 
     constructor(address feeder_) {
         feeder = feeder_;
@@ -41,11 +34,7 @@ contract Oracle is IERC7726 {
         _;
     }
 
-    /// @notice Feed the contract with a new base -> quote relation.
-    /// @param base The identification of the base element. If it corresponds to an ERC20, the internal computations
-    /// will use the attached decimals of that asset. If not 18 decimals will be used.
-    /// @param quote Same as `base` but for `quote`.
-    /// @param quoteAmount The amount of 1 wei of base amount represented as quote units.
+    /// @inheritdoc IOracle
     function setQuote(address base, address quote, uint256 quoteAmount) external onlyFeeder {
         uint64 referenceTime = uint64(block.timestamp);
         values[base][quote] = Quote(quoteAmount, referenceTime);
@@ -78,14 +67,9 @@ contract Oracle is IERC7726 {
     }
 }
 
-contract OracleFactory {
-    /// @notice Emitted when a new oracle contract is deployed.
-    event NewOracleDeployed(address where);
-
-    /// @notice Deploy a new oracle contract for an specific feeder.
-    /// @param feeder The account that will be able to fed values in the contract.
-    /// @param salt Extra bytes to generate different address for the same feeder.
-    function deploy(address feeder, bytes32 salt) external returns (Oracle) {
+contract OracleFactory is IOracleFactory {
+    /// @inheritdoc IOracleFactory
+    function deploy(address feeder, bytes32 salt) external returns (IOracle) {
         Oracle deployed = new Oracle{salt: salt}(feeder);
 
         emit NewOracleDeployed(address(deployed));
@@ -93,9 +77,7 @@ contract OracleFactory {
         return deployed;
     }
 
-    /// @notice Retuns the deterministic contract address for a feeder.
-    /// @param feeder The account that will be able to fed values in the contract.
-    /// @param salt Extra bytes to generate different address for the same feeder.
+    /// @inheritdoc IOracleFactory
     function getAddress(address feeder, bytes32 salt) public view returns (address) {
         bytes memory bytecode = abi.encodePacked(type(Oracle).creationCode, abi.encode(feeder));
 

--- a/src/Oracle.sol
+++ b/src/Oracle.sol
@@ -2,26 +2,33 @@
 pragma solidity = 0.8.28;
 
 import {IERC7726, IERC7726} from "src/interfaces/IERC7726.sol";
-import {IERC165} from "forge-std/interfaces/IERC165.sol";
 import {IERC20} from "forge-std/interfaces/IERC20.sol";
 import {MathLib} from "src/libraries/MathLib.sol";
 
 contract Oracle is IERC7726 {
+    /// @notice Dispatched when the action is not performed by the required feeder.
     error NotValidFeeder();
-    error ValueNotFound();
 
-    event Fed(address indexed base, address indexed quote, uint256 quoteAmount);
+    /// @notice Dispatched when the base/quote pair has never been feed.
+    error NeverFed();
+
+    /// @notice Emitted when the contract is feed with a new quote amount.
+    event Fed(address indexed base, address indexed quote, uint256 quoteAmount, uint64 referenceTime);
 
     struct Value {
-        /// Price of one base in quote denomination
+        /// @notice Price of one base in quote denomination
         uint256 amount;
-        /// Timestamp when the value was fed
+        /// @notice Timestamp when the value was fed
         uint64 referenceTime;
     }
 
+    /// @notice Owner of the contract able to feed new values
     address feeder;
+
+    /// @notice All fed values.
     mapping(address base => mapping(address quote => Value)) public values;
 
+    /// @dev check that only the feeder perform the action
     modifier onlyFeeder() {
         require(msg.sender == feeder, NotValidFeeder());
         _;
@@ -31,43 +38,65 @@ contract Oracle is IERC7726 {
         feeder = feeder_;
     }
 
-    /// @notice Feed the system with a new base -> quote relation.
-    /// @param base The identification of the base element
-    /// @param quote The identification of the quote element
+    /// @notice Feed the contract with a new base -> quote relation.
+    /// @param base The identification of the base element. If it corresponds to an ERC20, the internal computations
+    /// will use the attached decimals of that asset. If not 18 decimals will be used.
+    /// @param quote Same as `base` but for `quote`.
     /// @param quoteAmount The amount of 1 wei of base amount represented as quote units.
     function setQuote(address base, address quote, uint256 quoteAmount) external onlyFeeder {
-        values[base][quote] = Value(quoteAmount, uint64(block.timestamp));
+        uint64 referenceTime = uint64(block.timestamp);
+        values[base][quote] = Value(quoteAmount, referenceTime);
 
-        emit Fed(base, quote, quoteAmount);
+        emit Fed(base, quote, quoteAmount, referenceTime);
     }
 
     /// @inheritdoc IERC7726
     function getQuote(uint256 baseAmount, address base, address quote) external view returns (uint256 quoteAmount) {
         Value storage quoteValue = values[base][quote];
-        require(quoteValue.referenceTime > 0, ValueNotFound());
+        require(quoteValue.referenceTime > 0, NeverFed());
 
-        return MathLib.mulDiv(baseAmount, quoteValue.amount, 1 ** _extractDecimals(base));
+        return MathLib.mulDiv(baseAmount, quoteValue.amount, 10 ** _extractDecimals(base));
     }
 
     /// @dev extract the decimals used for the assetId
     /// - If the asset is an ERC20, then we ask the contract for its decimals
     /// - Otherwise we assume 18 decimals
     function _extractDecimals(address assetId) internal view returns (uint8) {
-        if (IERC165(assetId).supportsInterface(type(IERC20).interfaceId)) {
-            IERC20 erc20 = IERC20(assetId);
-            return erc20.decimals();
-        } else {
+        if (assetId.code.length == 0) {
             return 18;
+        } else {
+            (bool ok, bytes memory data) = assetId.staticcall(abi.encodeWithSelector(IERC20.decimals.selector));
+            if (ok) {
+                return abi.decode(data, (uint8));
+            } else {
+                return 18;
+            }
         }
     }
 }
 
 contract OracleFactory {
-    event NewOracle(address where);
+    /// @notice Emitted when a new oracle contract is deployed.
+    event NewOracleDeployed(address where);
 
-    function build(address feeder) external {
-        address deployed = address(new Oracle(feeder));
+    /// @notice Deploy a new oracle contract for an specific feeder.
+    /// @param feeder The account that will be able to fed values in the contract.
+    /// @param salt Extra bytes to generate different address for the same feeder.
+    function deploy(address feeder, bytes32 salt) external returns (Oracle) {
+        Oracle deployed = new Oracle{salt: salt}(feeder);
+        emit NewOracleDeployed(address(deployed));
 
-        emit NewOracle(deployed);
+        return deployed;
+    }
+
+    /// Retuns the deterministic contract address for a feeder.
+    /// @param feeder The account that will be able to fed values in the contract.
+    /// @param salt Extra bytes to generate different address for the same feeder.
+    function oracleAddress(address feeder, bytes32 salt) public view returns (address) {
+        bytes memory bytecode = abi.encodePacked(type(Oracle).creationCode, abi.encode(feeder));
+
+        return address(
+            uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), address(this), salt, keccak256(bytecode)))))
+        );
     }
 }

--- a/src/Oracle.sol
+++ b/src/Oracle.sol
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity = 0.8.28;
+
+import {IERC7726, IERC7726Ext} from "src/interfaces/IERC7726.sol";
+import {IERC165} from "forge-std/interfaces/IERC165.sol";
+import {IERC20} from "forge-std/interfaces/IERC20.sol";
+
+contract Oracle is IERC7726Ext {
+    error NotValidFeeder();
+    error ValueNotFound();
+
+    event Fed(address indexed base, address indexed quote, uint256 quoteAmount);
+
+    struct Value {
+        /// Price of one base in quote denomination
+        uint256 amount;
+        /// Timestamp when the value was fed
+        uint64 referenceTime;
+    }
+
+    address feeder;
+    mapping(address base => mapping(address quote => Value)) public values;
+
+    modifier onlyFeeder() {
+        require(msg.sender == feeder, NotValidFeeder());
+        _;
+    }
+
+    constructor(address feeder_) {
+        feeder = feeder_;
+    }
+
+    /// @notice Feed the system with a new base -> quote relation.
+    /// @param base The identification of the base element
+    /// @param quote The identification of the quote element
+    /// @param quoteAmount The amount of 1 wei of base amount represented as quote units.
+    function setQuote(address base, address quote, uint256 quoteAmount) external onlyFeeder {
+        values[base][quote] = Value(quoteAmount, uint64(block.timestamp));
+
+        emit Fed(base, quote, quoteAmount);
+    }
+
+    /// @inheritdoc IERC7726
+    function getQuote(uint256 baseAmount, address base, address quote) external view returns (uint256 quoteAmount) {
+        Value storage quoteValue = values[base][quote];
+        require(quoteValue.referenceTime > 0, ValueNotFound());
+
+        return baseAmount * quoteValue.amount;
+    }
+
+    /// @inheritdoc IERC7726Ext
+    function getIndicativeQuote(uint256 baseAmount, address base, address quote)
+        external
+        view
+        returns (uint256 quoteAmount)
+    {
+        //TODO
+    }
+}

--- a/src/Oracle.sol
+++ b/src/Oracle.sol
@@ -55,16 +55,13 @@ contract Oracle is IOracle {
     /// - Otherwise we assume 18 decimals
     function _extractDecimals(address assetId) internal view returns (uint8) {
         if (assetId.code.length == 0) {
-            // It means, it is not a contract address
             return DEFAULT_DECIMALS;
-        } else {
-            (bool ok, bytes memory data) = assetId.staticcall(abi.encodeWithSelector(IERC20.decimals.selector));
-            if (ok) {
-                return abi.decode(data, (uint8));
-            } else {
-                // It means, it is no an ERC20 address or the static call reverted
-                return DEFAULT_DECIMALS;
-            }
+        }
+
+        try IERC20(assetId).decimals() returns (uint8 decimals) {
+            return decimals;
+        } catch {
+            return DEFAULT_DECIMALS;
         }
     }
 }

--- a/src/Oracle.sol
+++ b/src/Oracle.sol
@@ -55,7 +55,7 @@ contract Oracle is IOracle {
     /// - Otherwise we assume 18 decimals
     function _extractDecimals(address assetId) internal view returns (uint8) {
         if (assetId.code.length == 0) {
-            // It means, it is not an contract address
+            // It means, it is not a contract address
             return DEFAULT_DECIMALS;
         } else {
             (bool ok, bytes memory data) = assetId.staticcall(abi.encodeWithSelector(IERC20.decimals.selector));

--- a/src/interfaces/IERC7726.sol
+++ b/src/interfaces/IERC7726.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.0;
+
+/// [ERC-7726](https://eips.ethereum.org/EIPS/eip-7726): Common Quote Oracle
+/// Interface for data feeds providing the relative value of assets.
+interface IERC7726 {
+    /// @notice Returns the value of `baseAmount` of `base` in quote `terms`.
+    /// It's rounded towards 0 and reverts if overflow
+    /// @param base The asset that the user needs to know the value for
+    /// @param quote The asset in which the user needs to value the base
+    /// @param baseAmount An amount of base in quote terms
+    function getQuote(uint256 baseAmount, address base, address quote) external view returns (uint256 quoteAmount);
+}
+
+/// Extension for IERC7726
+interface IERC7726Ext is IERC7726 {
+    /// @notice extension function that acts as `getQuote()` but provides an indicative value instead.
+    function getIndicativeQuote(uint256 baseAmount, address base, address quote)
+        external
+        view
+        returns (uint256 quoteAmount);
+}

--- a/src/interfaces/IERC7726.sol
+++ b/src/interfaces/IERC7726.sol
@@ -11,12 +11,3 @@ interface IERC7726 {
     /// @param baseAmount An amount of base in quote terms
     function getQuote(uint256 baseAmount, address base, address quote) external view returns (uint256 quoteAmount);
 }
-
-/// Extension for IERC7726
-interface IERC7726Ext is IERC7726 {
-    /// @notice extension function that acts as `getQuote()` but provides an indicative value instead.
-    function getIndicativeQuote(uint256 baseAmount, address base, address quote)
-        external
-        view
-        returns (uint256 quoteAmount);
-}

--- a/src/interfaces/IOracle.sol
+++ b/src/interfaces/IOracle.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >= 0.8.0;
+
+import {IERC7726, IERC7726} from "src/interfaces/IERC7726.sol";
+import {IERC20} from "forge-std/interfaces/IERC20.sol";
+import {MathLib} from "src/libraries/MathLib.sol";
+
+interface IOracle is IERC7726 {
+    /// @notice Dispatched when the action is not performed by the required feeder.
+    error NotValidFeeder();
+
+    /// @notice Dispatched when the base/quote pair has never been fed.
+    error NoQuote();
+
+    /// @notice Emitted when the contract is fed with a new quote amount.
+    event NewQuoteSet(address indexed base, address indexed quote, uint256 quoteAmount, uint64 referenceTime);
+
+    /// @notice Feed the contract with a new base -> quote relation.
+    /// @param base The identification of the base element. If it corresponds to an ERC20, the internal computations
+    /// will use the attached decimals of that asset. If not 18 decimals will be used.
+    /// @param quote Same as `base` but for `quote`.
+    /// @param quoteAmount The amount of 1 wei of base amount represented as quote units.
+    function setQuote(address base, address quote, uint256 quoteAmount) external;
+}
+
+interface IOracleFactory {
+    /// @notice Emitted when a new oracle contract is deployed.
+    event NewOracleDeployed(address where);
+
+    /// @notice Deploy a new oracle contract for an specific feeder.
+    /// @param feeder The account that will be able to fed values in the contract.
+    /// @param salt Extra bytes to generate different address for the same feeder.
+    function deploy(address feeder, bytes32 salt) external returns (IOracle);
+
+    /// @notice Retuns the deterministic contract address for a feeder.
+    /// @param feeder The account that will be able to fed values in the contract.
+    /// @param salt Extra bytes to generate different address for the same feeder.
+    function getAddress(address feeder, bytes32 salt) external view returns (address);
+}

--- a/test/unit/libraries/Oracle.t.sol
+++ b/test/unit/libraries/Oracle.t.sol
@@ -5,15 +5,14 @@ import "forge-std/Test.sol";
 import "src/Oracle.sol";
 import "src/interfaces/IERC7726.sol";
 
-contract Contract {}
+contract SomeContract {}
 
 contract TestOracle is Test {
     address constant FEEDER = address(1);
     bytes32 constant SALT = bytes32(uint256(42));
 
-    address CURR_A = address(new Contract()); //ERC20 contract address => 6 decimals
-    address CURR_B = address(this); // Contract address => 18 decimals
-    address CURR_C = address(123); // Non contract address => 18 decimals
+    address CURR_FROM_CONTRACT = address(new SomeContract()); //ERC20 contract address => 6 decimals
+    address CURR_NO_CONTRACT = address(123); // Non contract address => 18 decimals
 
     OracleFactory factory = new OracleFactory();
 
@@ -29,53 +28,53 @@ contract TestOracle is Test {
 
         vm.expectEmit();
         vm.warp(1 days);
-        emit IOracle.NewQuoteSet(CURR_A, CURR_B, 100, 1 days);
+        emit IOracle.NewQuoteSet(address(1), address(2), 100, 1 days);
 
         vm.prank(FEEDER);
-        oracle.setQuote(CURR_A, CURR_B, 100);
-    }
-
-    function testGetQuoteERC20() public {
-        IOracle oracle = factory.deploy(address(this), SALT);
-        oracle.setQuote(CURR_A, CURR_B, 100);
-
-        vm.mockCall(CURR_A, abi.encodeWithSelector(IERC20.decimals.selector), abi.encode(uint8(6)));
-        assertEq(oracle.getQuote(5 * 10 ** 6, CURR_A, CURR_B), 500);
-    }
-
-    function testGetQuoteNonERC20Contract() public {
-        IOracle oracle = factory.deploy(address(this), SALT);
-        oracle.setQuote(CURR_B, CURR_A, 100);
-
-        assertEq(oracle.getQuote(5 * 10 ** 18, CURR_B, CURR_A), 500);
-    }
-
-    function testGetQuoteNonContract() public {
-        IOracle oracle = factory.deploy(address(this), SALT);
-        oracle.setQuote(CURR_C, CURR_A, 100);
-
-        assertEq(oracle.getQuote(5 * 10 ** 18, CURR_C, CURR_A), 500);
-    }
-
-    function testGetQuoteWithErrInERC20() public {
-        IOracle oracle = factory.deploy(address(this), SALT);
-        oracle.setQuote(CURR_A, CURR_B, 100);
-
-        vm.mockCallRevert(CURR_A, abi.encodeWithSelector(IERC20.decimals.selector), abi.encode("error"));
-        assertEq(oracle.getQuote(5 * 10 ** 18, CURR_A, CURR_B), 500);
+        oracle.setQuote(address(1), address(2), 100);
     }
 
     function testNonFeeder() public {
         IOracle oracle = factory.deploy(FEEDER, SALT);
 
         vm.expectRevert(abi.encodeWithSelector(IOracle.NotValidFeeder.selector));
-        oracle.setQuote(CURR_A, CURR_B, 100);
+        oracle.setQuote(address(1), address(2), 100);
     }
 
     function testNeverFed() public {
         IOracle oracle = factory.deploy(address(this), SALT);
 
         vm.expectRevert(abi.encodeWithSelector(IOracle.NoQuote.selector));
-        oracle.getQuote(1, CURR_A, CURR_B);
+        oracle.getQuote(1, address(1), address(2));
+    }
+
+    function testGetQuoteERC20() public {
+        IOracle oracle = factory.deploy(address(this), SALT);
+        oracle.setQuote(CURR_FROM_CONTRACT, CURR_NO_CONTRACT, 100);
+
+        vm.mockCall(CURR_FROM_CONTRACT, abi.encodeWithSelector(IERC20.decimals.selector), abi.encode(uint8(6)));
+        assertEq(oracle.getQuote(5 * 10 ** 6, CURR_FROM_CONTRACT, CURR_NO_CONTRACT), 500);
+    }
+
+    function testGetQuoteNonERC20Contract() public {
+        IOracle oracle = factory.deploy(address(this), SALT);
+        oracle.setQuote(CURR_FROM_CONTRACT, CURR_NO_CONTRACT, 100);
+
+        assertEq(oracle.getQuote(5 * 10 ** 18, CURR_FROM_CONTRACT, CURR_NO_CONTRACT), 500);
+    }
+
+    function testGetQuoteERC20ContractWithErr() public {
+        IOracle oracle = factory.deploy(address(this), SALT);
+        oracle.setQuote(CURR_FROM_CONTRACT, CURR_NO_CONTRACT, 100);
+
+        vm.mockCallRevert(CURR_FROM_CONTRACT, abi.encodeWithSelector(IERC20.decimals.selector), abi.encode("error"));
+        assertEq(oracle.getQuote(5 * 10 ** 18, CURR_FROM_CONTRACT, CURR_NO_CONTRACT), 500);
+    }
+
+    function testGetQuoteNonContract() public {
+        IOracle oracle = factory.deploy(address(this), SALT);
+        oracle.setQuote(CURR_NO_CONTRACT, CURR_NO_CONTRACT, 100);
+
+        assertEq(oracle.getQuote(5 * 10 ** 18, CURR_NO_CONTRACT, CURR_NO_CONTRACT), 500);
     }
 }

--- a/test/unit/libraries/Oracle.t.sol
+++ b/test/unit/libraries/Oracle.t.sol
@@ -60,4 +60,16 @@ contract TestOracle is Test {
 
         assertEq(oracle.getQuote(5 * 10 ** 18, CURR_C, CURR_A), 500);
     }
+
+    function testNonFeeder() public {
+        Oracle oracle = factory.deploy(FEEDER, SALT);
+        vm.expectRevert(abi.encodeWithSelector(Oracle.NotValidFeeder.selector));
+        oracle.setQuote(CURR_A, CURR_B, 100);
+    }
+
+    function testNeverFed() public {
+        Oracle oracle = factory.deploy(FEEDER, SALT);
+        vm.expectRevert(abi.encodeWithSelector(Oracle.NeverFed.selector));
+        oracle.getQuote(1, CURR_A, CURR_B);
+    }
 }

--- a/test/unit/libraries/Oracle.t.sol
+++ b/test/unit/libraries/Oracle.t.sol
@@ -34,7 +34,7 @@ contract TestOracle is Test {
 
         vm.expectEmit();
         vm.warp(1 days);
-        emit Oracle.Fed(CURR_A, CURR_B, 100, 1 days);
+        emit Oracle.NewQuoteSet(CURR_A, CURR_B, 100, 1 days);
 
         vm.prank(FEEDER);
         oracle.setQuote(CURR_A, CURR_B, 100);
@@ -69,7 +69,7 @@ contract TestOracle is Test {
 
     function testNeverFed() public {
         Oracle oracle = factory.deploy(FEEDER, SALT);
-        vm.expectRevert(abi.encodeWithSelector(Oracle.NeverFed.selector));
+        vm.expectRevert(abi.encodeWithSelector(Oracle.NoQuote.selector));
         oracle.getQuote(1, CURR_A, CURR_B);
     }
 }

--- a/test/unit/libraries/Oracle.t.sol
+++ b/test/unit/libraries/Oracle.t.sol
@@ -24,52 +24,52 @@ contract TestOracle is Test {
 
     function testDeploy() public {
         vm.expectEmit();
-        emit OracleFactory.NewOracleDeployed(factory.getAddress(FEEDER, SALT));
+        emit IOracleFactory.NewOracleDeployed(factory.getAddress(FEEDER, SALT));
 
         factory.deploy(FEEDER, SALT);
     }
 
     function testSetQuote() public {
-        Oracle oracle = factory.deploy(FEEDER, SALT);
+        IOracle oracle = factory.deploy(FEEDER, SALT);
 
         vm.expectEmit();
         vm.warp(1 days);
-        emit Oracle.NewQuoteSet(CURR_A, CURR_B, 100, 1 days);
+        emit IOracle.NewQuoteSet(CURR_A, CURR_B, 100, 1 days);
 
         vm.prank(FEEDER);
         oracle.setQuote(CURR_A, CURR_B, 100);
     }
 
     function testGetQuoteERC20() public {
-        Oracle oracle = factory.deploy(address(this), SALT);
+        IOracle oracle = factory.deploy(address(this), SALT);
         oracle.setQuote(CURR_A, CURR_B, 100);
 
         assertEq(oracle.getQuote(5 * 10 ** ERC20_A.decimals(), CURR_A, CURR_B), 500);
     }
 
     function testGetQuoteNonERC20Contract() public {
-        Oracle oracle = factory.deploy(address(this), SALT);
+        IOracle oracle = factory.deploy(address(this), SALT);
         oracle.setQuote(CURR_B, CURR_A, 100);
 
         assertEq(oracle.getQuote(5 * 10 ** 18, CURR_B, CURR_A), 500);
     }
 
     function testGetQuoteNonContract() public {
-        Oracle oracle = factory.deploy(address(this), SALT);
+        IOracle oracle = factory.deploy(address(this), SALT);
         oracle.setQuote(CURR_C, CURR_A, 100);
 
         assertEq(oracle.getQuote(5 * 10 ** 18, CURR_C, CURR_A), 500);
     }
 
     function testNonFeeder() public {
-        Oracle oracle = factory.deploy(FEEDER, SALT);
-        vm.expectRevert(abi.encodeWithSelector(Oracle.NotValidFeeder.selector));
+        IOracle oracle = factory.deploy(FEEDER, SALT);
+        vm.expectRevert(abi.encodeWithSelector(IOracle.NotValidFeeder.selector));
         oracle.setQuote(CURR_A, CURR_B, 100);
     }
 
     function testNeverFed() public {
-        Oracle oracle = factory.deploy(FEEDER, SALT);
-        vm.expectRevert(abi.encodeWithSelector(Oracle.NoQuote.selector));
+        IOracle oracle = factory.deploy(FEEDER, SALT);
+        vm.expectRevert(abi.encodeWithSelector(IOracle.NoQuote.selector));
         oracle.getQuote(1, CURR_A, CURR_B);
     }
 }

--- a/test/unit/libraries/Oracle.t.sol
+++ b/test/unit/libraries/Oracle.t.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import "forge-std/mocks/MockERC20.sol";
+import "src/Oracle.sol";
+import "src/interfaces/IERC7726.sol";
+
+contract TestOracle is Test {
+    address constant FEEDER = address(1);
+    bytes32 constant SALT = bytes32(uint256(42));
+
+    MockERC20 ERC20_A = new MockERC20();
+
+    address CURR_A = address(ERC20_A); //ERC20 contract address => 6 decimals
+    address CURR_B = address(this); // Contract address => 18 decimals
+    address CURR_C = address(100); // Non contract address => 18 decimals
+
+    OracleFactory factory = new OracleFactory();
+
+    function setUp() public {
+        ERC20_A.initialize("", "", 6);
+    }
+
+    function testDeploy() public {
+        vm.expectEmit();
+        emit OracleFactory.NewOracleDeployed(factory.oracleAddress(FEEDER, SALT));
+
+        factory.deploy(FEEDER, SALT);
+    }
+
+    function testSetQuote() public {
+        Oracle oracle = factory.deploy(FEEDER, SALT);
+
+        vm.expectEmit();
+        vm.warp(1 days);
+        emit Oracle.Fed(CURR_A, CURR_B, 100, 1 days);
+
+        vm.prank(FEEDER);
+        oracle.setQuote(CURR_A, CURR_B, 100);
+    }
+
+    function testGetQuoteERC20() public {
+        Oracle oracle = factory.deploy(address(this), SALT);
+        oracle.setQuote(CURR_A, CURR_B, 100);
+
+        assertEq(oracle.getQuote(5 * 10 ** ERC20_A.decimals(), CURR_A, CURR_B), 500);
+    }
+
+    function testGetQuoteNonERC20Contract() public {
+        Oracle oracle = factory.deploy(address(this), SALT);
+        oracle.setQuote(CURR_B, CURR_A, 100);
+
+        assertEq(oracle.getQuote(5 * 10 ** 18, CURR_B, CURR_A), 500);
+    }
+
+    function testGetQuoteNonContract() public {
+        Oracle oracle = factory.deploy(address(this), SALT);
+        oracle.setQuote(CURR_C, CURR_A, 100);
+
+        assertEq(oracle.getQuote(5 * 10 ** 18, CURR_C, CURR_A), 500);
+    }
+}

--- a/test/unit/libraries/Oracle.t.sol
+++ b/test/unit/libraries/Oracle.t.sol
@@ -24,7 +24,7 @@ contract TestOracle is Test {
 
     function testDeploy() public {
         vm.expectEmit();
-        emit OracleFactory.NewOracleDeployed(factory.oracleAddress(FEEDER, SALT));
+        emit OracleFactory.NewOracleDeployed(factory.getAddress(FEEDER, SALT));
 
         factory.deploy(FEEDER, SALT);
     }


### PR DESCRIPTION
Fixes #7 

Initial implementation of the Oracle contract.

Some considerations:
- Super simple, 1 feeder per contract, no medians, no time checks.
- Any non-ERC20 ID will have 18 decimals.
- Indicative quotes not implemented yet (requires more thinking).