### PR TITLE
PoolRegistry: exists() by ensureExistence()

### DIFF
--- a/src/PoolRegistry.sol
+++ b/src/PoolRegistry.sol
@@ -43,7 +43,7 @@ contract PoolRegistry is Auth, IPoolRegistry {
 
     /// @inheritdoc IPoolRegistry
     function updateAdmin(PoolId poolId, address admin_, bool canManage) external auth {
-        require(exists(poolId), NonExistingPool(poolId));
+        ensureExistence(poolId);
         require(admin_ != address(0), EmptyAdmin());
 
         isAdmin[poolId][admin_] = canManage;
@@ -53,7 +53,7 @@ contract PoolRegistry is Auth, IPoolRegistry {
 
     /// @inheritdoc IPoolRegistry
     function updateMetadata(PoolId poolId, bytes calldata metadata_) external auth {
-        require(exists(poolId), NonExistingPool(poolId));
+        ensureExistence(poolId);
 
         metadata[poolId] = metadata_;
 
@@ -62,7 +62,7 @@ contract PoolRegistry is Auth, IPoolRegistry {
 
     /// @inheritdoc IPoolRegistry
     function updateShareClassManager(PoolId poolId, IShareClassManager shareClassManager_) external auth {
-        require(exists(poolId), NonExistingPool(poolId));
+        ensureExistence(poolId);
         require(address(shareClassManager_) != address(0), EmptyShareClassManager());
 
         shareClassManager[poolId] = shareClassManager_;
@@ -72,7 +72,7 @@ contract PoolRegistry is Auth, IPoolRegistry {
 
     /// @inheritdoc IPoolRegistry
     function updateCurrency(PoolId poolId, IERC20Metadata currency_) external auth {
-        require(exists(poolId), NonExistingPool(poolId));
+        ensureExistence(poolId);
         require(address(currency_) != address(0), EmptyCurrency());
 
         currency[poolId] = currency_;
@@ -80,12 +80,14 @@ contract PoolRegistry is Auth, IPoolRegistry {
         emit UpdatedPoolCurrency(poolId, currency_);
     }
 
+    /// @inheritdoc IPoolRegistry
     function setAddressFor(PoolId poolId, bytes32 key, address addr) external auth {
-        require(exists(poolId), NonExistingPool(poolId));
+        ensureExistence(poolId);
         addressFor[poolId][key] = addr;
     }
 
-    function exists(PoolId poolId) public view returns (bool) {
-        return address(shareClassManager[poolId]) != address(0);
+    /// @inheritdoc IPoolRegistry
+    function ensureExistence(PoolId poolId) public view {
+        require(address(shareClassManager[poolId]) != address(0), NonExistingPool(poolId));
     }
 }

--- a/src/interfaces/IPoolRegistry.sol
+++ b/src/interfaces/IPoolRegistry.sol
@@ -49,5 +49,5 @@ interface IPoolRegistry {
     /// @notice TODO
     function addressFor(PoolId poolId, bytes32 key) external view returns (address);
     /// @notice TODO
-    function exists(PoolId poolId) external view returns (bool);
+    function ensureExistence(PoolId poolId) external view;
 }

--- a/test/unit/PoolRegistry.t.sol
+++ b/test/unit/PoolRegistry.t.sol
@@ -167,9 +167,10 @@ contract PoolRegistryTest is Test {
 
     function testExists() public {
         PoolId poolId = registry.registerPool(makeAddr("fundManager"), USD, shareClassManager);
-        assertEq(registry.exists(poolId), true);
+        registry.ensureExistence(poolId);
 
         PoolId nonExistingPool = PoolId.wrap(0xDEAD);
-        assertEq(registry.exists(nonExistingPool), false);
+        vm.expectRevert(abi.encodeWithSelector(IPoolRegistry.NonExistingPool.selector, nonExistingPool));
+        registry.ensureExistence(nonExistingPool);
     }
 }


### PR DESCRIPTION
Minor change to avoid creating a NonExistingPool error each time a contract call `poolRegistry.exists()`

Based on: https://github.com/centrifuge/pools-internal/pull/47

Is this a correct solidity pattern?