### PR TITLE
Add `IFile` interface

### DIFF
--- a/src/interfaces/IFile.sol
+++ b/src/interfaces/IFile.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.5.0;
+
+/// Interface for contracts that requires a `file()` methods in order to update properties
+interface IFile {
+    /// Emit when the `what` parameter of `file()` is not supported by the implementation.
+    error UnrecognizedWhatParam();
+
+    /// @notice Emit when a call to `file()` was performed.
+    event Filed(bytes32 what, address addr);
+
+    /// @notice Updates a contract parameter.
+    /// @param what Name of the parameter to update.
+    /// @param data New value given to the `what` parameter.
+    function file(bytes32 what, address data) external;
+}


### PR DESCRIPTION
# Description

Add a small interface to the `file()` method used in many places. 

Benefits: 
  It factorizes event, error, and documentation to avoid copy/paste them in all contracts