### PR TITLE
Feat/ref: Allow investor asset per ShareClassId

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Filter directories
         run: |
           sudo apt update && sudo apt install -y lcov
-          lcov --remove lcov.info 'test/*' 'script/*' --output-file lcov.info --rc lcov_branch_coverage=1 --ignore-errors empty --ignore-errors unused
+          lcov --remove lcov.info 'test/*' 'script/*' --output-file lcov.info --rc lcov_branch_coverage=1
 
       # This step posts a detailed coverage report as a comment and deletes previous comments on
       # each push. The below step is used to fail coverage if the specified coverage threshold is

--- a/docs/pools/architecture.puml
+++ b/docs/pools/architecture.puml
@@ -111,7 +111,6 @@ class PoolManager <<(C, lightskyblue)>> {
     -- pool admin --
     + notifyPool()
     + notifyShareClass()
-    + notifyAllowedAsset()
     + setPoolMetadata()
     + setPoolAdmin()
     + allowInvestorAsset()

--- a/src/pools/Gateway.sol
+++ b/src/pools/Gateway.sol
@@ -66,13 +66,10 @@ contract Gateway is Auth, IGateway, IMessageHandler {
         );
     }
 
-    function sendNotifyAllowedAsset(PoolId poolId, ShareClassId, /*scId*/ AssetId assetId, bool isAllowed)
-        external
-        auth
-    {
+    function sendNotifyAllowedAsset(PoolId poolId, ShareClassId scId, AssetId assetId, bool isAllowed) external auth {
         bytes memory message = isAllowed
-            ? abi.encodePacked(MessageType.AllowAsset, poolId.raw(), assetId.raw())
-            : abi.encodePacked(MessageType.DisallowAsset, poolId.raw(), assetId.raw());
+            ? abi.encodePacked(MessageType.AllowAsset, poolId.raw(), scId.raw(), assetId.raw())
+            : abi.encodePacked(MessageType.DisallowAsset, poolId.raw(), scId.raw(), assetId.raw());
 
         _send(assetId.chainId(), message);
     }

--- a/src/pools/Holdings.sol
+++ b/src/pools/Holdings.sol
@@ -21,7 +21,6 @@ contract Holdings is Auth, IHoldings {
         IERC7726 valuation; // Used for existance
     }
 
-    mapping(PoolId => mapping(AssetId => bool)) public isAssetAllowed;
     mapping(PoolId => mapping(ShareClassId => mapping(AssetId => Holding))) public holding;
     mapping(PoolId => mapping(ShareClassId => mapping(AssetId => mapping(uint8 kind => AccountId)))) public accountId;
 
@@ -48,7 +47,6 @@ contract Holdings is Auth, IHoldings {
         require(address(valuation_) != address(0), WrongValuation());
 
         holding[poolId][scId][assetId] = Holding(0, 0, valuation_);
-        isAssetAllowed[poolId][assetId] = true;
 
         for (uint256 i; i < accounts.length; i++) {
             AccountId accountId_ = accounts[i];
@@ -158,5 +156,9 @@ contract Holdings is Auth, IHoldings {
         require(address(holding_.valuation) != address(0), HoldingNotFound());
 
         return holding_.valuation;
+    }
+
+    function exists(PoolId poolId, ShareClassId scId, AssetId assetId) external view returns (bool) {
+        return address(holding[poolId][scId][assetId].valuation) != address(0);
     }
 }

--- a/src/pools/interfaces/IHoldings.sol
+++ b/src/pools/interfaces/IHoldings.sol
@@ -106,6 +106,6 @@ interface IHoldings {
         view
         returns (AccountId);
 
-    /// @notice returns the allowance of an asset as a holding
-    function isAssetAllowed(PoolId poolId, AssetId assetId) external returns (bool);
+    /// @notice Tells if the holding exists for an asset in a share class
+    function exists(PoolId poolId, ShareClassId scId, AssetId assetId) external view returns (bool);
 }

--- a/src/pools/interfaces/IPoolManager.sol
+++ b/src/pools/interfaces/IPoolManager.sol
@@ -38,9 +38,6 @@ interface IPoolManagerAdminMethods {
     /// @notice Dispatched when the pool can not be unlocked by the caller
     error NotAuthorizedAdmin();
 
-    /// @notice Dispatched when a holding asset is not yet created and therefore allowed for investing.
-    error HoldingAssetNotAllowed();
-
     /// @notice Notify to a CV instance that a new pool is available
     /// @param chainId Chain where CV instance lives
     function notifyPool(uint32 chainId) external;
@@ -49,9 +46,7 @@ interface IPoolManagerAdminMethods {
     /// @param chainId Chain where CV instance lives
     function notifyShareClass(uint32 chainId, ShareClassId scId) external;
 
-    /// @notice Notify to a CV instance that a new asset in a share class is available for investing
     /// @dev Note: the chainId is retriver from the assetId
-    function notifyAllowedAsset(ShareClassId scId, AssetId assetId) external;
 
     /// @notice Attach custom data to a pool
     function setPoolMetadata(bytes calldata metadata) external;
@@ -59,8 +54,9 @@ interface IPoolManagerAdminMethods {
     /// @notice Allow/disallow an account to interact as pool admin
     function allowPoolAdmin(address account, bool allow) external;
 
-    /// @notice Allow/disallow an asset for investment
-    function allowInvestorAsset(AssetId assetId, bool allow) external;
+    /// @notice Allow/disallow an asset for investment.
+    /// Notify to the CV instance of that asset that the asset is available for investing for such share class id
+    function allowInvestorAsset(ShareClassId scId, AssetId assetId, bool allow) external;
 
     /// @notice Add a new share class to the pool
     /// @return The new share class Id

--- a/test/misc/unit/libraries/MathLib.t.sol
+++ b/test/misc/unit/libraries/MathLib.t.sol
@@ -28,6 +28,7 @@ contract MathLibTest is Test {
         assertEq(MathLib.mulDiv(x, y, denominator, MathLib.Rounding.Down), (x * y) / denominator);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testMulDivDownZeroDenominator(uint256 x, uint256 y) public {
         vm.expectRevert();
         MathLib.mulDiv(x, y, 0, MathLib.Rounding.Down);
@@ -41,6 +42,7 @@ contract MathLibTest is Test {
         assertEq(MathLib.mulDiv(x, y, denominator, MathLib.Rounding.Up), x * y == 0 ? 0 : (x * y - 1) / denominator + 1);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testMulDivUpUnderverflow(uint256 x, uint256 y) public {
         vm.assume(x > 0 && y > 0);
 
@@ -48,6 +50,7 @@ contract MathLibTest is Test {
         MathLib.mulDiv(x, y, 0, MathLib.Rounding.Up);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testMulDivUpZeroDenominator(uint256 x, uint256 y) public {
         vm.expectRevert();
         MathLib.mulDiv(x, y, 0, MathLib.Rounding.Up);
@@ -59,6 +62,7 @@ contract MathLibTest is Test {
         assertEq(x, uint256(MathLib.toUint128(x)));
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testToUint128Overflow(uint128 x) public {
         vm.assume(x > 0);
         vm.expectRevert(MathLib.Uint128_Overflow.selector);
@@ -71,6 +75,7 @@ contract MathLibTest is Test {
         assertEq(x, uint256(uint128(MathLib.toInt128(x))));
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testToInt128Overflow(uint256 x) public {
         x = bound(x, uint256(uint128(type(int128).max)) + 1, type(uint256).max);
         vm.expectRevert(MathLib.Int128_Overflow.selector);
@@ -83,6 +88,7 @@ contract MathLibTest is Test {
         assertEq(x, uint256(MathLib.toUint8(x)));
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testToUint8Overflow(uint256 x) public {
         vm.assume(x > type(uint8).max);
         vm.expectRevert(MathLib.Uint8_Overflow.selector);
@@ -95,6 +101,7 @@ contract MathLibTest is Test {
         assertEq(x, uint256(MathLib.toUint32(x)));
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function testToUint32Overflow(uint256 x) public {
         vm.assume(x > type(uint32).max);
         vm.expectRevert(MathLib.Uint32_Overflow.selector);

--- a/test/pools/integration/Cases.t.sol
+++ b/test/pools/integration/Cases.t.sol
@@ -123,13 +123,12 @@ contract TestConfiguration is TestCommon {
 
         scId = previewShareClassId(poolId);
 
-        (bytes[] memory cs, uint256 c) = (new bytes[](6), 0);
+        (bytes[] memory cs, uint256 c) = (new bytes[](5), 0);
         cs[c++] = abi.encodeWithSelector(poolManager.addShareClass.selector, bytes(""));
         cs[c++] = abi.encodeWithSelector(poolManager.notifyPool.selector, CHAIN_CV);
         cs[c++] = abi.encodeWithSelector(poolManager.notifyShareClass.selector, CHAIN_CV, scId);
         cs[c++] = abi.encodeWithSelector(poolManager.createHolding.selector, scId, USDC_C2, oneToOneValuation, 0x01);
-        cs[c++] = abi.encodeWithSelector(poolManager.allowInvestorAsset.selector, USDC_C2, true);
-        cs[c++] = abi.encodeWithSelector(poolManager.notifyAllowedAsset.selector, scId, USDC_C2);
+        cs[c++] = abi.encodeWithSelector(poolManager.allowInvestorAsset.selector, scId, USDC_C2, true);
         assertEq(c, cs.length);
 
         vm.prank(FM);

--- a/test/pools/unit/Holdings.t.sol
+++ b/test/pools/unit/Holdings.t.sol
@@ -354,3 +354,12 @@ contract TestValuation is TestCommon {
         holdings.valuation(POOL_A, SC_1, ASSET_A);
     }
 }
+
+contract TestExists is TestCommon {
+    function testSuccess() public {
+        holdings.create(POOL_A, SC_1, ASSET_A, itemValuation, new AccountId[](0));
+
+        assert(holdings.exists(POOL_A, SC_1, ASSET_A));
+        assert(!holdings.exists(POOL_A, SC_1, POOL_CURRENCY));
+    }
+}


### PR DESCRIPTION
Thread: https://kflabs.slack.com/archives/C07PG2EUR9C/p1739369288420839

### Changes
- No longer need a `Holdings.isAllowHolding` mapping 🎉 
- No longer need a `PoolMananger.notifyInvestorAsset` call 🎉 
- Changes to pass CI due an update in forge / foundry.

NOTE. Despite the refactorizations, nothing changes in the requirements for allowing an asset. The mandatory flow is:
```
CV -> CP: registerAsset()
CP: createHolding() //creating a holding acts as allowing a holding asset
CP: allowInvestorAsset()
```