### PR TITLE
Refactor/cleaning. Use ERC6909 as much as possible

### DIFF
--- a/src/BaseValuation.sol
+++ b/src/BaseValuation.sol
@@ -7,22 +7,21 @@ import {D18} from "src/types/D18.sol";
 import {Conversion} from "src/libraries/Conversion.sol";
 
 import {IBaseValuation} from "src/interfaces/IBaseValuation.sol";
-import {IERC20Metadata} from "src/interfaces/IERC20Metadata.sol";
-import {IAssetManager} from "src/interfaces/IAssetManager.sol";
+import {IERC6909MetadataExt} from "src/interfaces/ERC6909/IERC6909MetadataExt.sol";
 
 import {Auth} from "src/Auth.sol";
 
 abstract contract BaseValuation is Auth, IBaseValuation {
-    /// @notice AssetManager dependency.
-    IAssetManager public assetManager;
+    /// @notice ERC6909 dependency.
+    IERC6909MetadataExt public erc6909;
 
-    constructor(IAssetManager assetManager_, address deployer) Auth(deployer) {
-        assetManager = assetManager_;
+    constructor(IERC6909MetadataExt erc6909_, address deployer) Auth(deployer) {
+        erc6909 = erc6909_;
     }
 
     /// @inheritdoc IBaseValuation
     function file(bytes32 what, address data) external auth {
-        if (what == "assetManager") assetManager = IAssetManager(data);
+        if (what == "erc6909") erc6909 = IERC6909MetadataExt(data);
         else revert FileUnrecognizedWhat();
 
         emit File(what, data);
@@ -30,6 +29,6 @@ abstract contract BaseValuation is Auth, IBaseValuation {
 
     /// @notice Obtain the correct decimals given an asset address
     function _getDecimals(address asset) internal view returns (uint8) {
-        return assetManager.decimals(uint160(asset));
+        return erc6909.decimals(uint160(asset));
     }
 }

--- a/src/Holdings.sol
+++ b/src/Holdings.sol
@@ -6,7 +6,6 @@ import {AssetId} from "src/types/AssetId.sol";
 import {ShareClassId} from "src/types/ShareClassId.sol";
 import {AccountId} from "src/types/AccountId.sol";
 
-import {IERC20Metadata} from "src/interfaces/IERC20Metadata.sol";
 import {IHoldings} from "src/interfaces/IHoldings.sol";
 import {IPoolRegistry} from "src/interfaces/IPoolRegistry.sol";
 import {IERC7726} from "src/interfaces/IERC7726.sol";

--- a/src/OneToOneValuation.sol
+++ b/src/OneToOneValuation.sol
@@ -7,12 +7,12 @@ import {Conversion} from "src/libraries/Conversion.sol";
 
 import {IERC7726, IERC7726Ext} from "src/interfaces/IERC7726.sol";
 import {IOneToOneValuation} from "src/interfaces/IOneToOneValuation.sol";
-import {IAssetManager} from "src/interfaces/IAssetManager.sol";
+import {IERC6909MetadataExt} from "src/interfaces/ERC6909/IERC6909MetadataExt.sol";
 
 import {BaseValuation} from "src/BaseValuation.sol";
 
 contract OneToOneValuation is BaseValuation, IOneToOneValuation {
-    constructor(IAssetManager assetManager, address deployer) BaseValuation(assetManager, deployer) {}
+    constructor(IERC6909MetadataExt erc6909, address deployer) BaseValuation(erc6909, deployer) {}
 
     /// @inheritdoc IERC7726
     function getQuote(uint256 baseAmount, address base, address quote) external view returns (uint256 quoteAmount) {

--- a/src/TransientValuation.sol
+++ b/src/TransientValuation.sol
@@ -8,7 +8,7 @@ import {Conversion} from "src/libraries/Conversion.sol";
 
 import {IERC7726} from "src/interfaces/IERC7726.sol";
 import {ITransientValuation} from "src/interfaces/ITransientValuation.sol";
-import {IAssetManager} from "src/interfaces/IAssetManager.sol";
+import {IERC6909MetadataExt} from "src/interfaces/ERC6909/IERC6909MetadataExt.sol";
 
 import {BaseValuation} from "src/BaseValuation.sol";
 
@@ -16,7 +16,7 @@ contract TransientValuation is BaseValuation, ITransientValuation {
     /// @notice Temporal price set and used to obtain the quote.
     D18 public /*TODO: transient*/ price;
 
-    constructor(IAssetManager assetManager, address deployer) BaseValuation(assetManager, deployer) {}
+    constructor(IERC6909MetadataExt erc6909, address deployer) BaseValuation(erc6909, deployer) {}
 
     /// @inheritdoc ITransientValuation
     function setPrice(D18 price_) external {

--- a/src/interfaces/IERC20Metadata.sol
+++ b/src/interfaces/IERC20Metadata.sol
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.28;
-
-interface IERC20Metadata {
-    function decimals() external view returns (uint8);
-    function name() external view returns (string calldata);
-    function symbol() external view returns (string calldata);
-}

--- a/src/libraries/Conversion.sol
+++ b/src/libraries/Conversion.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IERC20Metadata} from "src/interfaces/IERC20Metadata.sol";
 import {MathLib} from "src/libraries/MathLib.sol";
 import {D18} from "src/types/D18.sol";
 

--- a/test/mock/MockAssetManager.sol
+++ b/test/mock/MockAssetManager.sol
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: BUSL-1.1
-pragma solidity 0.8.28;
-
-contract MockAssetManager {
-    function decimals(uint256 tokenId) external pure returns (uint8) {
-        return uint8(tokenId);
-    }
-}

--- a/test/mock/MockERC6909.sol
+++ b/test/mock/MockERC6909.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {IERC6909MetadataExt} from "src/interfaces/ERC6909/IERC6909MetadataExt.sol";
+
+contract MockERC6909 is IERC6909MetadataExt {
+    function decimals(uint256 tokenId) external pure returns (uint8) {
+        return uint8(tokenId);
+    }
+
+    function name(uint256 /*tokenId*/ ) external pure returns (string memory) {
+        return "mocked name";
+    }
+
+    function symbol(uint256 /*tokenId*/ ) external pure returns (string memory) {
+        return "mocked symbol";
+    }
+}

--- a/test/unit/BaseValuation.t.sol
+++ b/test/unit/BaseValuation.t.sol
@@ -22,16 +22,16 @@ contract TestFile is Test {
 
     function testSuccess() public {
         vm.expectEmit();
-        emit IBaseValuation.File("assetManager", address(23));
-        valuation.file("assetManager", address(23));
+        emit IBaseValuation.File("erc6909", address(23));
+        valuation.file("erc6909", address(23));
 
-        assertEq(address(valuation.assetManager()), address(23));
+        assertEq(address(valuation.erc6909()), address(23));
     }
 
     function testErrNotAuthorized() public {
         vm.prank(makeAddr("unauthorizedAddress"));
         vm.expectRevert(IAuth.NotAuthorized.selector);
-        valuation.file("assetManager", address(23));
+        valuation.file("erc6909", address(23));
     }
 
     function testErrFileUnrecognizedWhat() public {

--- a/test/unit/Holdings.t.sol
+++ b/test/unit/Holdings.t.sol
@@ -12,17 +12,16 @@ import {IPoolRegistry} from "src/interfaces/IPoolRegistry.sol";
 import {IAuth} from "src/interfaces/IAuth.sol";
 import {IERC7726} from "src/interfaces/IERC7726.sol";
 import {IHoldings} from "src/interfaces/IHoldings.sol";
-import {IERC20Metadata} from "src/interfaces/IERC20Metadata.sol";
 
 PoolId constant POOL_A = PoolId.wrap(42);
 ShareClassId constant SC_1 = ShareClassId.wrap(1);
 AssetId constant ASSET_A = AssetId.wrap(2);
 ShareClassId constant NON_SC = ShareClassId.wrap(0);
 AssetId constant NON_ASSET = AssetId.wrap(0);
-IERC20Metadata constant POOL_CURRENCY = IERC20Metadata(address(1));
+AssetId constant POOL_CURRENCY = AssetId.wrap(23);
 
 contract PoolRegistryMock {
-    function currency(PoolId) external pure returns (IERC20Metadata) {
+    function currency(PoolId) external pure returns (AssetId) {
         return POOL_CURRENCY;
     }
 }
@@ -37,7 +36,7 @@ contract TestCommon is Test {
         vm.mockCall(
             address(valuation),
             abi.encodeWithSelector(
-                IERC7726.getQuote.selector, uint256(baseAmount), AssetId.unwrap(ASSET_A), address(POOL_CURRENCY)
+                IERC7726.getQuote.selector, uint256(baseAmount), AssetId.unwrap(ASSET_A), POOL_CURRENCY.addr()
             ),
             abi.encode(uint256(quoteAmount))
         );

--- a/test/unit/IOneToOneValuation.t.sol
+++ b/test/unit/IOneToOneValuation.t.sol
@@ -6,15 +6,13 @@ import "forge-std/Test.sol";
 import {D18, d18} from "src/types/D18.sol";
 import {MathLib} from "src/libraries/MathLib.sol";
 import {OneToOneValuation} from "src/OneToOneValuation.sol";
-import {IERC20Metadata} from "src/interfaces/IERC20Metadata.sol";
-import {IAssetManager} from "src/interfaces/IAssetManager.sol";
-import {MockAssetManager} from "test/mock/MockAssetManager.sol";
+import {MockERC6909} from "test/mock/MockERC6909.sol";
 
 address constant C6 = address(6);
 address constant C18 = address(18);
 
 contract TestOneToOneValuation is Test {
-    OneToOneValuation valuation = new OneToOneValuation(IAssetManager(address(new MockAssetManager())), address(0));
+    OneToOneValuation valuation = new OneToOneValuation(new MockERC6909(), address(0));
 
     function testSameDecimals() public view {
         assertEq(valuation.getQuote(100 * 1e6, C6, C6), 100 * 1e6);

--- a/test/unit/PoolRegistry.t.sol
+++ b/test/unit/PoolRegistry.t.sol
@@ -8,7 +8,6 @@ import {AssetId} from "src/types/AssetId.sol";
 import {PoolRegistry} from "src/PoolRegistry.sol";
 import {IPoolRegistry} from "src/interfaces/IPoolRegistry.sol";
 import {IAuth} from "src/interfaces/IAuth.sol";
-import {IERC20Metadata} from "src/interfaces/IERC20Metadata.sol";
 import {IShareClassManager} from "src/interfaces/IShareClassManager.sol";
 
 contract PoolRegistryTest is Test {

--- a/test/unit/TransientValuation.t.sol
+++ b/test/unit/TransientValuation.t.sol
@@ -6,14 +6,13 @@ import "forge-std/Test.sol";
 import {D18, d18} from "src/types/D18.sol";
 import {MathLib} from "src/libraries/MathLib.sol";
 import {TransientValuation} from "src/TransientValuation.sol";
-import {IAssetManager} from "src/interfaces/IAssetManager.sol";
-import {MockAssetManager} from "test/mock/MockAssetManager.sol";
+import {MockERC6909} from "test/mock/MockERC6909.sol";
 
 address constant C6 = address(6);
 address constant C18 = address(18);
 
 contract TestTransientValuation is Test {
-    TransientValuation valuation = new TransientValuation(IAssetManager(address(new MockAssetManager())), address(0));
+    TransientValuation valuation = new TransientValuation(new MockERC6909(), address(0));
 
     function testSameDecimals() public {
         valuation.setPrice(d18(2, 1)); //2.0


### PR DESCRIPTION
### Description

- Valuation contracts no longer know about `AssetManager`, instead they know about generic ERC6909
- Remove the deprecated `IERC20Metadata` interface