### PR TITLE
Add exists() to PoolRegistry

### DIFF
--- a/src/PoolRegistry.sol
+++ b/src/PoolRegistry.sol
@@ -43,8 +43,8 @@ contract PoolRegistry is Auth, IPoolRegistry {
 
     /// @inheritdoc IPoolRegistry
     function updateAdmin(PoolId poolId, address admin_, bool canManage) external auth {
+        require(exists(poolId), NonExistingPool(poolId));
         require(admin_ != address(0), EmptyAdmin());
-        require(address(shareClassManager[poolId]) != address(0), NonExistingPool(poolId));
 
         isAdmin[poolId][admin_] = canManage;
 
@@ -53,7 +53,7 @@ contract PoolRegistry is Auth, IPoolRegistry {
 
     /// @inheritdoc IPoolRegistry
     function updateMetadata(PoolId poolId, bytes calldata metadata_) external auth {
-        require(address(shareClassManager[poolId]) != address(0), NonExistingPool(poolId));
+        require(exists(poolId), NonExistingPool(poolId));
 
         metadata[poolId] = metadata_;
 
@@ -62,7 +62,7 @@ contract PoolRegistry is Auth, IPoolRegistry {
 
     /// @inheritdoc IPoolRegistry
     function updateShareClassManager(PoolId poolId, IShareClassManager shareClassManager_) external auth {
-        require(address(shareClassManager[poolId]) != address(0), NonExistingPool(poolId));
+        require(exists(poolId), NonExistingPool(poolId));
         require(address(shareClassManager_) != address(0), EmptyShareClassManager());
 
         shareClassManager[poolId] = shareClassManager_;
@@ -72,7 +72,7 @@ contract PoolRegistry is Auth, IPoolRegistry {
 
     /// @inheritdoc IPoolRegistry
     function updateCurrency(PoolId poolId, IERC20Metadata currency_) external auth {
-        require(address(shareClassManager[poolId]) != address(0), NonExistingPool(poolId));
+        require(exists(poolId), NonExistingPool(poolId));
         require(address(currency_) != address(0), EmptyCurrency());
 
         currency[poolId] = currency_;
@@ -81,11 +81,11 @@ contract PoolRegistry is Auth, IPoolRegistry {
     }
 
     function setAddressFor(PoolId poolId, bytes32 key, address addr) external auth {
-        require(address(shareClassManager[poolId]) != address(0), NonExistingPool(poolId));
+        require(exists(poolId), NonExistingPool(poolId));
         addressFor[poolId][key] = addr;
     }
 
-    function exists(PoolId poolId) external view returns (bool) {
+    function exists(PoolId poolId) public view returns (bool) {
         return address(shareClassManager[poolId]) != address(0);
     }
 }

--- a/src/PoolRegistry.sol
+++ b/src/PoolRegistry.sol
@@ -84,4 +84,8 @@ contract PoolRegistry is Auth, IPoolRegistry {
         require(address(shareClassManager[poolId]) != address(0), NonExistingPool(poolId));
         addressFor[poolId][key] = addr;
     }
+
+    function exists(PoolId poolId) external view returns (bool) {
+        return address(shareClassManager[poolId]) != address(0);
+    }
 }

--- a/src/interfaces/IPoolRegistry.sol
+++ b/src/interfaces/IPoolRegistry.sol
@@ -48,4 +48,6 @@ interface IPoolRegistry {
     function isAdmin(PoolId poolId, address admin) external view returns (bool);
     /// @notice TODO
     function addressFor(PoolId poolId, bytes32 key) external view returns (address);
+    /// @notice TODO
+    function exists(PoolId poolId) external view returns (bool);
 }

--- a/test/unit/PoolRegistry.t.sol
+++ b/test/unit/PoolRegistry.t.sol
@@ -164,4 +164,12 @@ contract PoolRegistryTest is Test {
         registry.setAddressFor(poolId, "key", address(1));
         assertEq(address(registry.addressFor(poolId, "key")), address(1));
     }
+
+    function testExists() public {
+        PoolId poolId = registry.registerPool(makeAddr("fundManager"), USD, shareClassManager);
+        assertEq(registry.exists(poolId), true);
+
+        PoolId nonExistingPool = PoolId.wrap(0xDEAD);
+        assertEq(registry.exists(nonExistingPool), false);
+    }
 }


### PR DESCRIPTION
It's true that we can do:

```solidity
require(address(poolRegistry.shareClassManager(poolId)) != address(0))
```

But it seems too complex for a check that we should do everywhere, so I would prefer for the reader to have:
```solidity
require(poolRegistry.exists(poolId));
```