### PR TITLE
refactor: Remove price ratio storage from SingleShareClass

### DIFF
--- a/src/OneToOneValuation.sol
+++ b/src/OneToOneValuation.sol
@@ -5,7 +5,7 @@ import {D18, d18} from "src/types/D18.sol";
 
 import {Conversion} from "src/libraries/Conversion.sol";
 
-import {IERC7726, IERC7726Ext} from "src/interfaces/IERC7726.sol";
+import {IERC7726} from "src/interfaces/IERC7726.sol";
 import {IOneToOneValuation} from "src/interfaces/IOneToOneValuation.sol";
 import {IERC6909MetadataExt} from "src/interfaces/ERC6909/IERC6909MetadataExt.sol";
 

--- a/src/SingleShareClass.sol
+++ b/src/SingleShareClass.sol
@@ -4,32 +4,27 @@ pragma solidity 0.8.28;
 import {Auth} from "src/Auth.sol";
 import {D18, d18} from "src/types/D18.sol";
 import {IPoolRegistry} from "src/interfaces/IPoolRegistry.sol";
-import {IERC7726Ext} from "src/interfaces/IERC7726.sol";
+import {IERC7726} from "src/interfaces/IERC7726.sol";
 import {IShareClassManager} from "src/interfaces/IShareClassManager.sol";
 import {ISingleShareClass} from "src/interfaces/ISingleShareClass.sol";
 import {MathLib} from "src/libraries/MathLib.sol";
 import {PoolId} from "src/types/PoolId.sol";
 
