### PR TITLE
TransientValuation Support for different prices.

### DIFF
--- a/src/TransientValuation.sol
+++ b/src/TransientValuation.sol
@@ -14,17 +14,21 @@ import {BaseValuation} from "src/BaseValuation.sol";
 
 contract TransientValuation is BaseValuation, ITransientValuation {
     /// @notice Temporal price set and used to obtain the quote.
-    D18 public /*TODO: transient*/ price;
+    mapping(address base => mapping(address quite => D18)) public /*TODO: transient*/ price;
 
     constructor(IERC6909MetadataExt erc6909, address deployer) BaseValuation(erc6909, deployer) {}
 
     /// @inheritdoc ITransientValuation
-    function setPrice(D18 price_) external {
-        price = price_;
+    function setPrice(address base, address quote, D18 price_) external {
+        price[base][quote] = price_;
     }
 
     /// @inheritdoc IERC7726
     function getQuote(uint256 baseAmount, address base, address quote) external view returns (uint256 quoteAmount) {
-        return Conversion.convertWithPrice(baseAmount, _getDecimals(base), _getDecimals(quote), price);
+        D18 price_ = price[base][quote];
+
+        require(D18.unwrap(price_) != 0, PriceNotSet(base, quote));
+
+        return Conversion.convertWithPrice(baseAmount, _getDecimals(base), _getDecimals(quote), price_);
     }
 }

--- a/src/interfaces/ITransientValuation.sol
+++ b/src/interfaces/ITransientValuation.sol
@@ -7,9 +7,12 @@ import {IERC7726} from "src/interfaces/IERC7726.sol";
 /// @notice An IERC7726 valuation that allows to set a price that is only valid for the current transaction.
 /// NOTE: Do not use it if the valuation lifetime is longer than the transaction.
 interface ITransientValuation is IERC7726 {
-    /// @notice Set the price for the valuation.
+    /// @notice The price has not been set for a pair base quote.
+    error PriceNotSet(address base, address quote);
+
+    /// @notice Set the price for the valuation to transform an amount from base to quote denomination.
     /// The price is the 1 amount of base denominated in quote.
     /// i.e: if base BTC and quote USDC, the price is 90_000 USDC per BTC
     /// Check IERC7726 for more info about base and quote
-    function setPrice(D18 price) external;
+    function setPrice(address base, address quote, D18 price_) external;
 }

--- a/test/unit/TransientValuation.t.sol
+++ b/test/unit/TransientValuation.t.sol
@@ -5,6 +5,7 @@ import "forge-std/Test.sol";
 
 import {D18, d18} from "src/types/D18.sol";
 import {MathLib} from "src/libraries/MathLib.sol";
+import {ITransientValuation} from "src/interfaces/ITransientValuation.sol";
 import {TransientValuation} from "src/TransientValuation.sol";
 import {MockERC6909} from "test/mock/MockERC6909.sol";
 
@@ -15,33 +16,38 @@ contract TestTransientValuation is Test {
     TransientValuation valuation = new TransientValuation(new MockERC6909(), address(0));
 
     function testSameDecimals() public {
-        valuation.setPrice(d18(2, 1)); //2.0
+        valuation.setPrice(C6, C6, d18(2, 1)); //2.0
 
         assertEq(valuation.getQuote(100 * 1e6, C6, C6), 200 * 1e6);
     }
 
     function testHighPriceFromMoreDecimalsToLess() public {
-        valuation.setPrice(d18(3, 1)); //3.0
+        valuation.setPrice(C18, C6, d18(3, 1)); //3.0
 
         assertEq(valuation.getQuote(100 * 1e18, C18, C6), 300 * 1e6);
     }
 
     function testLowPriceFromMoreDecimalsToLess() public {
-        valuation.setPrice(d18(1, 3)); // 0.33...
+        valuation.setPrice(C18, C6, d18(1, 3)); // 0.33...
 
         assertEq(valuation.getQuote(100 * 1e18, C18, C6), 33_333_333);
     }
 
     function testHighPriceFromLessDecimalsToMore() public {
-        valuation.setPrice(d18(3, 1)); //3.0
+        valuation.setPrice(C6, C18, d18(3, 1)); //3.0
 
         assertEq(valuation.getQuote(100 * 1e6, C6, C18), 300 * 1e18);
     }
 
     function testLowPriceFromLessDecimalsToMore() public {
-        valuation.setPrice(d18(1, 3)); //0.33...
+        valuation.setPrice(C6, C18, d18(1, 3)); //0.33...
 
         // Note: last 2 zeros from the Eq is due lost of precision given the price only contains 18 decimals.
         assertEq(valuation.getQuote(100 * 1e6, C6, C18), 33_333_333_333_333_333_300);
+    }
+
+    function testErrPriceNotSet() public {
+        vm.expectRevert(abi.encodeWithSelector(ITransientValuation.PriceNotSet.selector, C6, C18));
+        valuation.getQuote(1 * 1e6, C6, C18);
     }
 }


### PR DESCRIPTION
When using `TransientValuation` in big multicalls, you will require fetching different values for different assets. It isn't easy to know at what moments you should call to `setPrice()` to set the price to the correct assets. Also, making a mistake is not a warning.

This PR allows having multiple prices for different pairs (base, quote) and also warns if a required price is not set.