### PR TITLE
PoolRegistry required changes

### DIFF
--- a/src/PoolRegistry.sol
+++ b/src/PoolRegistry.sol
@@ -12,6 +12,8 @@ import {IShareClassManager} from "src/interfaces/IShareClassManager.sol";
 contract PoolRegistry is Auth, IPoolRegistry {
     using MathLib for uint256;
 
+    uint32 public latestId;
+
     mapping(PoolId => bytes) public metadata;
     mapping(PoolId => IERC20Metadata) public currency;
     mapping(PoolId => IShareClassManager) public shareClassManager;
@@ -22,18 +24,16 @@ contract PoolRegistry is Auth, IPoolRegistry {
     constructor(address deployer) Auth(deployer) {}
 
     /// @inheritdoc IPoolRegistry
-    function registerPool(
-        uint32 localPoolId,
-        address admin_,
-        IERC20Metadata currency_,
-        IShareClassManager shareClassManager_
-    ) external auth returns (PoolId poolId) {
-        poolId = PoolIdLib.newFrom(localPoolId);
-
-        require(!exists(poolId), PoolAlreadyExists());
+    function registerPool(address admin_, IERC20Metadata currency_, IShareClassManager shareClassManager_)
+        external
+        auth
+        returns (PoolId poolId)
+    {
         require(admin_ != address(0), EmptyAdmin());
         require(address(currency_) != address(0), EmptyCurrency());
         require(address(shareClassManager_) != address(0), EmptyShareClassManager());
+
+        poolId = PoolIdLib.newFrom(++latestId);
 
         isAdmin[poolId][admin_] = true;
         currency[poolId] = currency_;

--- a/src/PoolRegistry.sol
+++ b/src/PoolRegistry.sol
@@ -16,7 +16,7 @@ contract PoolRegistry is Auth, IPoolRegistry {
     mapping(PoolId => IERC20Metadata) public currency;
     mapping(PoolId => IShareClassManager) public shareClassManager;
     mapping(PoolId => mapping(address => bool)) public isAdmin;
-    mapping(PoolId => mapping(AssetId => bool)) public isInvestorAsset;
+    mapping(PoolId => mapping(AssetId => bool)) public isInvestorAssetAllowed;
     mapping(PoolId => mapping(bytes32 key => address)) public addressFor;
 
     constructor(address deployer) Auth(deployer) {}
@@ -57,18 +57,18 @@ contract PoolRegistry is Auth, IPoolRegistry {
         require(exists(poolId), NonExistingPool(poolId));
         require(!assetId.isNull(), EmptyAsset());
 
-        isInvestorAsset[poolId][assetId] = isAllowed;
+        isInvestorAssetAllowed[poolId][assetId] = isAllowed;
 
         emit AllowedInvestorAsset(poolId, assetId, isAllowed);
     }
 
     /// @inheritdoc IPoolRegistry
-    function updateMetadata(PoolId poolId, bytes calldata metadata_) external auth {
+    function setMetadata(PoolId poolId, bytes calldata metadata_) external auth {
         require(exists(poolId), NonExistingPool(poolId));
 
         metadata[poolId] = metadata_;
 
-        emit UpdatedMetadata(poolId, metadata_);
+        emit SetMetadata(poolId, metadata_);
     }
 
     /// @inheritdoc IPoolRegistry

--- a/src/interfaces/IPoolRegistry.sol
+++ b/src/interfaces/IPoolRegistry.sol
@@ -15,7 +15,7 @@ interface IPoolRegistry {
     );
     event UpdatedAdmin(PoolId indexed poolId, address indexed admin, bool canManage);
     event AllowedInvestorAsset(PoolId indexed poolId, AssetId indexed assetId, bool isAllowed);
-    event UpdatedMetadata(PoolId indexed poolId, bytes metadata);
+    event SetMetadata(PoolId indexed poolId, bytes metadata);
     event UpdatedShareClassManager(PoolId indexed poolId, IShareClassManager indexed shareClassManager);
     event UpdatedCurrency(PoolId indexed poolId, IERC20Metadata currency);
     event SetAddressFor(PoolId indexed poolId, bytes32 key, address addr);
@@ -27,38 +27,51 @@ interface IPoolRegistry {
     error EmptyCurrency();
     error EmptyShareClassManager();
 
-    /// @notice TODO
+    /// @notice Register a new pool.
+    /// @param localPoolId is used to generate the final returned PoolId.
     function registerPool(
         uint32 localPoolId,
         address admin,
         IERC20Metadata currency,
         IShareClassManager shareClassManager
     ) external returns (PoolId poolId);
-    /// @notice TODO
+
+    /// @notice allow/disallow an address as an admin for the pool
     function updateAdmin(PoolId poolId, address newAdmin, bool canManage) external;
-    /// @notice TODO
+
+    /// @notice allow/disallow an investor asset to be used in this pool
     function allowInvestorAsset(PoolId poolId, AssetId assetId, bool isAllowed) external;
-    /// @notice TODO
-    function updateMetadata(PoolId poolId, bytes calldata metadata) external;
-    /// @notice TODO
+
+    /// @notice sets metadata for this pool
+    function setMetadata(PoolId poolId, bytes calldata metadata) external;
+
+    /// @notice updates the share class manager of the pool
     function updateShareClassManager(PoolId poolId, IShareClassManager shareClassManager) external;
-    /// @notice TODO
+
+    /// @notice updates the currency of the pool
     function updateCurrency(PoolId poolId, IERC20Metadata currency) external;
-    /// @notice TODO
+
+    /// @notice sets an address for an specific key
     function setAddressFor(PoolId poolid, bytes32 key, address addr) external;
 
-    /// @notice TODO
+    /// @notice returns the metadata attached to the pool, if any.
     function metadata(PoolId poolId) external view returns (bytes memory);
-    /// @notice TODO
+
+    /// @notice returns the currency of the pool
     function currency(PoolId poolId) external view returns (IERC20Metadata);
-    /// @notice TODO
+
+    /// @notice returns the shareClassManager used in the pool
     function shareClassManager(PoolId poolId) external view returns (IShareClassManager);
-    /// @notice TODO
+
+    /// @notice returns the existance of an admin
     function isAdmin(PoolId poolId, address admin) external view returns (bool);
-    /// @notice TODO
-    function isInvestorAsset(PoolId poolId, AssetId assetId) external view returns (bool);
-    /// @notice TODO
+
+    /// @notice returns the allowance of an investor asset
+    function isInvestorAssetAllowed(PoolId poolId, AssetId assetId) external view returns (bool);
+
+    /// @notice returns the address for an specific key
     function addressFor(PoolId poolId, bytes32 key) external view returns (address);
-    /// @notice TODO
+
+    /// @notice checks the existence of a pool
     function exists(PoolId poolId) external view returns (bool);
 }

--- a/src/interfaces/IPoolRegistry.sol
+++ b/src/interfaces/IPoolRegistry.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {PoolId} from "src/types/PoolId.sol";
+import {AssetId} from "src/types/AssetId.sol";
 import {IERC20Metadata} from "src/interfaces/IERC20Metadata.sol";
 import {IShareClassManager} from "src/interfaces/IShareClassManager.sol";
 
@@ -12,14 +13,16 @@ interface IPoolRegistry {
         IShareClassManager indexed shareClassManager,
         IERC20Metadata indexed currency
     );
-    event UpdatedPoolAdmin(PoolId indexed poolId, address indexed admin);
-    event UpdatedPoolMetadata(PoolId indexed poolId, bytes metadata);
+    event UpdatedAdmin(PoolId indexed poolId, address indexed admin, bool canManage);
+    event AllowedInvestorAsset(PoolId indexed poolId, AssetId indexed assetId, bool isAllowed);
+    event UpdatedMetadata(PoolId indexed poolId, bytes metadata);
     event UpdatedShareClassManager(PoolId indexed poolId, IShareClassManager indexed shareClassManager);
-    event UpdatedPoolCurrency(PoolId indexed poolId, IERC20Metadata currency);
-    event UpdatedAddressFor(PoolId indexed poolId, bytes32 key, address addr);
+    event UpdatedCurrency(PoolId indexed poolId, IERC20Metadata currency);
+    event SetAddressFor(PoolId indexed poolId, bytes32 key, address addr);
 
     error NonExistingPool(PoolId id);
     error EmptyAdmin();
+    error EmptyAsset();
     error EmptyCurrency();
     error EmptyShareClassManager();
 
@@ -29,6 +32,8 @@ interface IPoolRegistry {
         returns (PoolId);
     /// @notice TODO
     function updateAdmin(PoolId poolId, address newAdmin, bool canManage) external;
+    /// @notice TODO
+    function allowInvestorAsset(PoolId poolId, AssetId assetId, bool isAllowed) external;
     /// @notice TODO
     function updateMetadata(PoolId poolId, bytes calldata metadata) external;
     /// @notice TODO
@@ -46,6 +51,8 @@ interface IPoolRegistry {
     function shareClassManager(PoolId poolId) external view returns (IShareClassManager);
     /// @notice TODO
     function isAdmin(PoolId poolId, address admin) external view returns (bool);
+    /// @notice TODO
+    function isInvestorAsset(PoolId poolId, AssetId assetId) external view returns (bool);
     /// @notice TODO
     function addressFor(PoolId poolId, bytes32 key) external view returns (address);
     /// @notice TODO

--- a/src/interfaces/IPoolRegistry.sol
+++ b/src/interfaces/IPoolRegistry.sol
@@ -20,7 +20,6 @@ interface IPoolRegistry {
     event UpdatedCurrency(PoolId indexed poolId, IERC20Metadata currency);
     event SetAddressFor(PoolId indexed poolId, bytes32 key, address addr);
 
-    error PoolAlreadyExists();
     error NonExistingPool(PoolId id);
     error EmptyAdmin();
     error EmptyAsset();
@@ -28,13 +27,10 @@ interface IPoolRegistry {
     error EmptyShareClassManager();
 
     /// @notice Register a new pool.
-    /// @param localPoolId is used to generate the final returned PoolId.
-    function registerPool(
-        uint32 localPoolId,
-        address admin,
-        IERC20Metadata currency,
-        IShareClassManager shareClassManager
-    ) external returns (PoolId poolId);
+    /// @return a PoolId to identify the new pool.
+    function registerPool(address admin, IERC20Metadata currency, IShareClassManager shareClassManager)
+        external
+        returns (PoolId);
 
     /// @notice allow/disallow an address as an admin for the pool
     function updateAdmin(PoolId poolId, address newAdmin, bool canManage) external;

--- a/src/interfaces/IPoolRegistry.sol
+++ b/src/interfaces/IPoolRegistry.sol
@@ -20,6 +20,7 @@ interface IPoolRegistry {
     event UpdatedCurrency(PoolId indexed poolId, IERC20Metadata currency);
     event SetAddressFor(PoolId indexed poolId, bytes32 key, address addr);
 
+    error PoolAlreadyExists();
     error NonExistingPool(PoolId id);
     error EmptyAdmin();
     error EmptyAsset();
@@ -27,9 +28,12 @@ interface IPoolRegistry {
     error EmptyShareClassManager();
 
     /// @notice TODO
-    function registerPool(address admin, IERC20Metadata currency, IShareClassManager shareClassManager)
-        external
-        returns (PoolId);
+    function registerPool(
+        uint32 localPoolId,
+        address admin,
+        IERC20Metadata currency,
+        IShareClassManager shareClassManager
+    ) external returns (PoolId poolId);
     /// @notice TODO
     function updateAdmin(PoolId poolId, address newAdmin, bool canManage) external;
     /// @notice TODO

--- a/src/libraries/PoolIdLib.sol
+++ b/src/libraries/PoolIdLib.sol
@@ -2,9 +2,20 @@
 pragma solidity 0.8.28;
 
 import {PoolId} from "src/types/PoolId.sol";
+import {MathLib} from "src/libraries/MathLib.sol";
 
 library PoolIdLib {
+    using MathLib for uint256;
+
     function chainId(PoolId poolId) internal pure returns (uint32) {
         return uint32(PoolId.unwrap(poolId) >> 32);
+    }
+
+    function localId(PoolId poolId) internal pure returns (uint32) {
+        return uint32(PoolId.unwrap(poolId));
+    }
+
+    function newFrom(uint32 localPoolId) internal view returns (PoolId) {
+        return PoolId.wrap((uint64(block.chainid.toUint32()) << 32) | uint64(localPoolId));
     }
 }

--- a/src/libraries/PoolIdLib.sol
+++ b/src/libraries/PoolIdLib.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {PoolId} from "src/types/PoolId.sol";
+
 import {MathLib} from "src/libraries/MathLib.sol";
 
 library PoolIdLib {
@@ -9,10 +10,6 @@ library PoolIdLib {
 
     function chainId(PoolId poolId) internal pure returns (uint32) {
         return uint32(PoolId.unwrap(poolId) >> 32);
-    }
-
-    function localId(PoolId poolId) internal pure returns (uint32) {
-        return uint32(PoolId.unwrap(poolId));
     }
 
     function newFrom(uint32 localPoolId) internal view returns (PoolId) {

--- a/test/unit/PoolRegistry.t.sol
+++ b/test/unit/PoolRegistry.t.sol
@@ -11,8 +11,6 @@ import {IAuth} from "src/interfaces/IAuth.sol";
 import {IERC20Metadata} from "src/interfaces/IERC20Metadata.sol";
 import {IShareClassManager} from "src/interfaces/IShareClassManager.sol";
 
-uint32 constant LOCAL_POOL_ID = 1;
-
 contract PoolRegistryTest is Test {
     using MathLib for uint256;
 
@@ -37,29 +35,28 @@ contract PoolRegistryTest is Test {
     function testPoolRegistration(address fundAdmin) public nonZero(fundAdmin) notThisContract(fundAdmin) {
         vm.prank(makeAddr("unauthorizedAddress"));
         vm.expectRevert(IAuth.NotAuthorized.selector);
-        registry.registerPool(LOCAL_POOL_ID, address(this), USD, shareClassManager);
+        registry.registerPool(address(this), USD, shareClassManager);
 
         vm.expectRevert(IPoolRegistry.EmptyShareClassManager.selector);
-        registry.registerPool(LOCAL_POOL_ID, address(this), USD, IShareClassManager(address(0)));
+        registry.registerPool(address(this), USD, IShareClassManager(address(0)));
 
         vm.expectRevert(IPoolRegistry.EmptyAdmin.selector);
-        registry.registerPool(LOCAL_POOL_ID, address(0), USD, shareClassManager);
+        registry.registerPool(address(0), USD, shareClassManager);
 
         vm.expectRevert(IPoolRegistry.EmptyCurrency.selector);
-        registry.registerPool(LOCAL_POOL_ID, address(this), IERC20Metadata(address(0)), shareClassManager);
+        registry.registerPool(address(this), IERC20Metadata(address(0)), shareClassManager);
 
         vm.expectEmit();
-        emit IPoolRegistry.NewPool(PoolIdLib.newFrom(LOCAL_POOL_ID), fundAdmin, shareClassManager, USD);
-        PoolId poolId = registry.registerPool(LOCAL_POOL_ID, fundAdmin, USD, shareClassManager);
+        emit IPoolRegistry.NewPool(PoolIdLib.newFrom(1), fundAdmin, shareClassManager, USD);
+        PoolId poolId = registry.registerPool(fundAdmin, USD, shareClassManager);
+
         assertEq(poolId.chainId(), block.chainid.toUint32());
-        assertEq(poolId.localId(), LOCAL_POOL_ID);
+        assertEq(PoolId.unwrap(poolId), ((uint64(block.chainid.toUint32()) << 32) | 1));
+        assertEq(registry.latestId(), 1);
 
         assertTrue(registry.isAdmin(poolId, fundAdmin));
         assertFalse(registry.isAdmin(poolId, address(this)));
         assertEq(address(registry.shareClassManager(poolId)), address(shareClassManager));
-
-        vm.expectRevert(IPoolRegistry.PoolAlreadyExists.selector);
-        registry.registerPool(LOCAL_POOL_ID, address(this), IERC20Metadata(address(0)), shareClassManager);
     }
 
     function testUpdateAdmin(address fundAdmin, address additionalAdmin)
@@ -70,7 +67,7 @@ contract PoolRegistryTest is Test {
         notThisContract(additionalAdmin)
     {
         vm.assume(fundAdmin != additionalAdmin);
-        PoolId poolId = registry.registerPool(LOCAL_POOL_ID, fundAdmin, USD, shareClassManager);
+        PoolId poolId = registry.registerPool(fundAdmin, USD, shareClassManager);
 
         assertFalse(registry.isAdmin(poolId, additionalAdmin));
 
@@ -99,7 +96,7 @@ contract PoolRegistryTest is Test {
     }
 
     function testAllowInvestorAsset(address fundAdmin) public nonZero(fundAdmin) notThisContract(fundAdmin) {
-        PoolId poolId = registry.registerPool(LOCAL_POOL_ID, fundAdmin, USD, shareClassManager);
+        PoolId poolId = registry.registerPool(fundAdmin, USD, shareClassManager);
 
         AssetId validAsset = AssetId.wrap(address(1));
         assertFalse(registry.isInvestorAssetAllowed(poolId, validAsset));
@@ -131,7 +128,7 @@ contract PoolRegistryTest is Test {
     function testSetMetadata(bytes calldata metadata) public {
         address fundAdmin = makeAddr("fundAdmin");
 
-        PoolId poolId = registry.registerPool(LOCAL_POOL_ID, fundAdmin, USD, shareClassManager);
+        PoolId poolId = registry.registerPool(fundAdmin, USD, shareClassManager);
 
         assertEq(registry.metadata(poolId).length, 0);
 
@@ -155,7 +152,7 @@ contract PoolRegistryTest is Test {
     {
         address fundAdmin = makeAddr("fundAdmin");
 
-        PoolId poolId = registry.registerPool(LOCAL_POOL_ID, fundAdmin, USD, shareClassManager);
+        PoolId poolId = registry.registerPool(fundAdmin, USD, shareClassManager);
 
         assertEq(address(registry.shareClassManager(poolId)), address(shareClassManager));
 
@@ -179,7 +176,7 @@ contract PoolRegistryTest is Test {
     function testUpdateCurrency(IERC20Metadata currency) public nonZero(address(currency)) {
         address fundAdmin = makeAddr("fundAdmin");
 
-        PoolId poolId = registry.registerPool(LOCAL_POOL_ID, fundAdmin, USD, shareClassManager);
+        PoolId poolId = registry.registerPool(fundAdmin, USD, shareClassManager);
 
         vm.prank(makeAddr("unauthorizedAddress"));
         vm.expectRevert(IAuth.NotAuthorized.selector);
@@ -200,7 +197,7 @@ contract PoolRegistryTest is Test {
     }
 
     function testSetAddressFor() public {
-        PoolId poolId = registry.registerPool(LOCAL_POOL_ID, makeAddr("fundManager"), USD, shareClassManager);
+        PoolId poolId = registry.registerPool(makeAddr("fundManager"), USD, shareClassManager);
 
         PoolId nonExistingPool = PoolId.wrap(0xDEAD);
         vm.expectRevert(abi.encodeWithSelector(IPoolRegistry.NonExistingPool.selector, nonExistingPool));
@@ -217,7 +214,7 @@ contract PoolRegistryTest is Test {
     }
 
     function testExists() public {
-        PoolId poolId = registry.registerPool(LOCAL_POOL_ID, makeAddr("fundManager"), USD, shareClassManager);
+        PoolId poolId = registry.registerPool(makeAddr("fundManager"), USD, shareClassManager);
         assertEq(registry.exists(poolId), true);
 
         PoolId nonExistingPool = PoolId.wrap(0xDEAD);

--- a/test/unit/PoolRegistry.t.sol
+++ b/test/unit/PoolRegistry.t.sol
@@ -102,7 +102,7 @@ contract PoolRegistryTest is Test {
         PoolId poolId = registry.registerPool(LOCAL_POOL_ID, fundAdmin, USD, shareClassManager);
 
         AssetId validAsset = AssetId.wrap(address(1));
-        assertFalse(registry.isInvestorAsset(poolId, validAsset));
+        assertFalse(registry.isInvestorAssetAllowed(poolId, validAsset));
 
         vm.prank(makeAddr("unauthorizedAddress"));
         vm.expectRevert(IAuth.NotAuthorized.selector);
@@ -119,16 +119,16 @@ contract PoolRegistryTest is Test {
         vm.expectEmit();
         emit IPoolRegistry.AllowedInvestorAsset(poolId, validAsset, true);
         registry.allowInvestorAsset(poolId, validAsset, true);
-        assertTrue(registry.isInvestorAsset(poolId, validAsset));
+        assertTrue(registry.isInvestorAssetAllowed(poolId, validAsset));
 
         // Disallow an asset
         vm.expectEmit();
         emit IPoolRegistry.AllowedInvestorAsset(poolId, validAsset, false);
         registry.allowInvestorAsset(poolId, validAsset, false);
-        assertFalse(registry.isInvestorAsset(poolId, validAsset));
+        assertFalse(registry.isInvestorAssetAllowed(poolId, validAsset));
     }
 
-    function testUpdateMetadata(bytes calldata metadata) public {
+    function testSetMetadata(bytes calldata metadata) public {
         address fundAdmin = makeAddr("fundAdmin");
 
         PoolId poolId = registry.registerPool(LOCAL_POOL_ID, fundAdmin, USD, shareClassManager);
@@ -137,15 +137,15 @@ contract PoolRegistryTest is Test {
 
         vm.prank(makeAddr("unauthorizedAddress"));
         vm.expectRevert(IAuth.NotAuthorized.selector);
-        registry.updateMetadata(poolId, metadata);
+        registry.setMetadata(poolId, metadata);
 
         PoolId nonExistingPool = PoolId.wrap(0xDEAD);
         vm.expectRevert(abi.encodeWithSelector(IPoolRegistry.NonExistingPool.selector, nonExistingPool));
-        registry.updateMetadata(nonExistingPool, metadata);
+        registry.setMetadata(nonExistingPool, metadata);
 
         vm.expectEmit();
-        emit IPoolRegistry.UpdatedMetadata(poolId, metadata);
-        registry.updateMetadata(poolId, metadata);
+        emit IPoolRegistry.SetMetadata(poolId, metadata);
+        registry.setMetadata(poolId, metadata);
         assertEq(registry.metadata(poolId), metadata);
     }
 
@@ -176,7 +176,7 @@ contract PoolRegistryTest is Test {
         assertEq(address(registry.shareClassManager(poolId)), address(shareClassManager_));
     }
 
-    function testUpdatePoolCurrency(IERC20Metadata currency) public nonZero(address(currency)) {
+    function testUpdateCurrency(IERC20Metadata currency) public nonZero(address(currency)) {
         address fundAdmin = makeAddr("fundAdmin");
 
         PoolId poolId = registry.registerPool(LOCAL_POOL_ID, fundAdmin, USD, shareClassManager);


### PR DESCRIPTION
Requires changes to `PoolRegistry`

- We need `createPool()` to allow us to set a `PoolId` from the outside: [thread](https://github.com/centrifuge/pools-internal/pull/36#discussion_r1905330508)
- Added `allowInvestorAsset()`, previous `allowAsset()` in `ShareClassManager`
  - @peculiarity I was thinking about the name, and I really prefer "allow" because it means a binary answer: yes or no. All configure methods out there configure the content of the element. They receive a bunch of parameters or a `Config` struct. Here we are not configuring the Asset (that would happen in `AssetRegistry` probably), instead allowing its usage.
- Added tests for events.
- Rename `updateCurrency` (previously suggested by myself in the arch diagram) by `setCurrency` following this [rule](https://kflabs.slack.com/archives/C07PG2EUR9C/p1734003089245559?thread_ts=1733941850.823459&cid=C07PG2EUR9C)