### PR TITLE
PoolManager first impl

### DIFF
--- a/src/PoolLocker.sol
+++ b/src/PoolLocker.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+/// @dev The inherent contract of `PoolLocker` can not have storage to not break the delegatecall rules
+abstract contract PoolLocker {
+    error PoolAlreadyUnlocked();
+    error WrongExecutionInputs();
+
+    uint64 transient unlocked;
+
+    /// @dev allows to execute a method only if the pool is unlocked.
+    /// The method can only be execute as part of `execute()`
+    modifier poolUnlocked() {
+        require(unlocked != 0);
+        _;
+    }
+
+    /// @dev returns the unlocked poolId
+    function unlockedPoolId() public view returns (uint64) {
+        return unlocked;
+    }
+
+    /// @dev This method is called first in the multicall execution
+    function _unlock(uint64 poolId) internal virtual;
+
+    /// @dev This method is called last in the multical execution
+    function _lock() internal virtual;
+
+    /// @dev Performs a generic multicall
+    function _multiDelegatecall(address[] calldata targets, bytes[] calldata data) private returns (bytes[] memory results) {
+        require(targets.length == data.length, WrongExecutionInputs());
+
+        results = new bytes[](data.length);
+
+        for (uint32 i; i < targets.length; i++) {
+            (bool success, bytes memory result) = targets[i].call(data[i]);
+            if (!success) {
+                // Forward the error happened in target.call()
+                assembly {
+                    let ptr := mload(0x40)
+                    let size := returndatasize()
+                    returndatacopy(ptr, 0, size)
+                    revert(ptr, size)
+                }
+            }
+            results[i] = result;
+        }
+    }
+
+    /// @dev Will perform all methods between the unlock <-> lock
+    /// All calls with poolUnlocked modifier are able to be called inside this method
+    function execute(uint64 poolId, address[] calldata targets, bytes[] calldata data)
+        external
+        returns (bytes[] memory results)
+    {
+        require(unlocked == 0, PoolAlreadyUnlocked());
+        _unlock(poolId);
+        unlocked = poolId;
+
+        results = _multiDelegatecall(targets, data);
+
+        unlocked = 0;
+        _lock();
+    }
+}
+

--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+import {Auth} from "src/Auth.sol";
+
+contract PoolRegistry is Auth {
+    constructor(address owner) Auth(owner) {}
+
+    // Can also be called isFundManager or be extracted in a Permissions contract
+    // NOTE: The gateway contract is able to unlock any poolId
+    function isUnlocker(address who, uint64 poolId) auth public view returns (bool) {}
+
+    // Associate who to be the owner/poolAdmin of the new poolId
+    function registerPool(address who) auth public returns (uint64) {}
+}
+
+contract PoolManager is Auth {
+    PoolRegistry poolRegistry;
+    uint64 transient unlockedPool;
+
+    constructor(address owner) Auth(owner) {
+        poolRegistry = PoolRegistry(address(this));
+    }
+
+    modifier poolUnlocked() {
+        require(unlockedPool != 0);
+        _;
+    }
+
+    // This method is called first in a multicall
+    function unlock(uint64 poolId) external {
+        require(poolRegistry.isUnlocker(msg.sender, poolId));
+        unlockedPool = poolId;
+    }
+
+    // In case the fundManager wants to lock in the same multicall to do other actions
+    function lock() external {
+        require(poolRegistry.isUnlocker(msg.sender, unlockedPool));
+        unlockedPool = 0;
+    }
+
+    // ---- Calls that require to unlock ----
+
+    function allowPool(uint32 chainId) external poolUnlocked() {}
+    function allowShareClass(uint32 chainId) external poolUnlocked() {}
+
+    function depositRequest() external poolUnlocked() {
+        // Retriver the unlocked poolId to use it internally
+        shareClassManager.depositRequest(unlockedPool, ..);
+    }
+    function approveSubscription(uint64 poolId) external poolUnlocked() {}
+    function issueShares(uint64 poolId) external poolUnlocked() {}
+
+    // ---- Permissionless calls ----
+
+    function registerPool() external returns (uint64) {
+        // Dispatch some event associated to PoolManager
+        return poolRegistry.registerPool(msg.sender);
+    }
+
+    function claimDistribute(uint64 poolId) external {}
+}

--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -2,25 +2,58 @@
 pragma solidity 0.8.28;
 
 import {Auth} from "src/Auth.sol";
+import {D18} from "src/types/D18.sol";
 
