### PR TITLE
Remove PoolRegistry address storage

### DIFF
--- a/src/PoolRegistry.sol
+++ b/src/PoolRegistry.sol
@@ -18,7 +18,6 @@ contract PoolRegistry is Auth, IPoolRegistry {
     mapping(PoolId => IShareClassManager) public shareClassManager;
     mapping(PoolId => mapping(address => bool)) public isAdmin;
     mapping(PoolId => mapping(AssetId => bool)) public isInvestorAssetAllowed;
-    mapping(PoolId => mapping(bytes32 key => address)) public addressFor;
 
     constructor(address deployer) Auth(deployer) {}
 
@@ -88,13 +87,6 @@ contract PoolRegistry is Auth, IPoolRegistry {
         currency[poolId] = currency_;
 
         emit UpdatedCurrency(poolId, currency_);
-    }
-
-    function setAddressFor(PoolId poolId, bytes32 key, address addr) external auth {
-        require(exists(poolId), NonExistingPool(poolId));
-        addressFor[poolId][key] = addr;
-
-        emit SetAddressFor(poolId, key, addr);
     }
 
     function exists(PoolId poolId) public view returns (bool) {

--- a/src/interfaces/IPoolRegistry.sol
+++ b/src/interfaces/IPoolRegistry.sol
@@ -14,7 +14,6 @@ interface IPoolRegistry {
     event SetMetadata(PoolId indexed poolId, bytes metadata);
     event UpdatedShareClassManager(PoolId indexed poolId, IShareClassManager indexed shareClassManager);
     event UpdatedCurrency(PoolId indexed poolId, AssetId currency);
-    event SetAddressFor(PoolId indexed poolId, bytes32 key, address addr);
 
     error NonExistingPool(PoolId id);
     error EmptyAdmin();
@@ -43,9 +42,6 @@ interface IPoolRegistry {
     /// @notice updates the currency of the pool
     function updateCurrency(PoolId poolId, AssetId currency) external;
 
-    /// @notice sets an address for an specific key
-    function setAddressFor(PoolId poolid, bytes32 key, address addr) external;
-
     /// @notice returns the metadata attached to the pool, if any.
     function metadata(PoolId poolId) external view returns (bytes memory);
 
@@ -60,9 +56,6 @@ interface IPoolRegistry {
 
     /// @notice returns the allowance of an investor asset
     function isInvestorAssetAllowed(PoolId poolId, AssetId assetId) external view returns (bool);
-
-    /// @notice returns the address for an specific key
-    function addressFor(PoolId poolId, bytes32 key) external view returns (address);
 
     /// @notice checks the existence of a pool
     function exists(PoolId poolId) external view returns (bool);

--- a/test/unit/PoolRegistry.t.sol
+++ b/test/unit/PoolRegistry.t.sol
@@ -195,23 +195,6 @@ contract PoolRegistryTest is Test {
         assertEq(AssetId.unwrap(registry.currency(poolId)), AssetId.unwrap(currency));
     }
 
-    function testSetAddressFor() public {
-        PoolId poolId = registry.registerPool(makeAddr("fundManager"), USD, shareClassManager);
-
-        PoolId nonExistingPool = PoolId.wrap(0xDEAD);
-        vm.expectRevert(abi.encodeWithSelector(IPoolRegistry.NonExistingPool.selector, nonExistingPool));
-        registry.setAddressFor(nonExistingPool, "key", address(1));
-
-        vm.prank(makeAddr("unauthorizedAddress"));
-        vm.expectRevert(IAuth.NotAuthorized.selector);
-        registry.setAddressFor(poolId, "key", address(1));
-
-        vm.expectEmit();
-        emit IPoolRegistry.SetAddressFor(poolId, "key", address(1));
-        registry.setAddressFor(poolId, "key", address(1));
-        assertEq(address(registry.addressFor(poolId, "key")), address(1));
-    }
-
     function testExists() public {
         PoolId poolId = registry.registerPool(makeAddr("fundManager"), USD, shareClassManager);
         assertEq(registry.exists(poolId), true);


### PR DESCRIPTION
We no longer need to store the escrow address in the PoolRegistry, because we do not have escrow contracts and the address can be derived automatically from `(poolId, ShareClassId, EscrowId)` being `EscrowId` either `shareClassEscrow` or `pendingShareClassEscrow`