### PR TITLE
Allow reentrancy-protected methods without multicall

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -15,7 +15,7 @@ fs_permissions = [{ access = "read-write", path = ".forge-snapshots/"}, { access
 
 # False-alarm warnings
 ignored_warnings_from = [
-    "src/misc/Multicall.sol" # Issue: https://github.com/ethereum/solidity/issues/14359
+    "src/misc/ReentrancyProtection.sol" # Issue: https://github.com/ethereum/solidity/issues/14359
 ]
 
 [profile.default.fuzz]
@@ -80,7 +80,7 @@ fail_on_revert = false
   ignore = [
     "test/*.sol",
     #Check if https://github.com/foundry-rs/foundry/issues/9088 is fixed to remove the following:
-    "src/misc/Multicall.sol", #Because transient keyword
+    "src/misc/ReentrancyProtection.sol", #Because transient keyword
     "src/pools/Accounting.sol", #Because transient keyword
     "src/pools/PoolManager.sol", #Because transient keyword
     "src/pools/SingleShareClass.sol", #Because transient keyword

--- a/src/misc/ReentrancyProtection.sol
+++ b/src/misc/ReentrancyProtection.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+// NOTE: This file has warning disabled due https://github.com/ethereum/solidity/issues/14359
+// If perform any change on it, please ensure no other warnings appears
+
+import {IMulticall} from "src/misc/interfaces/IMulticall.sol";
+
+abstract contract ReentrancyProtection {
+    /// @notice Dispatched when there is a re-entrancy issue
+    error UnauthorizedSender();
+
+    address private transient _initiator;
+
+    /// @dev The method is protected for reentrancy issues.
+    modifier protected() {
+        if (_initiator == address(0)) {
+            // Single call re-entrancy lock
+            _initiator = msg.sender;
+            _;
+            _initiator = address(0);
+        } else {
+            // Multicall re-entrancy lock
+            require(msg.sender == _initiator, UnauthorizedSender());
+            _;
+        }
+    }
+}

--- a/src/misc/interfaces/IMulticall.sol
+++ b/src/misc/interfaces/IMulticall.sol
@@ -6,12 +6,6 @@ interface IMulticall {
     /// @notice Dispatched when an internal error has ocurred
     error CallFailed();
 
-    /// @notice Dispatched when there is a re-entrancy issue
-    error UnauthorizedSender();
-
-    /// @notice Dispatched when multicall is called inside of one protected method or recursively
-    error AlreadyInitiated();
-
     /// @notice Allows caller to execute multiple (batched) messages calls in one transaction.
     /// @param data An array of encoded methods of the same contract.
     /// @dev No reentrant execution is allowed.

--- a/test/misc/unit/Multicall.t.sol
+++ b/test/misc/unit/Multicall.t.sol
@@ -5,6 +5,7 @@ import "forge-std/Test.sol";
 
 import {IMulticall} from "src/misc/interfaces/IMulticall.sol";
 import {Multicall} from "src/misc/Multicall.sol";
+import {ReentrancyProtection} from "src/misc/ReentrancyProtection.sol";
 
 contract ExternalContract {
     MulticallImpl public multicall;
@@ -82,19 +83,11 @@ contract MulticallTest is Test {
         assertEq(multicall.value(), 0);
     }
 
-    function testErrAlreadyInitiated() public {
-        bytes[] memory calls = new bytes[](1);
-        calls[0] = abi.encodeWithSelector(multicall.multicall.selector, new bytes[](0));
-
-        vm.expectRevert(IMulticall.AlreadyInitiated.selector);
-        multicall.multicall(calls);
-    }
-
     function testErrUnauthorizedSender() public {
         bytes[] memory calls = new bytes[](1);
         calls[0] = abi.encodeWithSelector(multicall.addWithReentrancy.selector, 2);
 
-        vm.expectRevert(IMulticall.UnauthorizedSender.selector);
+        vm.expectRevert(ReentrancyProtection.UnauthorizedSender.selector);
         multicall.multicall(calls);
     }
 }


### PR DESCRIPTION
This PR extracts reentrancy logic from multicall. Currently `Multicall` contract also provides reentrancy checks, but you could use reentrancy checks without to provide a Multicall.

It also allows the nest of multicalls if the sender is the same, which should be safe, and desired. For example: 
  - In a single multicall I could operate several pools through `execute()` calls (which means other multicalls).
  - I could `execute(approve) + call permisionless methods + execute(issue)` again in a single transaction.
  - Or I could `createPool + execute(...)` in a single transaction too!