-contract PoolRegistry is Auth {
-    constructor(address owner) Auth(owner) {}
+/// [ERC-7726](https://eips.ethereum.org/EIPS/eip-7726): Common Quote Oracle
+/// Interface for data feeds providing the relative value of assets.
+interface IERC7726 {
+    /// @notice Returns the value of `baseAmount` of `base` in quote `terms`.
+    /// It's rounded towards 0 and reverts if overflow
+    /// @param base The asset that the user needs to know the value for
+    /// @param quote The asset in which the user needs to value the base
+    /// @param baseAmount An amount of base in quote terms
+    function getQuote(uint256 baseAmount, address base, address quote) external view returns (uint256 quoteAmount);
+}
 
-    // Can also be called isFundManager or be extracted in a Permissions contract
+interface IShareClassManager {
+    function requestDeposit(uint64 poolId, uint32 shareClassId, uint256 assetId, address investor) external;
+    function approveSubscription(
+        uint64 poolId,
+        uint32 shareClassId,
+        uint256 assetId,
+        D18 percentage,
+        IERC7726 valuation
+    ) external;
+    function issueShares(uint64 poolId, uint32 shareClassId, uint128 nav, uint64 epochIndex) external;
+    function claimShares(uint64 poolId, uint32 shareClassId, uint256 assetId, address investor) external;
+}
+
+interface IPoolRegistry {
+    // Can also be called "isFundManager" or be extracted in a Permissions contract
     // NOTE: The gateway contract is able to unlock any poolId
-    function isUnlocker(address who, uint64 poolId) auth public view returns (bool) {}
+    function isUnlocker(address who, uint64 poolId) external view returns (bool);
 
     // Associate who to be the owner/poolAdmin of the new poolId
-    function registerPool(address who) auth public returns (uint64) {}
+    function registerPool(address who) external returns (uint64);
+
+    function shareClassManager(uint64 poolId) external view returns (IShareClassManager);
+}
+
+interface IAccounting {
+    function unlock(uint64 poolId) external;
+    function lock(uint64 poolId) external;
 }
 
 contract PoolManager is Auth {
-    PoolRegistry poolRegistry;
-    uint64 transient unlockedPool;
+    error WrongExecutionInputs();
+    error FailedCallExecution(uint32 callIndex);
 
-    constructor(address owner) Auth(owner) {
-        poolRegistry = PoolRegistry(address(this));
-    }
+    IPoolRegistry poolRegistry;
+    IAccounting accounting;
+
+    uint64 unlockedPool; // Transient
+
+    constructor(address owner) Auth(owner) {}
 
     modifier poolUnlocked() {
         require(unlockedPool != 0);
@@ -28,28 +61,57 @@ contract PoolManager is Auth {
     }
 
     // This method is called first in a multicall
-    function unlock(uint64 poolId) external {
+    function _unlock(uint64 poolId) private {
         require(poolRegistry.isUnlocker(msg.sender, poolId));
         unlockedPool = poolId;
+        accounting.unlock(poolId);
     }
 
-    // In case the fundManager wants to lock in the same multicall to do other actions
-    function lock() external {
-        require(poolRegistry.isUnlocker(msg.sender, unlockedPool));
+    function _lock() private {
+        accounting.unlock(unlockedPool);
         unlockedPool = 0;
+    }
+
+    /// @dev Will perform all methods between the unlock <-> lock
+    /// @dev All calls with poolUnlocked modifier are able to be called inside this method
+    function execute(uint64 poolId, address[] calldata targets, bytes[] calldata data)
+        external
+        returns (bytes[] memory results)
+    {
+        _unlock(poolId);
+
+        require(targets.length == data.length, WrongExecutionInputs());
+
+        results = new bytes[](data.length);
+
+        for (uint32 i; i < targets.length; i++) {
+            (bool success, bytes memory result) = targets[i].call(data[i]);
+            if (!success) {
+                // Forward the error happened in target.call()
+                assembly {
+                    let ptr := mload(0x40)
+                    let size := returndatasize()
+                    returndatacopy(ptr, 0, size)
+                    revert(ptr, size)
+                }
+            }
+            results[i] = result;
+        }
+
+        _lock();
     }
 
     // ---- Calls that require to unlock ----
 
-    function allowPool(uint32 chainId) external poolUnlocked() {}
-    function allowShareClass(uint32 chainId) external poolUnlocked() {}
+    function allowPool(uint32 chainId) public poolUnlocked {}
+    function allowShareClass(uint32 chainId) public poolUnlocked {}
 
-    function depositRequest() external poolUnlocked() {
-        // Retriver the unlocked poolId to use it internally
-        shareClassManager.depositRequest(unlockedPool, ..);
+    function depositRequest(uint32 shareClassId, uint256 assetId, address investor) public poolUnlocked {
+        poolRegistry.shareClassManager(unlockedPool).requestDeposit(unlockedPool, shareClassId, assetId, investor);
     }
-    function approveSubscription(uint64 poolId) external poolUnlocked() {}
-    function issueShares(uint64 poolId) external poolUnlocked() {}
+
+    function approveSubscription(uint64 poolId) public poolUnlocked {}
+    function issueShares(uint64 poolId) public poolUnlocked {}
 
     // ---- Permissionless calls ----
 
@@ -58,5 +120,5 @@ contract PoolManager is Auth {
         return poolRegistry.registerPool(msg.sender);
     }
 
-    function claimDistribute(uint64 poolId) external {}
+    function claimShares(uint64 poolId) public {}
 }

--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -62,8 +62,8 @@ contract PoolManager is PoolLocker {
     IAssetManager immutable assetManager;
     IAccounting immutable accounting;
 
-    IHoldings immutable holdings;
-    IGateway immutable gateway;
+    IHoldings holdings;
+    IGateway gateway;
 
     constructor(
         IPoolRegistry poolRegistry_,
@@ -87,7 +87,7 @@ contract PoolManager is PoolLocker {
 
     /// @dev This method is called last in `execute()`
     function _lock() internal override {
-        accounting.lock(_unlockedPoolId());
+        accounting.lock(unlockedPoolId());
     }
 
     function registerPool() external returns (uint64) {
@@ -108,8 +108,10 @@ contract PoolManager is PoolLocker {
         private
         poolUnlocked
     {
-        uint64 poolId = _unlockedPoolId();
-        poolRegistry.shareClassManager(poolId).requestDeposit(poolId, shareClassId, assetId, investor, amount);
+        uint64 poolId = unlockedPoolId();
+        IShareClassManager shareClassManager = poolRegistry.shareClassManager(poolId);
+
+        shareClassManager.requestDeposit(poolId, shareClassId, assetId, investor, amount);
     }
 
     function approveSubscription(uint64 poolId) external poolUnlocked {}

--- a/src/interfaces/IPoolLocker.sol
+++ b/src/interfaces/IPoolLocker.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+interface IPoolLocker {
+    /// @notice Dispatched when the pool is already unlocked.
+    /// It means when calling to `execute()` inside `execute()`.
+    error PoolAlreadyUnlocked();
+
+    /// @notice Dispatched when the `targets` and `datas` length parameters in `execute()` do not matched.
+    error WrongExecutionParams();
+
+    /// @notice Returns the unlocked poolId.
+    /// In only will contain a non-zero value if called inside `execute()`
+    function unlockedPoolId() external returns (uint64);
+
+    /// @notice Execute a multicall inside an unlocked pool.
+    /// In one call fails, it reverts the whole transaction.
+    function execute(uint64 poolId, address[] calldata targets, bytes[] calldata datas)
+        external
+        returns (bytes[] memory results);
+}

--- a/test/unit/PoolLocker.t.sol
+++ b/test/unit/PoolLocker.t.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+import {PoolLocker} from "src/PoolLocker.sol";
+
+contract UserContract {
+    address testAddress;
+    uint256 public state = 1;
+
+    constructor(address testAddress_) {
+        testAddress = testAddress_;
+    }
+
+    function userMethod() external returns (uint256) {
+        state = 100;
+        return 23;
+    }
+}
+
+contract PoolManagerMock is PoolLocker {
+    function _unlock(uint64 poolId) internal override {
+        // Do something
+    }
+
+    function _lock() internal override {
+        // Do something
+    }
+
+    function poolRelatedMethod() external poolUnlocked returns (uint64) {
+        return unlockedPoolId();
+    }
+}
+
+contract PoolLockerTest is Test {
+    uint64 constant POOL_A = 42;
+
+    UserContract userContract = new UserContract(address(this));
+    PoolManagerMock poolManager = new PoolManagerMock();
+
+    function testMultipleCustomCalls() public {
+        address[] memory targets = new address[](2);
+        targets[0] = address(poolManager);
+        targets[1] = address(userContract);
+
+        bytes[] memory methods = new bytes[](2);
+        methods[0] = abi.encodeWithSelector(poolManager.poolRelatedMethod.selector);
+        methods[1] = abi.encodeWithSelector(userContract.userMethod.selector);
+
+        bytes[] memory results = poolManager.execute(POOL_A, targets, methods);
+        assertEq(abi.decode(results[0], (uint64)), POOL_A);
+        assertEq(abi.decode(results[1], (uint256)), 23);
+
+        assertEq(userContract.state(), 100);
+    }
+}

--- a/test/unit/PoolLocker.t.sol
+++ b/test/unit/PoolLocker.t.sol
@@ -3,31 +3,40 @@ pragma solidity ^0.8.28;
 
 import "forge-std/Test.sol";
 import {PoolLocker} from "src/PoolLocker.sol";
+import {IPoolLocker} from "src/interfaces/IPoolLocker.sol";
 
 contract UserContract {
     address testAddress;
-    uint256 public state = 1;
+    uint256 public state;
 
     constructor(address testAddress_) {
         testAddress = testAddress_;
     }
 
-    function userMethod() external returns (uint256) {
+    function setState() external returns (uint256) {
         state = 100;
         return 23;
+    }
+
+    function userFailMethod() external pure {
+        revert("user error");
     }
 }
 
 contract PoolManagerMock is PoolLocker {
+    uint64 public wasUnlock;
+    bool public waslock;
+
     function _unlock(uint64 poolId) internal override {
-        // Do something
+        wasUnlock = poolId;
     }
 
     function _lock() internal override {
-        // Do something
+        waslock = true;
     }
 
-    function poolRelatedMethod() external poolUnlocked returns (uint64) {
+    function poolRelatedMethod() external view poolUnlocked returns (uint64) {
+        require(wasUnlock == unlockedPoolId());
         return unlockedPoolId();
     }
 }
@@ -45,12 +54,56 @@ contract PoolLockerTest is Test {
 
         bytes[] memory methods = new bytes[](2);
         methods[0] = abi.encodeWithSelector(poolManager.poolRelatedMethod.selector);
-        methods[1] = abi.encodeWithSelector(userContract.userMethod.selector);
+        methods[1] = abi.encodeWithSelector(userContract.setState.selector);
 
         bytes[] memory results = poolManager.execute(POOL_A, targets, methods);
         assertEq(abi.decode(results[0], (uint64)), POOL_A);
         assertEq(abi.decode(results[1], (uint256)), 23);
 
+        assertEq(poolManager.wasUnlock(), POOL_A);
+        assertEq(poolManager.waslock(), true);
         assertEq(userContract.state(), 100);
+    }
+
+    function testRevertAtError() public {
+        // Will revert the whole transaction when the first error appears
+
+        address[] memory targets = new address[](2);
+        targets[0] = address(userContract);
+        targets[1] = address(userContract);
+
+        bytes[] memory methods = new bytes[](2);
+        methods[0] = abi.encodeWithSelector(userContract.setState.selector);
+        methods[1] = abi.encodeWithSelector(userContract.userFailMethod.selector);
+
+        vm.expectRevert("user error");
+        poolManager.execute(POOL_A, targets, methods);
+
+        assertEq(userContract.state(), 0);
+    }
+
+    function testErrPoolAlreadyUnlocked() public {
+        address[] memory innerTargets = new address[](1);
+        innerTargets[0] = address(poolManager);
+
+        bytes[] memory innerMethods = new bytes[](1);
+        innerMethods[0] = abi.encodeWithSelector(poolManager.poolRelatedMethod.selector);
+
+        address[] memory targets = new address[](1);
+        targets[0] = address(poolManager);
+
+        bytes[] memory methods = new bytes[](1);
+        methods[0] = abi.encodeWithSelector(poolManager.execute.selector, POOL_A, innerTargets, innerMethods);
+
+        vm.expectRevert(IPoolLocker.PoolAlreadyUnlocked.selector);
+        poolManager.execute(POOL_A, targets, methods);
+    }
+
+    function testErrWrongExecutionParams() public {
+        address[] memory targets = new address[](1);
+        bytes[] memory methods = new bytes[](2);
+
+        vm.expectRevert(IPoolLocker.WrongExecutionParams.selector);
+        poolManager.execute(POOL_A, targets, methods);
     }
 }


### PR DESCRIPTION
fixes #28 

Just as draft to show the unlocking mechanism.

I think if we know the entry point is always `PoolManager`, we no longer need the complex `unlock(poolId, array_of_encoded_calls)`. Simply:
- `multicall`
  - `unlock(poolId)`
  - `approveDistribution()`
  - Do whatever onchain/offchain
  - `issueShares()`
  - lock() //optional
  
The caller (fund manager) is free in the multicall to compose any method from `PoolManager` as they want to perform its custom business logic.

