### PR TITLE
Deny warnings only for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
 
       - name: Run tests
-        run: forge test --no-match-path "test/invariant/**/*.sol"
+        run: forge test --no-match-path "test/invariant/**/*.sol" --deny-warnings
         env:
           FOUNDRY_PROFILE: ci
           FORK_TESTS: false
@@ -75,7 +75,7 @@ jobs:
       - name: Build contracts
         run: |
           forge --version
-          forge build --sizes
+          forge build --sizes --deny-warnings
 
       - name: Check formatting
         run: forge fmt --check

--- a/foundry.toml
+++ b/foundry.toml
@@ -6,7 +6,6 @@ libs = ['lib']
 
 solc_version = "0.8.28"
 evm_version = "cancun"
-deny_warnings = true
 
 optimizer = true
 optimizer_runs = 500


### PR DESCRIPTION
Here https://github.com/centrifuge/asset-pools/pull/14 we addws `deny-warnings` option to `foundry.toml`. Nevertheless, this option is super annoying for local development/testing and trying things.

Moved this option only to be applied by the CI but not affect local workflows