### PR TITLE
Add TransientValuation contract helper

### DIFF
--- a/src/Holdings.sol
+++ b/src/Holdings.sol
@@ -93,7 +93,7 @@ contract Holdings is Auth, IHoldings {
         Item storage item_ = item[poolId][itemId_.index()];
         address poolCurrency = address(poolRegistry.currency(poolId));
 
-        amountValue = uint128(valuation_.getQuote(amount, AssetId.unwrap(item_.assetId), poolCurrency));
+        amountValue = valuation_.getQuote(amount, AssetId.unwrap(item_.assetId), poolCurrency).toUint128();
 
         item_.assetAmount += amount;
         item_.assetAmountValue += amountValue;
@@ -113,7 +113,7 @@ contract Holdings is Auth, IHoldings {
         Item storage item_ = item[poolId][itemId_.index()];
         address poolCurrency = address(poolRegistry.currency(poolId));
 
-        amountValue = uint128(valuation_.getQuote(amount, AssetId.unwrap(item_.assetId), poolCurrency));
+        amountValue = valuation_.getQuote(amount, AssetId.unwrap(item_.assetId), poolCurrency).toUint128();
 
         item_.assetAmount -= amount;
         item_.assetAmountValue -= amountValue;
@@ -128,7 +128,7 @@ contract Holdings is Auth, IHoldings {
         Item storage item_ = item[poolId][itemId_.index()];
         address poolCurrency = address(poolRegistry.currency(poolId));
         uint128 currentAmountValue =
-            uint128(item_.valuation.getQuote(item_.assetAmount, AssetId.unwrap(item_.assetId), poolCurrency));
+            item_.valuation.getQuote(item_.assetAmount, AssetId.unwrap(item_.assetId), poolCurrency).toUint128();
 
         diffValue = currentAmountValue > item_.assetAmountValue
             ? uint256(currentAmountValue - item_.assetAmountValue).toInt128()

--- a/src/TransientValuation.sol
+++ b/src/TransientValuation.sol
@@ -1,17 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IERC7726} from "src/interfaces/IERC7726.sol";
 import {AssetId} from "src/types/AssetId.sol";
 import {D18} from "src/types/D18.sol";
-import {MathLib} from "src/libraries/MathLib.sol";
+
+import {Conversion} from "src/libraries/Conversion.sol";
+
+import {IERC7726} from "src/interfaces/IERC7726.sol";
 import {ITransientValuation} from "src/interfaces/ITransientValuation.sol";
-import {IERC20Metadata} from "src/interfaces/IERC20Metadata.sol";
 
 contract TransientValuation is ITransientValuation {
-    using MathLib for uint256;
-
-    /// Temporal price set and used to obtain the quote.
+    /// @notice Temporal price set and used to obtain the quote.
     D18 public /*TODO: transient*/ price;
 
     /// @inheritdoc ITransientValuation
@@ -21,13 +20,6 @@ contract TransientValuation is ITransientValuation {
 
     /// @inheritdoc IERC7726
     function getQuote(uint256 baseAmount, address base, address quote) external view returns (uint256 quoteAmount) {
-        uint8 baseDecimals = IERC20Metadata(base).decimals();
-        uint8 quoteDecimals = IERC20Metadata(quote).decimals();
-
-        if (baseDecimals == quoteDecimals) {
-            return price.mulUint256(baseAmount);
-        }
-
-        return price.mulUint256(MathLib.mulDiv(baseAmount, 10 ** quoteDecimals, 10 ** baseDecimals));
+        return Conversion.convertWithPrice(baseAmount, base, quote, price);
     }
 }

--- a/src/TransientValuation.sol
+++ b/src/TransientValuation.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {IERC7726} from "src/interfaces/IERC7726.sol";
+import {AssetId} from "src/types/AssetId.sol";
+import {D18} from "src/types/D18.sol";
+import {MathLib} from "src/libraries/MathLib.sol";
+import {ITransientValuation} from "src/interfaces/ITransientValuation.sol";
+import {IERC20Metadata} from "src/interfaces/IERC20Metadata.sol";
+
+contract TransientValuation is ITransientValuation {
+    using MathLib for uint256;
+
+    /// Temporal price set and used to obtain the quote.
+    D18 public /*TODO: transient*/ price;
+
+    /// @inheritdoc ITransientValuation
+    function setPrice(D18 price_) external {
+        price = price_;
+    }
+
+    /// @inheritdoc IERC7726
+    function getQuote(uint256 baseAmount, address base, address quote) external view returns (uint256 quoteAmount) {
+        uint8 baseDecimals = IERC20Metadata(base).decimals();
+        uint8 quoteDecimals = IERC20Metadata(quote).decimals();
+
+        if (baseDecimals == quoteDecimals) {
+            return price.mulUint256(baseAmount);
+        }
+
+        return price.mulUint256(MathLib.mulDiv(baseAmount, 10 ** quoteDecimals, 10 ** baseDecimals));
+    }
+}

--- a/src/interfaces/IERC20Metadata.sol
+++ b/src/interfaces/IERC20Metadata.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.28;
 
 interface IERC20Metadata {
-    function decimals() external returns (uint8);
-    function name() external returns (string calldata);
-    function symbol() external returns (string calldata);
+    function decimals() external view returns (uint8);
+    function name() external view returns (string calldata);
+    function symbol() external view returns (string calldata);
 }

--- a/src/interfaces/ITransientValuation.sol
+++ b/src/interfaces/ITransientValuation.sol
@@ -4,7 +4,8 @@ pragma solidity 0.8.28;
 import {D18} from "src/types/D18.sol";
 import {IERC7726} from "src/interfaces/IERC7726.sol";
 
-/// @notice Interface for a valuation with temporal value
+/// @notice An IERC7726 valuation that allows to set a price that is only valid for the current transaction.
+/// NOTE: Do not use it if the valuation lifetime is longer than the transaction.
 interface ITransientValuation is IERC7726 {
     /// @notice Set the price for the valuation.
     /// The price is the 1 amount of base denominated in quote.

--- a/src/interfaces/ITransientValuation.sol
+++ b/src/interfaces/ITransientValuation.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {D18} from "src/types/D18.sol";
+import {IERC7726} from "src/interfaces/IERC7726.sol";
+
+/// @notice Interface for a valuation with temporal value
+interface ITransientValuation is IERC7726 {
+    /// @notice Set the price for the valuation.
+    /// The price is the 1 amount of base denominated in quote.
+    /// i.e: if base BTC and quote USDC, the price is 90_000 USDC per BTC
+    /// Check IERC7726 for more info about base and quote
+    function setPrice(D18 price) external;
+}

--- a/src/libraries/Conversion.sol
+++ b/src/libraries/Conversion.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {IERC20Metadata} from "src/interfaces/IERC20Metadata.sol";
+import {MathLib} from "src/libraries/MathLib.sol";
+import {D18} from "src/types/D18.sol";
+
+library Conversion {
+    function convertWithPrice(uint256 baseAmount, address base, address quote, D18 price)
+        external
+        view
+        returns (uint256 quoteAmount)
+    {
+        uint8 baseDecimals = IERC20Metadata(base).decimals();
+        uint8 quoteDecimals = IERC20Metadata(quote).decimals();
+
+        if (baseDecimals == quoteDecimals) {
+            return price.mulUint256(baseAmount);
+        }
+
+        return price.mulUint256(MathLib.mulDiv(baseAmount, 10 ** quoteDecimals, 10 ** baseDecimals));
+    }
+}

--- a/src/types/D18.sol
+++ b/src/types/D18.sol
@@ -70,6 +70,11 @@ function d18(uint128 value) pure returns (D18) {
     return D18.wrap(value);
 }
 
+/// @dev Easy way to construct a decimal number
+function d18(uint128 num, uint128 den) pure returns (D18) {
+    return D18.wrap(MathLib.mulDiv(num, 1e18, den).toUint128());
+}
+
 using {
     add as +, sub as -, divD8 as /, inner, mulD8 as *, mulUint128, mulUint256, reciprocalMulUint256
 } for D18 global;

--- a/test/unit/TransientValuation.t.sol
+++ b/test/unit/TransientValuation.t.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import "forge-std/Test.sol";
+
+import {D18, d18} from "src/types/D18.sol";
+import {MathLib} from "src/libraries/MathLib.sol";
+import {TransientValuation} from "src/TransientValuation.sol";
+import {IERC20Metadata} from "src/interfaces/IERC20Metadata.sol";
+
+contract C18 {
+    function decimals() external pure returns (uint8) {
+        return 18;
+    }
+}
+
+contract C6 {
+    function decimals() external pure returns (uint8) {
+        return 6;
+    }
+}
+
+contract TestPortfolio is Test {
+    address c18 = address(new C18());
+    address c6 = address(new C6());
+    TransientValuation valuation = new TransientValuation();
+
+    function testHighPriceFromMoreDecimalsToLess() public {
+        valuation.setPrice(d18(3, 1)); //3.0
+
+        assertEq(valuation.getQuote(100 * 1e18, c18, c6), 300 * 1e6);
+    }
+
+    function testLowPriceFromMoreDecimalsToLess() public {
+        valuation.setPrice(d18(1, 3)); // 0.33...
+
+        assertEq(valuation.getQuote(100 * 1e18, c18, c6), 33_333_333);
+    }
+
+    function testHighPriceFromLessDecimalsToMore() public {
+        valuation.setPrice(d18(3, 1)); //3.0
+
+        assertEq(valuation.getQuote(100 * 1e6, c6, c18), 300 * 1e18);
+    }
+
+    function testLowPriceFromLessDecimalsToMore() public {
+        valuation.setPrice(d18(1, 3)); //0.33...
+
+        // Note: last 2 zeros from the Eq is due lost of precision given the price only contains 18 decimals.
+        assertEq(valuation.getQuote(100 * 1e6, c6, c18), 33_333_333_333_333_333_300);
+    }
+}

--- a/test/unit/TransientValuation.t.sol
+++ b/test/unit/TransientValuation.t.sol
@@ -25,6 +25,12 @@ contract TestPortfolio is Test {
     address c6 = address(new C6());
     TransientValuation valuation = new TransientValuation();
 
+    function testSameDecimals() public {
+        valuation.setPrice(d18(2, 1)); //2.0
+
+        assertEq(valuation.getQuote(100 * 1e6, c6, c6), 200 * 1e6);
+    }
+
     function testHighPriceFromMoreDecimalsToLess() public {
         valuation.setPrice(d18(3, 1)); //3.0
 

--- a/test/unit/TransientValuation.t.sol
+++ b/test/unit/TransientValuation.t.sol
@@ -20,7 +20,7 @@ contract C6 {
     }
 }
 
-contract TestPortfolio is Test {
+contract TestTransientValuation is Test {
     address c18 = address(new C18());
     address c6 = address(new C6());
     TransientValuation valuation = new TransientValuation();

--- a/test/unit/libraries/D18.t.sol
+++ b/test/unit/libraries/D18.t.sol
@@ -106,11 +106,4 @@ contract D18Test is Test {
 
         assertEq(divD8(numerator, denominator).inner(), numerator.inner() * 1e18 / denominator.inner());
     }
-
-    function testMulUint256() public pure {
-        D18 factor = d18(1_500_000_000_000_000_000); // 1.5
-        uint256 value = 4_000_000_000_000_000_000_000_000;
-
-        assertEq(factor.mulUint256(value), 6_000_000_000_000_000_000_000_000);
-    }
 }

--- a/test/unit/libraries/D18.t.sol
+++ b/test/unit/libraries/D18.t.sol
@@ -106,4 +106,11 @@ contract D18Test is Test {
 
         assertEq(divD8(numerator, denominator).inner(), numerator.inner() * 1e18 / denominator.inner());
     }
+
+    function testMulUint256() public pure {
+        D18 factor = d18(1_500_000_000_000_000_000); // 1.5
+        uint256 value = 4_000_000_000_000_000_000_000_000;
+
+        assertEq(factor.mulUint256(value), 6_000_000_000_000_000_000_000_000);
+    }
 }


### PR DESCRIPTION
The `TransientValuation` is an `IERC7726` valuation that can be set by anyone with low cost as a temporal value to be used in methods that require an `IERC7726 valuation` parameter, but the user wants to provide a fixed value instead.

Example:

```solidity
transientValuation.setPrice(0.5);
holdings.increase(transientValuation); // It will call to getQuote() using the provided price.
```

closes POOLS-43