### PR TITLE
Add view to IPoolRegistry methods

### DIFF
--- a/src/interfaces/IPoolRegistry.sol
+++ b/src/interfaces/IPoolRegistry.sol
@@ -6,7 +6,6 @@ import {IERC20Metadata} from "src/interfaces/IERC20Metadata.sol";
 import {IShareClassManager} from "src/interfaces/IShareClassManager.sol";
 
 interface IPoolRegistry {
-    /// Events
     event NewPool(
         PoolId poolId,
         address indexed admin,
@@ -19,25 +18,10 @@ interface IPoolRegistry {
     event UpdatedPoolCurrency(PoolId indexed poolId, IERC20Metadata currency);
     event UpdatedAddressFor(PoolId indexed poolId, bytes32 key, address addr);
 
-    /// Errors
     error NonExistingPool(PoolId id);
     error EmptyAdmin();
     error EmptyCurrency();
     error EmptyShareClassManager();
-
-    /// Functions
-
-    /// Getters
-    /// @notice TODO
-    function metadata(PoolId poolId) external returns (bytes memory);
-    /// @notice TODO
-    function currency(PoolId poolId) external returns (IERC20Metadata);
-    /// @notice TODO
-    function shareClassManager(PoolId poolId) external returns (IShareClassManager);
-    /// @notice TODO
-    function isAdmin(PoolId poolId, address admin) external returns (bool);
-    /// @notice TODO
-    function addressFor(PoolId poolId, bytes32 key) external returns (address);
 
     /// @notice TODO
     function registerPool(address admin, IERC20Metadata currency, IShareClassManager shareClassManager)
@@ -53,4 +37,15 @@ interface IPoolRegistry {
     function updateCurrency(PoolId poolId, IERC20Metadata currency) external;
     /// @notice TODO
     function setAddressFor(PoolId poolid, bytes32 key, address addr) external;
+
+    /// @notice TODO
+    function metadata(PoolId poolId) external view returns (bytes memory);
+    /// @notice TODO
+    function currency(PoolId poolId) external view returns (IERC20Metadata);
+    /// @notice TODO
+    function shareClassManager(PoolId poolId) external view returns (IShareClassManager);
+    /// @notice TODO
+    function isAdmin(PoolId poolId, address admin) external view returns (bool);
+    /// @notice TODO
+    function addressFor(PoolId poolId, bytes32 key) external view returns (address);
 }


### PR DESCRIPTION
Sorry for this new small PR, but we need to add `view` to the interface methods to let it call them from view methods.

I've also ordered methods following: https://www.rareskills.io/post/solidity-style-guide where normal methods comes before view methods