### PR TITLE
Refactor: Multicall using Call struct

### DIFF
--- a/src/Multicall.sol
+++ b/src/Multicall.sol
@@ -5,13 +5,11 @@ import {IMulticall} from "src/interfaces/IMulticall.sol";
 
 contract Multicall is IMulticall {
     /// @dev Performs a generic multicall. It reverts the whole transaction if one call fails.
-    function aggregate(address[] calldata targets, bytes[] calldata datas) external returns (bytes[] memory results) {
-        require(targets.length == datas.length, WrongExecutionParams());
+    function aggregate(Call[] calldata calls) external returns (bytes[] memory results) {
+        results = new bytes[](calls.length);
 
-        results = new bytes[](datas.length);
-
-        for (uint32 i; i < targets.length; i++) {
-            (bool success, bytes memory result) = targets[i].call(datas[i]);
+        for (uint32 i; i < calls.length; i++) {
+            (bool success, bytes memory result) = calls[i].target.call(calls[i].data);
             // Forward the error happened in target.call().
             if (!success) {
                 assembly {

--- a/src/PoolLocker.sol
+++ b/src/PoolLocker.sol
@@ -25,15 +25,12 @@ abstract contract PoolLocker is IPoolLocker {
 
     /// @inheritdoc IPoolLocker
     /// @dev All calls with `poolUnlocked` modifier are able to be called inside this method
-    function execute(PoolId poolId, address[] calldata targets, bytes[] calldata datas)
-        external
-        returns (bytes[] memory results)
-    {
+    function execute(PoolId poolId, IMulticall.Call[] calldata calls) external returns (bytes[] memory results) {
         require(PoolId.unwrap(_unlockedPoolId) == 0, PoolAlreadyUnlocked());
         _beforeUnlock(poolId);
         _unlockedPoolId = poolId;
 
-        results = multicall.aggregate(targets, datas);
+        results = multicall.aggregate(calls);
 
         _beforeLock();
         _unlockedPoolId = PoolId.wrap(0);

--- a/src/interfaces/IMulticall.sol
+++ b/src/interfaces/IMulticall.sol
@@ -3,8 +3,11 @@ pragma solidity 0.8.28;
 
 /// @notice Allows to call several calls in the same transactions
 interface IMulticall {
+    /// @notice Identify a call method.
     struct Call {
+        /// @notice Contract from where to perform the call
         address target;
+        /// @notice Encoding of selector + parameters of the method
         bytes data;
     }
 

--- a/src/interfaces/IMulticall.sol
+++ b/src/interfaces/IMulticall.sol
@@ -3,10 +3,12 @@ pragma solidity 0.8.28;
 
 /// @notice Allows to call several calls in the same transactions
 interface IMulticall {
-    /// @notice Dispatched when the `targets` and `datas` length parameters in `execute()` do not matched.
-    error WrongExecutionParams();
+    struct Call {
+        address target;
+        bytes data;
+    }
 
     /// @notice Execute a generic multicall.
     /// If one call fails, it reverts the whole transaction.
-    function aggregate(address[] calldata targets, bytes[] calldata datas) external returns (bytes[] memory results);
+    function aggregate(Call[] calldata calls) external returns (bytes[] memory results);
 }

--- a/src/interfaces/IPoolLocker.sol
+++ b/src/interfaces/IPoolLocker.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {PoolId} from "src/types/PoolId.sol";
+import {IMulticall} from "src/interfaces/IMulticall.sol";
 
 /// @notice Abstract the mechanism to unlock pools
 interface IPoolLocker {
@@ -16,9 +17,7 @@ interface IPoolLocker {
     error PoolLocked();
 
     /// @notice Execute a multicall inside of an unlocked pool.
-    function execute(PoolId poolId, address[] calldata targets, bytes[] calldata datas)
-        external
-        returns (bytes[] memory results);
+    function execute(PoolId poolId, IMulticall.Call[] calldata calls) external returns (bytes[] memory results);
 
     /// @notice Returns the unlocked poolId.
     /// In only will contain a non-zero value if called inside `execute()`


### PR DESCRIPTION
### Problem

When a multicall grows in size, it becomes very verbose and error-prone when configuring the multicall, because `target` and `data` are split per call. See [this](https://github.com/centrifuge/pools-internal/pull/74)

### Solution

Using a `Call` struct to join both fields, it becomes more readable and less error-prone. Also, it's easier to refactor test cases.