-struct Epoch {
-    /// @dev Amount of approved deposits (in pool denomination)
-    uint128 approvedDepositAmount;
-    /// @dev Amount of approved shares (in share denomination)
-    uint128 approvedShareAmount;
-}
-
-struct EpochRatio {
+struct EpochAmounts {
     /// @dev Percentage of approved deposits
-    D18 depositRatio;
+    D18 depositApprovalRate;
     /// @dev Percentage of approved redemptions
-    D18 redeemRatio;
-    /// @dev Price of one pool per asset token set during redeem approval
-    D18 depositAssetToPoolQuote;
-    /// @dev Price of one pool per asset token set during redeem approval
-    D18 redeemAssetToPoolQuote;
-    /// @dev Price of one pool per share class token set during deposit flow
-    D18 depositShareToPoolQuote;
-    /// @dev Price of one pool per share class token set during redeem flow
-    D18 redeemShareToPoolQuote;
+    D18 redeemApprovalRate;
+    /// @dev Total approved asset amount of deposit asset
+    uint128 depositAssetAmount;
+    /// @dev Total approved pool amount of deposit asset
+    uint128 depositPoolAmount;
+    /// @dev Total number of share class tokens issued
+    uint128 depositSharesIssued;
+    /// @dev Total asset amount of revoked share class tokens
+    uint128 redeemAssetAmount;
+    /// @dev Total approved amount of redeemed share class tokens
+    uint128 redeemSharesRevoked;
 }
 
 struct UserOrder {
@@ -55,6 +50,7 @@ struct AssetEpochState {
 contract SingleShareClass is Auth, ISingleShareClass {
     using MathLib for D18;
     using MathLib for uint128;
+    using MathLib for uint256;
 
     /// Storage
     // uint32 private transient _epochIncrement;
@@ -64,11 +60,11 @@ contract SingleShareClass is Auth, ISingleShareClass {
     mapping(bytes16 scId => uint128) public totalIssuance;
     mapping(PoolId poolId => uint32 epochId_) public epochId;
     mapping(bytes16 scId => D18 navPerShare) private _shareClassNavPerShare;
-    mapping(bytes16 scId => mapping(uint32 epochId_ => Epoch epoch)) public epoch;
     mapping(bytes16 scId => mapping(address assetId => AssetEpochState)) public assetEpochState;
     mapping(bytes16 scId => mapping(address payoutAssetId => uint128 pending)) public pendingRedeem;
     mapping(bytes16 scId => mapping(address paymentAssetId => uint128 pending)) public pendingDeposit;
-    mapping(bytes16 scId => mapping(address assetId => mapping(uint32 epochId_ => EpochRatio epoch))) public epochRatio;
+    mapping(bytes16 scId => mapping(address assetId => mapping(uint32 epochId_ => EpochAmounts epoch))) public
+        epochAmounts;
     mapping(bytes16 scId => mapping(address payoutAssetId => mapping(address investor => UserOrder pending))) public
         redeemRequest;
     mapping(bytes16 scId => mapping(address paymentAssetId => mapping(address investor => UserOrder pending))) public
@@ -151,7 +147,7 @@ contract SingleShareClass is Auth, ISingleShareClass {
         bytes16 shareClassId_,
         D18 approvalRatio,
         address paymentAssetId,
-        IERC7726Ext valuation
+        IERC7726 valuation
     ) external auth returns (uint128 approvedPoolAmount, uint128 approvedAssetAmount) {
         _ensureShareClassExists(poolId, shareClassId_);
         require(approvalRatio.inner() <= 1e18, ISingleShareClass.MaxApprovalRatioExceeded());
@@ -172,16 +168,14 @@ contract SingleShareClass is Auth, ISingleShareClass {
 
         // Increase approved
         address poolCurrency = poolRegistry.currency(poolId).addr();
-        D18 paymentAssetPrice = valuation.getFactor(paymentAssetId, poolCurrency);
-        approvedPoolAmount = paymentAssetPrice.mulUint128(approvedAssetAmount);
+        approvedPoolAmount =
+            (IERC7726(valuation).getQuote(approvedAssetAmount, paymentAssetId, poolCurrency)).toUint128();
 
         // Update epoch data
-        epoch[shareClassId_][approvalEpochId].approvedDepositAmount += approvedPoolAmount;
-
-        EpochRatio storage epochRatio_ = epochRatio[shareClassId_][paymentAssetId][approvalEpochId];
-        epochRatio_.depositRatio = approvalRatio;
-        epochRatio_.depositAssetToPoolQuote = paymentAssetPrice;
-
+        EpochAmounts storage epochAmounts_ = epochAmounts[shareClassId_][paymentAssetId][approvalEpochId];
+        epochAmounts_.depositApprovalRate = approvalRatio;
+        epochAmounts_.depositAssetAmount = approvedAssetAmount;
+        epochAmounts_.depositPoolAmount = approvedPoolAmount;
         assetEpochState[shareClassId_][paymentAssetId].latestDepositApproval = approvalEpochId;
 
         emit IShareClassManager.ApprovedDeposits(
@@ -192,8 +186,7 @@ contract SingleShareClass is Auth, ISingleShareClass {
             approvalRatio,
             approvedPoolAmount,
             approvedAssetAmount,
-            pendingDepositPostUpdate,
-            paymentAssetPrice
+            pendingDepositPostUpdate
         );
     }
 
@@ -203,7 +196,7 @@ contract SingleShareClass is Auth, ISingleShareClass {
         bytes16 shareClassId_,
         D18 approvalRatio,
         address payoutAssetId,
-        IERC7726Ext valuation
+        IERC7726 /* valuation */
     ) external auth returns (uint128 approvedShareAmount, uint128 pendingShareAmount) {
         _ensureShareClassExists(poolId, shareClassId_);
         require(approvalRatio.inner() <= 1e18, ISingleShareClass.MaxApprovalRatioExceeded());
@@ -222,16 +215,10 @@ contract SingleShareClass is Auth, ISingleShareClass {
         pendingRedeem[shareClassId_][payoutAssetId] -= approvedShareAmount;
         pendingShareAmount = pendingRedeem[shareClassId_][payoutAssetId];
 
-        // Increase approved
-        address poolCurrency = poolRegistry.currency(poolId).addr();
-        D18 assetToPool = valuation.getFactor(payoutAssetId, poolCurrency);
-
         // Update epoch data
-        epoch[shareClassId_][approvalEpochId].approvedShareAmount += approvedShareAmount;
-
-        EpochRatio storage epochRatio_ = epochRatio[shareClassId_][payoutAssetId][approvalEpochId];
-        epochRatio_.redeemRatio = approvalRatio;
-        epochRatio_.redeemAssetToPoolQuote = assetToPool;
+        EpochAmounts storage epochAmounts_ = epochAmounts[shareClassId_][payoutAssetId][approvalEpochId];
+        epochAmounts_.redeemApprovalRate = approvalRatio;
+        epochAmounts_.redeemSharesRevoked = approvedShareAmount;
 
         assetEpochState[shareClassId_][payoutAssetId].latestRedeemApproval = approvalEpochId;
 
@@ -242,8 +229,7 @@ contract SingleShareClass is Auth, ISingleShareClass {
             payoutAssetId,
             approvalRatio,
             approvedShareAmount,
-            pendingShareAmount,
-            assetToPool
+            pendingShareAmount
         );
     }
 
@@ -278,13 +264,14 @@ contract SingleShareClass is Auth, ISingleShareClass {
 
         for (uint32 epochId_ = startEpochId; epochId_ <= endEpochId; epochId_++) {
             // Skip redeem epochs
-            if (epochRatio[shareClassId_][depositAssetId][epochId_].depositRatio.inner() == 0) {
+            if (epochAmounts[shareClassId_][depositAssetId][epochId_].depositApprovalRate.inner() == 0) {
                 continue;
             }
 
-            uint128 newShareAmount =
-                navPerShare.reciprocalMulUint128(epoch[shareClassId_][epochId_].approvedDepositAmount);
-            epochRatio[shareClassId_][depositAssetId][epochId_].depositShareToPoolQuote = navPerShare;
+            uint128 newShareAmount = navPerShare.reciprocalMulUint128(
+                epochAmounts[shareClassId_][depositAssetId][epochId_].depositPoolAmount
+            );
+            epochAmounts[shareClassId_][depositAssetId][epochId_].depositSharesIssued = newShareAmount;
             totalIssuance_ += newShareAmount;
             uint128 nav = navPerShare.mulUint128(totalIssuance_);
 
@@ -297,11 +284,13 @@ contract SingleShareClass is Auth, ISingleShareClass {
     }
 
     /// @inheritdoc IShareClassManager
-    function revokeShares(PoolId poolId, bytes16 shareClassId_, address payoutAssetId, D18 navPerShare)
-        external
-        auth
-        returns (uint128 payoutAssetAmount, uint128 payoutPoolAmount)
-    {
+    function revokeShares(
+        PoolId poolId,
+        bytes16 shareClassId_,
+        address payoutAssetId,
+        D18 navPerShare,
+        IERC7726 valuation
+    ) external auth returns (uint128 payoutAssetAmount, uint128 payoutPoolAmount) {
         AssetEpochState memory assetEpochState_ = assetEpochState[shareClassId_][payoutAssetId];
         require(
             assetEpochState_.latestRedeemApproval > assetEpochState_.latestRevocation,
@@ -309,7 +298,7 @@ contract SingleShareClass is Auth, ISingleShareClass {
         );
 
         return revokeSharesUntilEpoch(
-            poolId, shareClassId_, payoutAssetId, navPerShare, assetEpochState_.latestRedeemApproval
+            poolId, shareClassId_, payoutAssetId, navPerShare, valuation, assetEpochState_.latestRedeemApproval
         );
     }
 
@@ -319,41 +308,85 @@ contract SingleShareClass is Auth, ISingleShareClass {
         bytes16 shareClassId_,
         address payoutAssetId,
         D18 navPerShare,
+        IERC7726 valuation,
         uint32 endEpochId
     ) public auth returns (uint128 payoutAssetAmount, uint128 payoutPoolAmount) {
         _ensureShareClassExists(poolId, shareClassId_);
         require(endEpochId < epochId[poolId], IShareClassManager.EpochNotFound());
 
         uint128 totalIssuance_ = totalIssuance[shareClassId_];
+        address poolCurrency = poolRegistry.currency(poolId).addr();
 
         // First issuance starts at epoch 0, subsequent ones at latest pointer plus one
         uint32 startEpochId = assetEpochState[shareClassId_][payoutAssetId].latestRevocation + 1;
 
         for (uint32 epochId_ = startEpochId; epochId_ <= endEpochId; epochId_++) {
-            EpochRatio storage epochRatio_ = epochRatio[shareClassId_][payoutAssetId][epochId_];
+            EpochAmounts storage epochAmounts_ = epochAmounts[shareClassId_][payoutAssetId][epochId_];
 
             // Skip deposit epochs
-            if (epochRatio_.redeemRatio.inner() == 0) {
+            if (epochAmounts_.redeemApprovalRate.inner() == 0) {
                 continue;
             }
 
-            uint128 revokedShareAmount = epoch[shareClassId_][epochId_].approvedShareAmount;
-
-            // payout = shares * navPerShare
-            uint128 epochPoolAmount = navPerShare.mulUint128(revokedShareAmount);
-
-            epochRatio_.redeemShareToPoolQuote = navPerShare;
-            payoutPoolAmount += epochPoolAmount;
-            payoutAssetAmount += epochRatio_.redeemAssetToPoolQuote.reciprocalMulUint128(epochPoolAmount);
-            totalIssuance_ -= revokedShareAmount;
-            uint128 nav = navPerShare.mulUint128(totalIssuance_);
-
-            emit IShareClassManager.RevokedShares(poolId, shareClassId_, epochId_, navPerShare, nav, revokedShareAmount);
+            payoutPoolAmount += revokeEpochShares(
+                poolId,
+                shareClassId_,
+                payoutAssetId,
+                navPerShare,
+                valuation,
+                poolCurrency,
+                epochAmounts_,
+                totalIssuance_,
+                epochId_
+            );
+            payoutAssetAmount += epochAmounts_.redeemAssetAmount;
+            totalIssuance_ -= epochAmounts_.redeemSharesRevoked;
         }
 
         totalIssuance[shareClassId_] = totalIssuance_;
         assetEpochState[shareClassId_][payoutAssetId].latestRevocation = endEpochId;
         _shareClassNavPerShare[shareClassId_] = navPerShare;
+    }
+
+    /// @notice Revokes shares for a single epoch, updates epoch ratio and emits event.
+    ///
+    /// @param poolId Identifier of the pool
+    /// @param shareClassId_ Identifier of the share class
+    /// @param payoutAssetId Identifier of the payout asset
+    /// @param navPerShare Total value of assets of the pool and share class per share
+    /// @param valuation Source of truth for quotas, e.g. the price of a pool amount in payout asset
+    /// @param poolCurrency The address of the pool currency
+    /// @param epochAmounts_ Epoch ratio storage for the amount of revoked share class tokens and the corresponding
+    /// amount
+    /// in payout asset
+    /// @param totalIssuance_ Total issuance of share class tokens before revoking
+    /// @param epochId_ Identifier of the epoch for which we revoke
+    /// @return payoutPoolAmount Converted amount of pool currency based on number of revoked shares
+    function revokeEpochShares(
+        PoolId poolId,
+        bytes16 shareClassId_,
+        address payoutAssetId,
+        D18 navPerShare,
+        IERC7726 valuation,
+        address poolCurrency,
+        EpochAmounts storage epochAmounts_,
+        uint128 totalIssuance_,
+        uint32 epochId_
+    ) internal returns (uint128 payoutPoolAmount) {
+        payoutPoolAmount = navPerShare.mulUint128(epochAmounts_.redeemSharesRevoked);
+        epochAmounts_.redeemAssetAmount =
+            IERC7726(valuation).getQuote(payoutPoolAmount, poolCurrency, payoutAssetId).toUint128();
+
+        uint128 nav = navPerShare.mulUint128(totalIssuance_ - epochAmounts_.redeemSharesRevoked);
+        emit IShareClassManager.RevokedShares(
+            poolId,
+            shareClassId_,
+            epochId_,
+            navPerShare,
+            nav,
+            epochAmounts_.redeemSharesRevoked,
+            epochAmounts_.redeemAssetAmount
+        );
     }
 
     /// @inheritdoc IShareClassManager
@@ -384,22 +417,20 @@ contract SingleShareClass is Auth, ISingleShareClass {
         UserOrder storage userOrder = depositRequest[shareClassId_][depositAssetId][investor];
 
         for (uint32 epochId_ = userOrder.lastUpdate; epochId_ <= endEpochId; epochId_++) {
-            EpochRatio memory epochRatio_ = epochRatio[shareClassId_][depositAssetId][epochId_];
+            EpochAmounts memory epochAmounts_ = epochAmounts[shareClassId_][depositAssetId][epochId_];
 
             // Skip redeem epochs
-            if (epochRatio_.depositRatio.inner() == 0) {
+            if (epochAmounts_.depositApprovalRate.inner() == 0) {
                 continue;
             }
 
-            uint128 approvedAssetAmount = epochRatio_.depositRatio.mulUint128(userOrder.pending);
-
-            // #shares = poolAmount * poolToShares * poolAmount = (assetToPool * assetAmount) / shareToPool
-            uint128 investorShareAmount = epochRatio_.depositShareToPoolQuote.reciprocalMulUint128(
-                epochRatio_.depositAssetToPoolQuote.mulUint128(approvedAssetAmount)
-            );
+            uint128 approvedAssetAmount = epochAmounts_.depositApprovalRate.mulUint128(userOrder.pending);
+            uint128 claimableShareAmount = uint256(approvedAssetAmount).mulDiv(
+                epochAmounts_.depositSharesIssued, epochAmounts_.depositAssetAmount
+            ).toUint128();
 
             userOrder.pending -= approvedAssetAmount;
-            payoutShareAmount += investorShareAmount;
+            payoutShareAmount += claimableShareAmount;
             paymentAssetAmount += approvedAssetAmount;
 
             emit IShareClassManager.ClaimedDeposit(
@@ -410,7 +441,7 @@ contract SingleShareClass is Auth, ISingleShareClass {
                 depositAssetId,
                 approvedAssetAmount,
                 userOrder.pending,
-                investorShareAmount
+                claimableShareAmount
             );
         }
 
@@ -445,22 +476,20 @@ contract SingleShareClass is Auth, ISingleShareClass {
         UserOrder storage userOrder = redeemRequest[shareClassId_][payoutAssetId][investor];
 
         for (uint32 epochId_ = userOrder.lastUpdate; epochId_ <= endEpochId; epochId_++) {
-            EpochRatio memory epochRatio_ = epochRatio[shareClassId_][payoutAssetId][epochId_];
+            EpochAmounts memory epochAmounts_ = epochAmounts[shareClassId_][payoutAssetId][epochId_];
 
             // Skip deposit epochs
-            if (epochRatio_.redeemRatio.inner() == 0) {
+            if (epochAmounts_.redeemApprovalRate.inner() == 0) {
                 continue;
             }
 
-            uint128 approvedShareAmount = epochRatio_.redeemRatio.mulUint128(userOrder.pending);
-
-            // assetAmount = poolAmount * poolToAsset = poolAmount / assetToPool = (#shares * shareToPool) / assetToPool
-            uint128 approvedAssetAmount = epochRatio_.redeemAssetToPoolQuote.reciprocalMulUint128(
-                epochRatio_.redeemShareToPoolQuote.mulUint128(approvedShareAmount)
-            );
+            uint128 approvedShareAmount = epochAmounts_.redeemApprovalRate.mulUint128(userOrder.pending);
+            uint128 claimableAssetAmount = uint256(approvedShareAmount).mulDiv(
+                epochAmounts_.redeemAssetAmount, epochAmounts_.redeemSharesRevoked
+            ).toUint128();
 
             paymentShareAmount += approvedShareAmount;
-            payoutAssetAmount += approvedAssetAmount;
+            payoutAssetAmount += claimableAssetAmount;
 
             userOrder.pending -= approvedShareAmount;
 
@@ -472,7 +501,7 @@ contract SingleShareClass is Auth, ISingleShareClass {
                 payoutAssetId,
                 approvedShareAmount,
                 userOrder.pending,
-                approvedAssetAmount
+                claimableAssetAmount
             );
         }
 

--- a/src/SingleShareClass.sol
+++ b/src/SingleShareClass.sol
@@ -235,7 +235,7 @@ contract SingleShareClass is Auth, ISingleShareClass {
 
     /// @inheritdoc IShareClassManager
     function issueShares(PoolId poolId, bytes16 shareClassId_, address depositAssetId, D18 navPerShare) external auth {
-        EpochPointers memory epochPointers_ = epochPointers[shareClassId_][depositAssetId];
+        EpochPointers storage epochPointers_ = epochPointers[shareClassId_][depositAssetId];
         require(
             epochPointers_.latestDepositApproval > epochPointers_.latestIssuance, ISingleShareClass.ApprovalRequired()
         );
@@ -288,7 +288,7 @@ contract SingleShareClass is Auth, ISingleShareClass {
         D18 navPerShare,
         IERC7726 valuation
     ) external auth returns (uint128 payoutAssetAmount, uint128 payoutPoolAmount) {
-        EpochPointers memory epochPointers_ = epochPointers[shareClassId_][payoutAssetId];
+        EpochPointers storage epochPointers_ = epochPointers[shareClassId_][payoutAssetId];
         require(
             epochPointers_.latestRedeemApproval > epochPointers_.latestRevocation, ISingleShareClass.ApprovalRequired()
         );
@@ -464,7 +464,7 @@ contract SingleShareClass is Auth, ISingleShareClass {
         UserOrder storage userOrder = redeemRequest[shareClassId_][payoutAssetId][investor];
 
         for (uint32 epochId_ = userOrder.lastUpdate; epochId_ <= endEpochId; epochId_++) {
-            EpochAmounts memory epochAmounts_ = epochAmounts[shareClassId_][payoutAssetId][epochId_];
+            EpochAmounts storage epochAmounts_ = epochAmounts[shareClassId_][payoutAssetId][epochId_];
 
             // Skip deposit epochs
             if (epochAmounts_.redeemApprovalRate.inner() == 0) {

--- a/src/SingleShareClass.sol
+++ b/src/SingleShareClass.sol
@@ -148,7 +148,7 @@ contract SingleShareClass is Auth, ISingleShareClass {
         D18 approvalRatio,
         address paymentAssetId,
         IERC7726 valuation
-    ) external auth returns (uint128 approvedPoolAmount, uint128 approvedAssetAmount) {
+    ) external auth returns (uint128 approvedAssetAmount, uint128 approvedPoolAmount) {
         _ensureShareClassExists(poolId, shareClassId_);
         require(approvalRatio.inner() <= 1e18, ISingleShareClass.MaxApprovalRatioExceeded());
 
@@ -324,7 +324,7 @@ contract SingleShareClass is Auth, ISingleShareClass {
                 continue;
             }
 
-            payoutPoolAmount += revokeEpochShares(
+            payoutPoolAmount += _revokeEpochShares(
                 poolId,
                 shareClassId_,
                 payoutAssetId,
@@ -358,7 +358,7 @@ contract SingleShareClass is Auth, ISingleShareClass {
     /// @param totalIssuance_ Total issuance of share class tokens before revoking
     /// @param epochId_ Identifier of the epoch for which we revoke
     /// @return payoutPoolAmount Converted amount of pool currency based on number of revoked shares
-    function revokeEpochShares(
+    function _revokeEpochShares(
         PoolId poolId,
         bytes16 shareClassId_,
         address payoutAssetId,

--- a/src/SingleShareClass.sol
+++ b/src/SingleShareClass.sol
@@ -409,7 +409,7 @@ contract SingleShareClass is Auth, ISingleShareClass {
         UserOrder storage userOrder = depositRequest[shareClassId_][depositAssetId][investor];
 
         for (uint32 epochId_ = userOrder.lastUpdate; epochId_ <= endEpochId; epochId_++) {
-            EpochAmounts memory epochAmounts_ = epochAmounts[shareClassId_][depositAssetId][epochId_];
+            EpochAmounts storage epochAmounts_ = epochAmounts[shareClassId_][depositAssetId][epochId_];
 
             // Skip redeem epochs
             if (epochAmounts_.depositApprovalRate.inner() == 0) {

--- a/src/SingleShareClass.sol
+++ b/src/SingleShareClass.sol
@@ -344,47 +344,6 @@ contract SingleShareClass is Auth, ISingleShareClass {
         _shareClassNavPerShare[shareClassId_] = navPerShare;
     }
 
-    /// @notice Revokes shares for a single epoch, updates epoch ratio and emits event.
-    ///
-    /// @param poolId Identifier of the pool
-    /// @param shareClassId_ Identifier of the share class
-    /// @param payoutAssetId Identifier of the payout asset
-    /// @param navPerShare Total value of assets of the pool and share class per share
-    /// @param valuation Source of truth for quotas, e.g. the price of a pool amount in payout asset
-    /// @param poolCurrency The address of the pool currency
-    /// @param epochAmounts_ Epoch ratio storage for the amount of revoked share class tokens and the corresponding
-    /// amount
-    /// in payout asset
-    /// @param totalIssuance_ Total issuance of share class tokens before revoking
-    /// @param epochId_ Identifier of the epoch for which we revoke
-    /// @return payoutPoolAmount Converted amount of pool currency based on number of revoked shares
-    function _revokeEpochShares(
-        PoolId poolId,
-        bytes16 shareClassId_,
-        address payoutAssetId,
-        D18 navPerShare,
-        IERC7726 valuation,
-        address poolCurrency,
-        EpochAmounts storage epochAmounts_,
-        uint128 totalIssuance_,
-        uint32 epochId_
-    ) internal returns (uint128 payoutPoolAmount) {
-        payoutPoolAmount = navPerShare.mulUint128(epochAmounts_.redeemSharesRevoked);
-        epochAmounts_.redeemAssetAmount =
-            IERC7726(valuation).getQuote(payoutPoolAmount, poolCurrency, payoutAssetId).toUint128();
-
-        uint128 nav = navPerShare.mulUint128(totalIssuance_ - epochAmounts_.redeemSharesRevoked);
-        emit IShareClassManager.RevokedShares(
-            poolId,
-            shareClassId_,
-            epochId_,
-            navPerShare,
-            nav,
-            epochAmounts_.redeemSharesRevoked,
-            epochAmounts_.redeemAssetAmount
-        );
-    }
-
     /// @inheritdoc IShareClassManager
     function claimDeposit(PoolId poolId, bytes16 shareClassId_, address investor, address depositAssetId)
         external
@@ -516,6 +475,47 @@ contract SingleShareClass is Auth, ISingleShareClass {
         _ensureShareClassExists(poolId, shareClassId_);
 
         return (_shareClassNavPerShare[shareClassId_], totalIssuance[shareClassId_]);
+    }
+
+    /// @notice Revokes shares for a single epoch, updates epoch ratio and emits event.
+    ///
+    /// @param poolId Identifier of the pool
+    /// @param shareClassId_ Identifier of the share class
+    /// @param payoutAssetId Identifier of the payout asset
+    /// @param navPerShare Total value of assets of the pool and share class per share
+    /// @param valuation Source of truth for quotas, e.g. the price of a pool amount in payout asset
+    /// @param poolCurrency The address of the pool currency
+    /// @param epochAmounts_ Epoch ratio storage for the amount of revoked share class tokens and the corresponding
+    /// amount
+    /// in payout asset
+    /// @param totalIssuance_ Total issuance of share class tokens before revoking
+    /// @param epochId_ Identifier of the epoch for which we revoke
+    /// @return payoutPoolAmount Converted amount of pool currency based on number of revoked shares
+    function _revokeEpochShares(
+        PoolId poolId,
+        bytes16 shareClassId_,
+        address payoutAssetId,
+        D18 navPerShare,
+        IERC7726 valuation,
+        address poolCurrency,
+        EpochAmounts storage epochAmounts_,
+        uint128 totalIssuance_,
+        uint32 epochId_
+    ) private returns (uint128 payoutPoolAmount) {
+        payoutPoolAmount = navPerShare.mulUint128(epochAmounts_.redeemSharesRevoked);
+        epochAmounts_.redeemAssetAmount =
+            IERC7726(valuation).getQuote(payoutPoolAmount, poolCurrency, payoutAssetId).toUint128();
+
+        uint128 nav = navPerShare.mulUint128(totalIssuance_ - epochAmounts_.redeemSharesRevoked);
+        emit IShareClassManager.RevokedShares(
+            poolId,
+            shareClassId_,
+            epochId_,
+            navPerShare,
+            nav,
+            epochAmounts_.redeemSharesRevoked,
+            epochAmounts_.redeemAssetAmount
+        );
     }
 
     /// @notice Updates the amount of a request to deposit (exchange) an asset amount for share class tokens.

--- a/src/interfaces/IERC7726.sol
+++ b/src/interfaces/IERC7726.sol
@@ -12,10 +12,3 @@ interface IERC7726 {
     /// @param baseAmount The amount of base in base terms.
     function getQuote(uint256 baseAmount, address base, address quote) external view returns (uint256 quoteAmount);
 }
-
-interface IERC7726Ext is IERC7726 {
-    /// @notice Returns the internal ratio used to convert base into quote, e.g. ETH to USDC
-    /// @param base The numerator asset for the desired ratio
-    /// @param quote The denominator asset
-    function getFactor(address base, address quote) external view returns (D18 factor);
-}

--- a/src/interfaces/IShareClassManager.sol
+++ b/src/interfaces/IShareClassManager.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.28;
 
 import {D18} from "src/types/D18.sol";
-import {IERC7726Ext} from "src/interfaces/IERC7726.sol";
+import {IERC7726} from "src/interfaces/IERC7726.sol";
 import {PoolId} from "src/types/PoolId.sol";
 
 interface IShareClassManager {
@@ -34,8 +34,7 @@ interface IShareClassManager {
         D18 approvalRatio,
         uint128 approvedPoolAmount,
         uint128 approvedAssetAmount,
-        uint128 pendingAssetAmount,
-        D18 assetToPool
+        uint128 pendingAssetAmount
     );
     event ApprovedRedeems(
         PoolId indexed poolId,
@@ -44,8 +43,7 @@ interface IShareClassManager {
         address assetId,
         D18 approvalRatio,
         uint128 approvedShareClassAmount,
-        uint128 pending,
-        D18 assetToPool
+        uint128 pendingShareClassAmount
     );
     event IssuedShares(
         PoolId indexed poolId,
@@ -62,7 +60,8 @@ interface IShareClassManager {
         uint32 indexed epoch,
         D18 navPerShare,
         uint128 nav,
-        uint128 revokedShareAmount
+        uint128 revokedShareAmount,
+        uint128 revokedAssetAmount
     );
 
     event ClaimedDeposit(
@@ -156,7 +155,7 @@ interface IShareClassManager {
     /// @param shareClassId Identifier of the share class
     /// @param approvalRatio Percentage of approved requests
     /// @param paymentAssetId Identifier of the asset locked for the deposit request
-    /// @param valuation Converter for quotas, e.g. price ratio of asset amount to pool amount
+    /// @param valuation Source of truth for quotas, e.g. the price of an asset amount to pool amount
     /// @return approvedPoolAmount Sum of deposit request amounts in pool amount which was approved
     /// @return approvedAssetAmount Sum of deposit request amounts in asset amount which was not approved
     function approveDeposits(
@@ -164,7 +163,7 @@ interface IShareClassManager {
         bytes16 shareClassId,
         D18 approvalRatio,
         address paymentAssetId,
-        IERC7726Ext valuation
+        IERC7726 valuation
     ) external returns (uint128 approvedPoolAmount, uint128 approvedAssetAmount);
 
     /// @notice Approves a percentage of all redemption requests for the given triplet of pool id, share class id and
@@ -175,7 +174,7 @@ interface IShareClassManager {
     /// @param approvalRatio Percentage of approved requests
     /// @param payoutAssetId Identifier of the asset for which all requests want to exchange their share class tokens
     /// for
-    /// @param valuation Converter for quotas, e.g. price ratio of share class token amount to pool amount
+    /// @param valuation Source of truth for quotas, e.g. the price of a share class token amount to pool amount
     /// @return approvedShareAmount Sum of redemption request amounts in pool amount which was approved
     /// @return pendingShareAmount Sum of redemption request amounts in share class token amount which was not approved
     function approveRedeems(
@@ -183,7 +182,7 @@ interface IShareClassManager {
         bytes16 shareClassId,
         D18 approvalRatio,
         address payoutAssetId,
-        IERC7726Ext valuation
+        IERC7726 valuation
     ) external returns (uint128 approvedShareAmount, uint128 pendingShareAmount);
 
     /// @notice Emits new shares for the given identifier based on the provided NAV per share.
@@ -200,11 +199,16 @@ interface IShareClassManager {
     /// @param shareClassId Identifier of the share class
     /// @param payoutAssetId Identifier of the payout asset
     /// @param navPerShare Total value of assets of the pool and share class per share
+    /// @param valuation Source of truth for quotas, e.g. the price of a share class token amount to pool amount
     /// @return payoutAssetAmount Converted amount of payout asset based on number of revoked shares
     /// @return payoutPoolAmount Converted amount of pool currency based on number of revoked shares
-    function revokeShares(PoolId poolId, bytes16 shareClassId, address payoutAssetId, D18 navPerShare)
-        external
-        returns (uint128 payoutAssetAmount, uint128 payoutPoolAmount);
+    function revokeShares(
+        PoolId poolId,
+        bytes16 shareClassId,
+        address payoutAssetId,
+        D18 navPerShare,
+        IERC7726 valuation
+    ) external returns (uint128 payoutAssetAmount, uint128 payoutPoolAmount);
 
     /// @notice Collects shares for an investor after their deposit request was (partially) approved and new shares were
     /// issued.

--- a/src/interfaces/IShareClassManager.sol
+++ b/src/interfaces/IShareClassManager.sol
@@ -156,15 +156,15 @@ interface IShareClassManager {
     /// @param approvalRatio Percentage of approved requests
     /// @param paymentAssetId Identifier of the asset locked for the deposit request
     /// @param valuation Source of truth for quotas, e.g. the price of an asset amount to pool amount
-    /// @return approvedPoolAmount Sum of deposit request amounts in pool amount which was approved
     /// @return approvedAssetAmount Sum of deposit request amounts in asset amount which was not approved
+    /// @return approvedPoolAmount Sum of deposit request amounts in pool amount which was approved
     function approveDeposits(
         PoolId poolId,
         bytes16 shareClassId,
         D18 approvalRatio,
         address paymentAssetId,
         IERC7726 valuation
-    ) external returns (uint128 approvedPoolAmount, uint128 approvedAssetAmount);
+    ) external returns (uint128 approvedAssetAmount, uint128 approvedPoolAmount);
 
     /// @notice Approves a percentage of all redemption requests for the given triplet of pool id, share class id and
     /// deposit asset id.

--- a/src/interfaces/ISingleShareClass.sol
+++ b/src/interfaces/ISingleShareClass.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {D18} from "src/types/D18.sol";
+import {IERC7726} from "src/interfaces/IERC7726.sol";
 import {PoolId} from "src/types/PoolId.sol";
 import {IShareClassManager} from "src/interfaces/IShareClassManager.sol";
 
@@ -30,13 +31,13 @@ interface ISingleShareClass is IShareClassManager {
     ) external;
 
     /// @notice Revokes shares for an epoch span and sets the price based on amount of approved redemption shares and
-    /// the
-    /// provided NAV.
+    /// the provided NAV.
     ///
     /// @param poolId Identifier of the pool
     /// @param shareClassId Identifier of the share class
     /// @param payoutAssetId Identifier of the payout asset
     /// @param navPerShare Total value of assets of the pool and share class per share
+    /// @param valuation Source of truth for quotas, e.g. the price of a share class token amount to pool amount
     /// @param endEpochId Identifier of the maximum epoch until which shares are revoked
     /// @return payoutAssetAmount Converted amount of payout asset based on number of revoked shares
     /// @return payoutPoolAmount Converted amount of pool currency based on number of revoked shares
@@ -45,6 +46,7 @@ interface ISingleShareClass is IShareClassManager {
         bytes16 shareClassId,
         address payoutAssetId,
         D18 navPerShare,
+        IERC7726 valuation,
         uint32 endEpochId
     ) external returns (uint128 payoutAssetAmount, uint128 payoutPoolAmount);
 


### PR DESCRIPTION
Supersedes #70

## Background

> Handling prices directly is difficult. (i.e What precision they need? Should be prices or factors? How they interact with plain uint128 of unknown representation?). In fact, the own [ERC7726](https://eips.ethereum.org/EIPS/eip-7726#rationale) spec hides the price concept and gives a rationale of why:
> 
> > The spec doesn’t include a getPrice function because it is rarely needed on-chain, and it would be a decimal number of difficult representation.
> 
> So we should avoid calling to a `getPrice` or `getFactor` as much as we can, given their bad side-effects


## Changes 

* Replaces storage of price ratios during approval, issuance and revocation with derivation via approved amounts
  * Base idea during claiming: 
  ```solidity
  claimableAmount = approvalRate * pendingUserAmount / approvedAmount * {issued, revoked}Amount
  ```
* Removes `IERC7726Ext` which was only required for price ratios in SCM
* Renames `AssetEpochState` to `EpochPointers`: Apart form the `EpochId`, both epoch related storages operate on asset-granularity (among other keys) such that I feel like the `Asset` prefix is redundant. Moreover, now that `EpochRatio` was replaced by `EpochAmounts`, `EpochState` is not descriptive and conflicting with `EpochAmounts` (i.e. it is not clear what an epoch state refers to)