### PR TITLE
ShareClassManager: use prices instead of factors

### DIFF
--- a/src/TransientValuation.sol
+++ b/src/TransientValuation.sol
@@ -6,7 +6,7 @@ import {D18} from "src/types/D18.sol";
 
 import {Conversion} from "src/libraries/Conversion.sol";
 
-import {IERC7726} from "src/interfaces/IERC7726.sol";
+import {IERC7726, IERC7726Ext} from "src/interfaces/IERC7726.sol";
 import {ITransientValuation} from "src/interfaces/ITransientValuation.sol";
 
 contract TransientValuation is ITransientValuation {
@@ -21,5 +21,10 @@ contract TransientValuation is ITransientValuation {
     /// @inheritdoc IERC7726
     function getQuote(uint256 baseAmount, address base, address quote) external view returns (uint256 quoteAmount) {
         return Conversion.convertWithPrice(baseAmount, base, quote, price);
+    }
+
+    /// @inheritdoc IERC7726Ext
+    function getPrice(address, /*base*/ address /*quote*/ ) external view returns (D18) {
+        return price;
     }
 }

--- a/src/interfaces/IERC7726.sol
+++ b/src/interfaces/IERC7726.sol
@@ -14,8 +14,8 @@ interface IERC7726 {
 }
 
 interface IERC7726Ext is IERC7726 {
-    /// @notice Returns the internal ratio used to convert base into quote, e.g. ETH to USDC
+    /// @notice Returns the current price used to convert base into quote, e.g. ETH to USDC
     /// @param base The numerator asset for the desired ratio
     /// @param quote The denominator asset
-    function getFactor(address base, address quote) external view returns (D18 factor);
+    function getPrice(address base, address quote) external view returns (D18 price);
 }

--- a/src/interfaces/IShareClassManager.sol
+++ b/src/interfaces/IShareClassManager.sol
@@ -175,7 +175,7 @@ interface IShareClassManager {
     /// @param approvalRatio Percentage of approved requests
     /// @param payoutAssetId Identifier of the asset for which all requests want to exchange their share class tokens
     /// for
-    /// @param valuation Converter for quotas, e.g. price ratio of share class token amount to pool amount
+    /// @param valuation Converter for quotas, e.g. price ratio of asset amount to pool amount
     /// @return approvedShareAmount Sum of redemption request amounts in pool amount which was approved
     /// @return pendingShareAmount Sum of redemption request amounts in share class token amount which was not approved
     function approveRedeems(

--- a/src/interfaces/ITransientValuation.sol
+++ b/src/interfaces/ITransientValuation.sol
@@ -2,11 +2,11 @@
 pragma solidity 0.8.28;
 
 import {D18} from "src/types/D18.sol";
-import {IERC7726} from "src/interfaces/IERC7726.sol";
+import {IERC7726Ext} from "src/interfaces/IERC7726.sol";
 
 /// @notice An IERC7726 valuation that allows to set a price that is only valid for the current transaction.
 /// NOTE: Do not use it if the valuation lifetime is longer than the transaction.
-interface ITransientValuation is IERC7726 {
+interface ITransientValuation is IERC7726Ext {
     /// @notice Set the price for the valuation.
     /// The price is the 1 amount of base denominated in quote.
     /// i.e: if base BTC and quote USDC, the price is 90_000 USDC per BTC

--- a/src/types/D18.sol
+++ b/src/types/D18.sol
@@ -65,6 +65,11 @@ function reciprocalMulUint256(D18 d, uint256 value) pure returns (uint256) {
     return MathLib.mulDiv(value, 1e18, d.inner());
 }
 
+/// TODO
+function inverse(D18 d) pure returns (D18) {
+    return d18(MathLib.mulDiv(1e18, 1e18, d.inner()).toUint128());
+}
+
 /// @dev Easy way to construct a decimal number
 function d18(uint128 value) pure returns (D18) {
     return D18.wrap(value);
@@ -76,5 +81,13 @@ function d18(uint128 num, uint128 den) pure returns (D18) {
 }
 
 using {
-    add as +, sub as -, divD8 as /, inner, mulD8 as *, mulUint128, mulUint256, reciprocalMulUint256
+    add as +,
+    sub as -,
+    divD8 as /,
+    inner,
+    mulD8 as *,
+    mulUint128,
+    mulUint256,
+    reciprocalMulUint256,
+    inverse
 } for D18 global;


### PR DESCRIPTION
This PR comes from this [thread](https://github.com/centrifuge/pools-internal/pull/35#discussion_r1916273277)

## Description 

There are currently two minor issues if we handle prices as factors that we ideally do not want to have them:

1. Values used to convert from `assetToPool` are no prices, they are factors. For example, for CFG -> USDC we will have a price of `0.3` but a factor of `0.0000000000003` because CFG is 18 decimals and usdc 6. This can be difficult to handle from a UX perspective if they want to show the "human" readable prices as `0.3`, or perform inverses.

2. The `D18` type treated as a factor does not have enough resolution to convert a 27-decimal currency into a 6-decimal currency. Even for a 18 dec -> 6 dec conversion, we can lose significant precision. `D18` should be used only to hold prices, no factors.

This PR avoids factor usage to use prices instead.