### PR TITLE
Rename AssetManager to AssetRegistry

### DIFF
--- a/docs/pools/architecture.puml
+++ b/docs/pools/architecture.puml
@@ -18,11 +18,11 @@ class IERC6909Fungible<wards = PoolManager> {
 
 IERC6909Fungible --|> ERC6909
 
-class AssetManager {
+class AssetRegistry {
     + registerAsset(assetId, name, decimals, symbol)
 }
 
-AssetManager --|> IERC6909Fungible
+AssetRegistry --|> IERC6909Fungible
 
 class Holdings<wards = PoolManager> <<(C, lightskyblue)>> {
     + create(poolId, shareClassId, assetId, valuation, accounts)
@@ -139,7 +139,7 @@ PoolManager -up-> AccountType
 PoolManager -down---> PoolRegistry
 PoolManager -left-> IShareClassManager
 PoolManager -down--> Accounting
-PoolManager -down-> AssetManager
+PoolManager -down-> AssetRegistry
 PoolManager -down--> Holdings
 PoolManager -right-> Gateway
 

--- a/script/pools/Deployer.s.sol
+++ b/script/pools/Deployer.s.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 import "forge-std/Script.sol";
 
 import {TransientValuation} from "src/misc/TransientValuation.sol";
-import {OneToOneValuation} from "src/misc/OneToOneValuation.sol";
+import {IdentityValuation} from "src/misc/IdentityValuation.sol";
 import {Multicall} from "src/misc/Multicall.sol";
 
 import {AssetId, newAssetId} from "src/pools/types/AssetId.sol";
@@ -35,7 +35,7 @@ contract Deployer is Script {
 
     // Utilities
     TransientValuation public transientValuation;
-    OneToOneValuation public oneToOneValuation;
+    IdentityValuation public identityValuation;
 
     // Data
     AssetId immutable USD = newAssetId(840);
@@ -55,7 +55,7 @@ contract Deployer is Script {
         gateway = new Gateway(IAdapter(address(0 /* TODO */ )), poolManager, address(this));
 
         transientValuation = new TransientValuation(assetRegistry, address(this));
-        oneToOneValuation = new OneToOneValuation(assetRegistry, address(this));
+        identityValuation = new IdentityValuation(assetRegistry, address(this));
 
         _file();
         _rely();
@@ -90,6 +90,6 @@ contract Deployer is Script {
         gateway.deny(address(this));
 
         transientValuation.deny(address(this));
-        oneToOneValuation.deny(address(this));
+        identityValuation.deny(address(this));
     }
 }

--- a/script/pools/Deployer.s.sol
+++ b/script/pools/Deployer.s.sol
@@ -13,7 +13,7 @@ import {IAdapter} from "src/pools/interfaces/IAdapter.sol";
 import {PoolRegistry} from "src/pools/PoolRegistry.sol";
 import {SingleShareClass} from "src/pools/SingleShareClass.sol";
 import {Holdings} from "src/pools/Holdings.sol";
-import {AssetManager} from "src/pools/AssetManager.sol";
+import {AssetRegistry} from "src/pools/AssetRegistry.sol";
 import {Accounting} from "src/pools/Accounting.sol";
 import {Gateway} from "src/pools/Gateway.sol";
 import {PoolManager, IPoolManager} from "src/pools/PoolManager.sol";
@@ -26,7 +26,7 @@ contract Deployer is Script {
     // Core contracts
     Multicall public multicall;
     PoolRegistry public poolRegistry;
-    AssetManager public assetManager;
+    AssetRegistry public assetRegistry;
     Accounting public accounting;
     Holdings public holdings;
     SingleShareClass public singleShareClass;
@@ -44,18 +44,18 @@ contract Deployer is Script {
         multicall = new Multicall();
 
         poolRegistry = new PoolRegistry(address(this));
-        assetManager = new AssetManager(address(this));
+        assetRegistry = new AssetRegistry(address(this));
         accounting = new Accounting(address(this));
         holdings = new Holdings(poolRegistry, address(this));
 
         singleShareClass = new SingleShareClass(poolRegistry, address(this));
         poolManager = new PoolManager(
-            multicall, poolRegistry, assetManager, accounting, holdings, IGateway(ADDRESS_TO_FILE), address(this)
+            multicall, poolRegistry, assetRegistry, accounting, holdings, IGateway(ADDRESS_TO_FILE), address(this)
         );
         gateway = new Gateway(IAdapter(address(0 /* TODO */ )), poolManager, address(this));
 
-        transientValuation = new TransientValuation(assetManager, address(this));
-        oneToOneValuation = new OneToOneValuation(assetManager, address(this));
+        transientValuation = new TransientValuation(assetRegistry, address(this));
+        oneToOneValuation = new OneToOneValuation(assetRegistry, address(this));
 
         _file();
         _rely();
@@ -68,7 +68,7 @@ contract Deployer is Script {
 
     function _rely() private {
         poolRegistry.rely(address(poolManager));
-        assetManager.rely(address(poolManager));
+        assetRegistry.rely(address(poolManager));
         holdings.rely(address(poolManager));
         accounting.rely(address(poolManager));
         singleShareClass.rely(address(poolManager));
@@ -77,12 +77,12 @@ contract Deployer is Script {
     }
 
     function _initialConfig() private {
-        assetManager.registerAsset(USD, "United States dollar", "USD", 18);
+        assetRegistry.registerAsset(USD, "United States dollar", "USD", 18);
     }
 
     function removeDeployerAccess() public {
         poolRegistry.deny(address(this));
-        assetManager.deny(address(this));
+        assetRegistry.deny(address(this));
         accounting.deny(address(this));
         holdings.deny(address(this));
         singleShareClass.deny(address(this));

--- a/src/misc/IdentityValuation.sol
+++ b/src/misc/IdentityValuation.sol
@@ -5,12 +5,12 @@ import {ConversionLib} from "src/misc/libraries/ConversionLib.sol";
 import {d18} from "src/misc/types/D18.sol";
 
 import {IERC7726} from "src/misc/interfaces/IERC7726.sol";
-import {IOneToOneValuation} from "src/misc/interfaces/IOneToOneValuation.sol";
+import {IIdentityValuation} from "src/misc/interfaces/IIdentityValuation.sol";
 import {IERC6909MetadataExt} from "src/misc/interfaces/IERC6909.sol";
 
 import {BaseValuation} from "src/misc/BaseValuation.sol";
 
-contract OneToOneValuation is BaseValuation, IOneToOneValuation {
+contract IdentityValuation is BaseValuation, IIdentityValuation {
     constructor(IERC6909MetadataExt erc6909, address deployer) BaseValuation(erc6909, deployer) {}
 
     /// @inheritdoc IERC7726

--- a/src/misc/interfaces/IBaseValuation.sol
+++ b/src/misc/interfaces/IBaseValuation.sol
@@ -13,7 +13,7 @@ interface IBaseValuation is IERC7726 {
 
     /// @notice Updates a contract parameter.
     /// @param what Name of the parameter to update.
-    /// Accepts a `bytes32` representation of 'assetManager' string value.
+    /// Accepts a `bytes32` representation of 'assetRegistry' string value.
     /// @param data New value given to the `what` parameter
     function file(bytes32 what, address data) external;
 }

--- a/src/misc/interfaces/IIdentityValuation.sol
+++ b/src/misc/interfaces/IIdentityValuation.sol
@@ -4,4 +4,4 @@ pragma solidity 0.8.28;
 import {IERC7726} from "src/misc/interfaces/IERC7726.sol";
 
 /// @notice An IERC7726 valuation that always values 1:1.
-interface IOneToOneValuation is IERC7726 {}
+interface IIdentityValuation is IERC7726 {}

--- a/src/pools/AssetRegistry.sol
+++ b/src/pools/AssetRegistry.sol
@@ -9,16 +9,16 @@ import {ERC6909Fungible} from "src/misc/ERC6909Fungible.sol";
 import {IERC6909MetadataExt} from "src/misc/interfaces/IERC6909.sol";
 
 import {AssetId} from "src/pools/types/AssetId.sol";
-import {IAssetManager} from "src/pools/interfaces/IAssetManager.sol";
+import {IAssetRegistry} from "src/pools/interfaces/IAssetRegistry.sol";
 
-contract AssetManager is ERC6909Fungible, IAssetManager {
+contract AssetRegistry is ERC6909Fungible, IAssetRegistry {
     using MathLib for uint256;
 
     mapping(AssetId => Asset) public asset;
 
     constructor(address owner) ERC6909Fungible(owner) {}
 
-    /// @inheritdoc IAssetManager
+    /// @inheritdoc IAssetRegistry
     function registerAsset(AssetId assetId_, string calldata name_, string calldata symbol_, uint8 decimals_)
         external
         auth
@@ -35,7 +35,7 @@ contract AssetManager is ERC6909Fungible, IAssetManager {
         emit NewAssetEntry(assetId_, name_, symbol_, asset_.decimals);
     }
 
-    /// @inheritdoc IAssetManager
+    /// @inheritdoc IAssetRegistry
     function isRegistered(AssetId assetId) external view returns (bool) {
         return asset[assetId].decimals > 0;
     }

--- a/src/pools/interfaces/IAssetRegistry.sol
+++ b/src/pools/interfaces/IAssetRegistry.sol
@@ -6,7 +6,7 @@ import {IERC6909Fungible, IERC6909MetadataExt} from "src/misc/interfaces/IERC690
 import {AssetId} from "src/pools/types/AssetId.sol";
 
 /// @notice Interface for registering and handling assets
-interface IAssetManager is IERC6909MetadataExt, IERC6909Fungible {
+interface IAssetRegistry is IERC6909MetadataExt, IERC6909Fungible {
     event NewAssetEntry(AssetId indexed assetId, string name, string symbol, uint8 decimals);
 
     /// @dev Fired when id == 0

--- a/src/pools/interfaces/IPoolManager.sol
+++ b/src/pools/interfaces/IPoolManager.sol
@@ -10,7 +10,7 @@ import {AccountId} from "src/pools/types/AccountId.sol";
 import {PoolId} from "src/pools/types/PoolId.sol";
 import {IShareClassManager} from "src/pools/interfaces/IShareClassManager.sol";
 
-/// @notice AssetManager accounts identifications used by the PoolManager
+/// @notice AssetRegistry accounts identifications used by the PoolManager
 enum EscrowId {
     /// @notice Represents the escrow for undeployed capital in the share class.
     /// Contains the already invested but not yet approved funds.
@@ -141,7 +141,7 @@ interface IPoolManager is IPoolManagerAdminMethods {
 
     /// @notice Updates a contract parameter.
     /// @param what Name of the parameter to update.
-    /// Accepts a `bytes32` representation of 'poolRegistry', 'assetManager', 'accounting', 'holdings', 'gateway' as
+    /// Accepts a `bytes32` representation of 'poolRegistry', 'assetRegistry', 'accounting', 'holdings', 'gateway' as
     /// string value.
     function file(bytes32 what, address data) external;
 

--- a/test/misc/unit/BaseValuation.t.sol
+++ b/test/misc/unit/BaseValuation.t.sol
@@ -11,7 +11,7 @@ import {IERC6909MetadataExt} from "src/misc/interfaces/IERC6909.sol";
 import {BaseValuation} from "src/misc/BaseValuation.sol";
 
 contract BaseValuationImpl is BaseValuation {
-    constructor(IERC6909MetadataExt assetManager, address deployer) BaseValuation(assetManager, deployer) {}
+    constructor(IERC6909MetadataExt assetRegistry, address deployer) BaseValuation(assetRegistry, deployer) {}
 
     function getQuote(uint256 baseAmount, address base, address quote) external view returns (uint256 quoteAmount) {}
 }

--- a/test/misc/unit/IdentityValuation.t.sol
+++ b/test/misc/unit/IdentityValuation.t.sol
@@ -5,15 +5,15 @@ import "forge-std/Test.sol";
 
 import {D18, d18} from "src/misc/types/D18.sol";
 import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {OneToOneValuation} from "src/misc/OneToOneValuation.sol";
+import {IdentityValuation} from "src/misc/IdentityValuation.sol";
 
 import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
 
 address constant C6 = address(6);
 address constant C18 = address(18);
 
-contract TestOneToOneValuation is Test {
-    OneToOneValuation valuation = new OneToOneValuation(new MockERC6909(), address(0));
+contract TestIdentityValuation is Test {
+    IdentityValuation valuation = new IdentityValuation(new MockERC6909(), address(0));
 
     function testSameDecimals() public view {
         assertEq(valuation.getQuote(100 * 1e6, C6, C6), 100 * 1e6);

--- a/test/pools/integration/Cases.t.sol
+++ b/test/pools/integration/Cases.t.sol
@@ -45,7 +45,7 @@ contract TestCommon is Deployer, Test {
 
         // Label contracts & actors (for debugging)
         vm.label(address(transientValuation), "TransientValuation");
-        vm.label(address(oneToOneValuation), "OneToOneValuation");
+        vm.label(address(identityValuation), "IdentityValuation");
         vm.label(address(multicall), "Multicall");
         vm.label(address(poolRegistry), "PoolRegistry");
         vm.label(address(assetRegistry), "AssetRegistry");
@@ -127,7 +127,7 @@ contract TestConfiguration is TestCommon {
         cs[c++] = abi.encodeWithSelector(poolManager.addShareClass.selector, bytes(""));
         cs[c++] = abi.encodeWithSelector(poolManager.notifyPool.selector, CHAIN_CV);
         cs[c++] = abi.encodeWithSelector(poolManager.notifyShareClass.selector, CHAIN_CV, scId);
-        cs[c++] = abi.encodeWithSelector(poolManager.createHolding.selector, scId, USDC_C2, oneToOneValuation, 0x01);
+        cs[c++] = abi.encodeWithSelector(poolManager.createHolding.selector, scId, USDC_C2, identityValuation, 0x01);
         cs[c++] = abi.encodeWithSelector(poolManager.allowInvestorAsset.selector, scId, USDC_C2, true);
         assertEq(c, cs.length);
 

--- a/test/pools/integration/Cases.t.sol
+++ b/test/pools/integration/Cases.t.sol
@@ -48,7 +48,7 @@ contract TestCommon is Deployer, Test {
         vm.label(address(oneToOneValuation), "OneToOneValuation");
         vm.label(address(multicall), "Multicall");
         vm.label(address(poolRegistry), "PoolRegistry");
-        vm.label(address(assetManager), "AssetManager");
+        vm.label(address(assetRegistry), "AssetRegistry");
         vm.label(address(accounting), "Accounting");
         vm.label(address(holdings), "Holdings");
         vm.label(address(singleShareClass), "SingleShareClass");
@@ -77,7 +77,7 @@ contract TestConfiguration is TestCommon {
     function testAssetRegistration() public {
         cv.registerAsset(USDC_C2, "USD Coin", "USDC", 6);
 
-        (string memory name, string memory symbol, uint8 decimals) = assetManager.asset(USDC_C2);
+        (string memory name, string memory symbol, uint8 decimals) = assetRegistry.asset(USDC_C2);
         assertEq(name, "USD Coin");
         assertEq(symbol, "USDC");
         assertEq(decimals, 6);

--- a/test/pools/unit/AssetRegistry.t.sol
+++ b/test/pools/unit/AssetRegistry.t.sol
@@ -9,12 +9,12 @@ import {MathLib} from "src/misc/libraries/MathLib.sol";
 import {IERC6909, IERC6909MetadataExt, IERC6909TotalSupplyExt} from "src/misc/interfaces/IERC6909.sol";
 
 import {AssetId} from "src/pools/types/AssetId.sol";
-import {AssetManager} from "src/pools/AssetManager.sol";
-import {IAssetManager} from "src/pools/interfaces/IAssetManager.sol";
+import {AssetRegistry} from "src/pools/AssetRegistry.sol";
+import {IAssetRegistry} from "src/pools/interfaces/IAssetRegistry.sol";
 
-abstract contract AssetManagerBaseTest is Test {
+abstract contract AssetRegistryBaseTest is Test {
     address self;
-    AssetManager manager;
+    AssetRegistry manager;
     AssetId assetId = AssetId.wrap(1);
     string name = "MyTestAsset";
     string symbol = "MTA";
@@ -22,11 +22,11 @@ abstract contract AssetManagerBaseTest is Test {
 
     function setUp() public virtual {
         self = address(this);
-        manager = new AssetManager(self);
+        manager = new AssetRegistry(self);
     }
 }
 
-contract AuthTest is AssetManagerBaseTest {
+contract AuthTest is AssetRegistryBaseTest {
     function testAssignedWardsOnInitialization() public view {
         assertEq(manager.wards(self), 1);
     }
@@ -51,10 +51,10 @@ contract AuthTest is AssetManagerBaseTest {
     }
 }
 
-contract AssetManagementTest is AssetManagerBaseTest {
+contract AssetManagementTest is AssetRegistryBaseTest {
     function testRegistrationOfANewAsset() public {
         vm.expectEmit();
-        emit IAssetManager.NewAssetEntry(assetId, name, symbol, decimals);
+        emit IAssetRegistry.NewAssetEntry(assetId, name, symbol, decimals);
         manager.registerAsset(assetId, name, symbol, decimals);
         assertTrue(manager.isRegistered(assetId));
 
@@ -66,7 +66,7 @@ contract AssetManagementTest is AssetManagerBaseTest {
     }
 
     function testRevertOnNewAssetRegistration() public {
-        vm.expectRevert(IAssetManager.IncorrectAssetId.selector);
+        vm.expectRevert(IAssetRegistry.IncorrectAssetId.selector);
         manager.registerAsset(AssetId.wrap(0), "AssetWithEmptyId", "N/A", 18);
     }
 
@@ -77,7 +77,7 @@ contract AssetManagementTest is AssetManagerBaseTest {
         symbol = "MNUA";
 
         vm.expectEmit();
-        emit IAssetManager.NewAssetEntry(assetId, name, symbol, decimals);
+        emit IAssetRegistry.NewAssetEntry(assetId, name, symbol, decimals);
         manager.registerAsset(assetId, name, symbol, 6);
 
         (string memory name_, string memory symbol_, uint8 decimals_) = manager.asset(assetId);
@@ -89,7 +89,7 @@ contract AssetManagementTest is AssetManagerBaseTest {
     function testRevertOnUpdateAnExistingAsset() public {
         manager.registerAsset(assetId, "MyNewAsset", "MNA", 18);
 
-        vm.expectRevert(IAssetManager.IncorrectAssetId.selector);
+        vm.expectRevert(IAssetRegistry.IncorrectAssetId.selector);
         manager.registerAsset(AssetId.wrap(0), "MyUpdatedAsset", "MUNA", 18);
     }
 
@@ -98,7 +98,7 @@ contract AssetManagementTest is AssetManagerBaseTest {
     }
 }
 
-contract AssetMetadataRetrievalTest is AssetManagerBaseTest {
+contract AssetMetadataRetrievalTest is AssetRegistryBaseTest {
     using MathLib for uint128;
 
     uint256 rawAssetId;
@@ -114,7 +114,7 @@ contract AssetMetadataRetrievalTest is AssetManagerBaseTest {
     }
 
     function testRevertWhenAssetDoesNotExist() public {
-        vm.expectRevert(IAssetManager.AssetNotFound.selector);
+        vm.expectRevert(IAssetRegistry.AssetNotFound.selector);
         manager.decimals(8337);
     }
 
@@ -135,7 +135,7 @@ contract AssetMetadataRetrievalTest is AssetManagerBaseTest {
     }
 }
 
-contract AssetManagerSupportedInterfacesTest is AssetManagerBaseTest {
+contract AssetRegistrySupportedInterfacesTest is AssetRegistryBaseTest {
     function testSupport() public view {
         assertTrue(manager.supportsInterface(type(IERC165).interfaceId));
         assertTrue(manager.supportsInterface(type(IERC6909).interfaceId));

--- a/test/pools/unit/PoolManager.t.sol
+++ b/test/pools/unit/PoolManager.t.sol
@@ -16,7 +16,7 @@ import {ShareClassId} from "src/pools/types/ShareClassId.sol";
 import {IPoolRegistry} from "src/pools/interfaces/IPoolRegistry.sol";
 import {IHoldings} from "src/pools/interfaces/IHoldings.sol";
 import {IAccounting} from "src/pools/interfaces/IAccounting.sol";
-import {IAssetManager} from "src/pools/interfaces/IAssetManager.sol";
+import {IAssetRegistry} from "src/pools/interfaces/IAssetRegistry.sol";
 import {IShareClassManager} from "src/pools/interfaces/IShareClassManager.sol";
 import {IGateway} from "src/pools/interfaces/IGateway.sol";
 import {IPoolLocker} from "src/pools/interfaces/IPoolLocker.sol";
@@ -31,13 +31,13 @@ contract TestCommon is Test {
     IPoolRegistry immutable poolRegistry = IPoolRegistry(makeAddr("PoolRegistry"));
     IHoldings immutable holdings = IHoldings(makeAddr("Holdings"));
     IAccounting immutable accounting = IAccounting(makeAddr("Accounting"));
-    IAssetManager immutable assetManager = IAssetManager(makeAddr("AssetManager"));
+    IAssetRegistry immutable assetRegistry = IAssetRegistry(makeAddr("AssetRegistry"));
     IGateway immutable gateway = IGateway(makeAddr("Gateway"));
     IShareClassManager immutable scm = IShareClassManager(makeAddr("ShareClassManager"));
 
     Multicall multicall = new Multicall();
     PoolManager poolManager =
-        new PoolManager(multicall, poolRegistry, assetManager, accounting, holdings, gateway, address(0));
+        new PoolManager(multicall, poolRegistry, assetRegistry, accounting, holdings, gateway, address(0));
 
     function _mockSuccessfulMulticall() private {
         vm.mockCall(
@@ -207,8 +207,8 @@ contract TestAllowInvestorAsset is TestCommon {
 contract TestCreateHolding is TestCommon {
     function testErrAssetNotFound() public {
         vm.mockCall(
-            address(assetManager),
-            abi.encodeWithSelector(assetManager.isRegistered.selector, ASSET_A),
+            address(assetRegistry),
+            abi.encodeWithSelector(assetRegistry.isRegistered.selector, ASSET_A),
             abi.encode(false)
         );
 
@@ -218,7 +218,7 @@ contract TestCreateHolding is TestCommon {
             abi.encodeWithSelector(poolManager.createHolding.selector, SC_A, ASSET_A, address(1), 0)
         );
 
-        vm.expectRevert(IAssetManager.AssetNotFound.selector);
+        vm.expectRevert(IAssetRegistry.AssetNotFound.selector);
         poolManager.execute(POOL_A, calls);
     }
 }


### PR DESCRIPTION
Bonus: `OneToOneValuation` to `IdentityValuation`, given we still refer to it with the old name.