### PR TITLE
Feat: CallEscrow

### DIFF
--- a/src/CallEscrow.sol
+++ b/src/CallEscrow.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {ICallEscrow} from "src/interfaces/ICallEscrow.sol";
+import {Auth} from "src/Auth.sol";
+
+contract CallEscrow is Auth, ICallEscrow {
+    constructor(address deployer) Auth(deployer) {}
+
+    /// @inheritdoc ICallEscrow
+    function call(address target, bytes calldata data) external returns (bool success, bytes memory results) {
+        return target.call(data);
+    }
+}

--- a/src/PoolLocker.sol
+++ b/src/PoolLocker.sol
@@ -32,9 +32,8 @@ abstract contract PoolLocker is IPoolLocker {
         ICallEscrow callEscrow = _beforeUnlock(poolId);
         _unlockedPoolId = poolId;
 
+        // If custom escrow, we wrap the calls to be called by it as msg.sender
         if (address(callEscrow) != address(0)) {
-            // We wrap the calls to be called by the custom escrow
-
             IMulticall.Call[] memory wrapCalls = new IMulticall.Call[](calls.length);
             for (uint256 i; i < calls.length; i++) {
                 wrapCalls[i] = IMulticall.Call(

--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -18,7 +18,8 @@ import {
     IPoolManagerAdminMethods,
     IPoolManagerHandler,
     EscrowId,
-    AccountType
+    AccountType,
+    MULTICALL_ESCROW_KEY
 } from "src/interfaces/IPoolManager.sol";
 import {IMulticall} from "src/interfaces/IMulticall.sol";
 import {IERC7726} from "src/interfaces/IERC7726.sol";
@@ -423,9 +424,11 @@ contract PoolManager is Auth, PoolLocker, IPoolManager, IPoolManagerHandler {
     // internal / private methods
     //----------------------------------------------------------------------------------------------
 
-    function _beforeUnlock(PoolId poolId) internal override {
+    function _beforeUnlock(PoolId poolId) internal override returns (IMulticall) {
         require(poolRegistry.isAdmin(poolId, msg.sender), NotAuthorizedAdmin());
         accounting.unlock(poolId, bytes32("TODO"));
+
+        return IMulticall(poolRegistry.addressFor(poolId, MULTICALL_ESCROW_KEY));
     }
 
     function _beforeLock() internal override {

--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -116,6 +116,11 @@ contract PoolManager is Auth, PoolLocker, IPoolManager, IPoolManagerHandler {
     //----------------------------------------------------------------------------------------------
 
     /// @inheritdoc IPoolManagerAdminMethods
+    function setAddressFor(bytes32 key, address value) external {
+        poolRegistry.setAddressFor(unlockedPoolId(), key, value);
+    }
+
+    /// @inheritdoc IPoolManagerAdminMethods
     function notifyPool(uint32 chainId) external poolUnlocked {
         gateway.sendNotifyPool(chainId, unlockedPoolId());
     }

--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -19,9 +19,10 @@ import {
     IPoolManagerHandler,
     EscrowId,
     AccountType,
-    MULTICALL_ESCROW_KEY
+    CALL_ESCROW_KEY
 } from "src/interfaces/IPoolManager.sol";
 import {IMulticall} from "src/interfaces/IMulticall.sol";
+import {ICallEscrow} from "src/interfaces/ICallEscrow.sol";
 import {IERC7726} from "src/interfaces/IERC7726.sol";
 
 import {MathLib} from "src/libraries/MathLib.sol";
@@ -424,11 +425,11 @@ contract PoolManager is Auth, PoolLocker, IPoolManager, IPoolManagerHandler {
     // internal / private methods
     //----------------------------------------------------------------------------------------------
 
-    function _beforeUnlock(PoolId poolId) internal override returns (IMulticall) {
+    function _beforeUnlock(PoolId poolId) internal override returns (ICallEscrow) {
         require(poolRegistry.isAdmin(poolId, msg.sender), NotAuthorizedAdmin());
         accounting.unlock(poolId, bytes32("TODO"));
 
-        return IMulticall(poolRegistry.addressFor(poolId, MULTICALL_ESCROW_KEY));
+        return ICallEscrow(poolRegistry.addressFor(poolId, CALL_ESCROW_KEY));
     }
 
     function _beforeLock() internal override {

--- a/src/PoolRegistry.sol
+++ b/src/PoolRegistry.sol
@@ -18,6 +18,7 @@ contract PoolRegistry is Auth, IPoolRegistry {
     mapping(PoolId => IShareClassManager) public shareClassManager;
     mapping(PoolId => mapping(address => bool)) public isAdmin;
     mapping(PoolId => mapping(AssetId => bool)) public isInvestorAssetAllowed;
+    mapping(PoolId => mapping(bytes32 key => address)) public addressFor;
 
     constructor(address deployer) Auth(deployer) {}
 
@@ -87,6 +88,13 @@ contract PoolRegistry is Auth, IPoolRegistry {
         currency[poolId] = currency_;
 
         emit UpdatedCurrency(poolId, currency_);
+    }
+
+    function setAddressFor(PoolId poolId, bytes32 key, address addr) external auth {
+        require(exists(poolId), NonExistingPool(poolId));
+        addressFor[poolId][key] = addr;
+
+        emit SetAddressFor(poolId, key, addr);
     }
 
     function exists(PoolId poolId) public view returns (bool) {

--- a/src/interfaces/ICallEscrow.sol
+++ b/src/interfaces/ICallEscrow.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+/// @notice Allows to pass a generic call to be called from this contract
+interface ICallEscrow {
+    /// @notice Perform the call passed by parameter.
+    /// @param target contract where to perform the call
+    /// @param data encoded selector + parameters of the call
+    function call(address target, bytes calldata data) external returns (bool success, bytes memory results);
+}

--- a/src/interfaces/IPoolManager.sol
+++ b/src/interfaces/IPoolManager.sol
@@ -10,7 +10,7 @@ import {D18} from "src/types/D18.sol";
 import {IShareClassManager} from "src/interfaces/IShareClassManager.sol";
 import {IERC7726} from "src/interfaces/IERC7726.sol";
 
-bytes32 constant MULTICALL_ESCROW_KEY = bytes32("multicall-escrow");
+bytes32 constant CALL_ESCROW_KEY = bytes32("multicall-escrow");
 
 /// @notice AssetManager accounts identifications used by the PoolManager
 enum EscrowId {

--- a/src/interfaces/IPoolManager.sol
+++ b/src/interfaces/IPoolManager.sol
@@ -10,7 +10,7 @@ import {D18} from "src/types/D18.sol";
 import {IShareClassManager} from "src/interfaces/IShareClassManager.sol";
 import {IERC7726} from "src/interfaces/IERC7726.sol";
 
-bytes32 constant CALL_ESCROW_KEY = bytes32("multicall-escrow");
+bytes32 constant CALL_ESCROW_KEY = bytes32("call-escrow");
 
 /// @notice AssetManager accounts identifications used by the PoolManager
 enum EscrowId {
@@ -42,6 +42,10 @@ interface IPoolManagerAdminMethods {
 
     /// @notice Dispatched when a holding asset is disallowed but the asset is still allowed for investor usage.
     error InvestorAssetStillAllowed();
+
+    /// @notice Set an address attached to the pool by a given key
+    /// @param key Identification of the address
+    function setAddressFor(bytes32 key, address value) external;
 
     /// @notice Notify to a CV instance that a new pool is available
     /// @param chainId Chain where CV instance lives

--- a/src/interfaces/IPoolManager.sol
+++ b/src/interfaces/IPoolManager.sol
@@ -10,6 +10,8 @@ import {D18} from "src/types/D18.sol";
 import {IShareClassManager} from "src/interfaces/IShareClassManager.sol";
 import {IERC7726} from "src/interfaces/IERC7726.sol";
 
+bytes32 constant MULTICALL_ESCROW_KEY = bytes32("multicall-escrow");
+
 /// @notice AssetManager accounts identifications used by the PoolManager
 enum EscrowId {
     /// @notice Represents the escrow for undeployed capital in the share class.

--- a/src/interfaces/IPoolRegistry.sol
+++ b/src/interfaces/IPoolRegistry.sol
@@ -14,6 +14,7 @@ interface IPoolRegistry {
     event SetMetadata(PoolId indexed poolId, bytes metadata);
     event UpdatedShareClassManager(PoolId indexed poolId, IShareClassManager indexed shareClassManager);
     event UpdatedCurrency(PoolId indexed poolId, AssetId currency);
+    event SetAddressFor(PoolId indexed poolId, bytes32 key, address addr);
 
     error NonExistingPool(PoolId id);
     error EmptyAdmin();
@@ -42,6 +43,9 @@ interface IPoolRegistry {
     /// @notice updates the currency of the pool
     function updateCurrency(PoolId poolId, AssetId currency) external;
 
+    /// @notice sets an address for an specific key
+    function setAddressFor(PoolId poolid, bytes32 key, address addr) external;
+
     /// @notice returns the metadata attached to the pool, if any.
     function metadata(PoolId poolId) external view returns (bytes memory);
 
@@ -56,6 +60,9 @@ interface IPoolRegistry {
 
     /// @notice returns the allowance of an investor asset
     function isInvestorAssetAllowed(PoolId poolId, AssetId assetId) external view returns (bool);
+
+    /// @notice returns the address for an specific key
+    function addressFor(PoolId poolId, bytes32 key) external view returns (address);
 
     /// @notice checks the existence of a pool
     function exists(PoolId poolId) external view returns (bool);

--- a/test/unit/PoolLocker.t.sol
+++ b/test/unit/PoolLocker.t.sol
@@ -6,6 +6,7 @@ import {PoolId} from "src/types/PoolId.sol";
 import {PoolLocker} from "src/PoolLocker.sol";
 import {IPoolLocker} from "src/interfaces/IPoolLocker.sol";
 import {IMulticall} from "src/interfaces/IMulticall.sol";
+import {ICallEscrow} from "src/interfaces/ICallEscrow.sol";
 import {Multicall} from "src/Multicall.sol";
 
 contract PoolManagerMock is PoolLocker {
@@ -18,8 +19,9 @@ contract PoolManagerMock is PoolLocker {
         return unlockedPoolId();
     }
 
-    function _beforeUnlock(PoolId poolId) internal override {
+    function _beforeUnlock(PoolId poolId) internal override returns (ICallEscrow) {
         wasUnlockWithPool = poolId;
+        return ICallEscrow(address(0));
     }
 
     function _beforeLock() internal override {

--- a/test/unit/PoolRegistry.t.sol
+++ b/test/unit/PoolRegistry.t.sol
@@ -195,6 +195,23 @@ contract PoolRegistryTest is Test {
         assertEq(AssetId.unwrap(registry.currency(poolId)), AssetId.unwrap(currency));
     }
 
+    function testSetAddressFor() public {
+        PoolId poolId = registry.registerPool(makeAddr("fundManager"), USD, shareClassManager);
+
+        PoolId nonExistingPool = PoolId.wrap(0xDEAD);
+        vm.expectRevert(abi.encodeWithSelector(IPoolRegistry.NonExistingPool.selector, nonExistingPool));
+        registry.setAddressFor(nonExistingPool, "key", address(1));
+
+        vm.prank(makeAddr("unauthorizedAddress"));
+        vm.expectRevert(IAuth.NotAuthorized.selector);
+        registry.setAddressFor(poolId, "key", address(1));
+
+        vm.expectEmit();
+        emit IPoolRegistry.SetAddressFor(poolId, "key", address(1));
+        registry.setAddressFor(poolId, "key", address(1));
+        assertEq(address(registry.addressFor(poolId, "key")), address(1));
+    }
+
     function testExists() public {
         PoolId poolId = registry.registerPool(makeAddr("fundManager"), USD, shareClassManager);
         assertEq(registry.exists(poolId), true);


### PR DESCRIPTION
# Description

Allow the FM to choose the contract that will be used to call the methods added in `PoolManager.execute()`. So the FM have control about the `msg.sender` used.

### Problem

As an example, a FM will want to perform the following:
```solidity
execute(PoolA)
   poolManager.approve()
   erc20.transfer() // or erc6909 or uniswap.swap ...
   poolManager.issue()
```
   
Nevertheless, the above has a problem. The `msg.sender` of the above calls is  `PoolLocker.multicall`. To be able to transfer, the FM needs to call `erc20.allowance()` for the multicall. This opens a security hole because other FM from other pools will also use the same multicall, or even the multicall can be used standalone. So, anyone can perform the `transfer()` on behalf.

### Solution

Optional call escrows. Similar concept to the escrows used for ERC20. 
- If the FM does not need to make permission and external calls, it can just use the current and default multicall. 
- If they need to identify the sender for external calls, they can configure an `ICallEscrow` contract address attached to the pool to perform allowances from other contracts. The FM owns that address and can trust it as the sender for other contracts.

i.e.
```solidity
// Configure OPTIONALY a call escrow and give transfer permisions
fm -> execute(PoolA)
         poolManager.setAddressFor("call-escrow", CALL_ESCROW_A);
fm -> erc20.allowance(CALL_ESCROW_A);
         
// Use as normal         
fm -> execute(PoolA)
         poolManager.approve()
         erc20.transfer() // or erc6909 or uniswap.swap ...
         poolManager.issue()
```

## Changes

- Revert the removal of `PoolRegisty.addresFor()` to store the multicall escrow address.
- Add `ICallEscrow` that just wrap a call to be the sender of the wrapped call.
- Adapt `PoolLocker` to use optionally the call escrow