### PR TITLE
Feat: Batch addition for CP

### DIFF
--- a/script/pools/Deployer.s.sol
+++ b/script/pools/Deployer.s.sol
@@ -6,31 +6,29 @@ import "forge-std/Script.sol";
 import {TransientValuation} from "src/misc/TransientValuation.sol";
 import {IdentityValuation} from "src/misc/IdentityValuation.sol";
 
+import {Gateway} from "src/common/Gateway.sol";
+
 import {AssetId, newAssetId} from "src/pools/types/AssetId.sol";
-import {IGateway} from "src/pools/interfaces/IGateway.sol";
 import {IAdapter} from "src/pools/interfaces/IAdapter.sol";
 import {PoolRegistry} from "src/pools/PoolRegistry.sol";
 import {SingleShareClass} from "src/pools/SingleShareClass.sol";
 import {Holdings} from "src/pools/Holdings.sol";
 import {AssetRegistry} from "src/pools/AssetRegistry.sol";
 import {Accounting} from "src/pools/Accounting.sol";
-import {Gateway} from "src/pools/Gateway.sol";
+import {MessageProcessor} from "src/pools/MessageProcessor.sol";
 import {PoolManager, IPoolManager} from "src/pools/PoolManager.sol";
 import {PoolRouter} from "src/pools/PoolRouter.sol";
 
 contract Deployer is Script {
-    /// @dev Identifies an address that requires to be overwritten by a `file()` method before ending the deployment.
-    /// Just a placesholder and visual indicator.
-    address constant ADDRESS_TO_FILE = address(123);
-
     // Core contracts
     PoolRegistry public poolRegistry;
     AssetRegistry public assetRegistry;
     Accounting public accounting;
     Holdings public holdings;
     SingleShareClass public singleShareClass;
-    PoolManager public poolManager;
     Gateway public gateway;
+    PoolManager public poolManager;
+    MessageProcessor public messageProcessor;
     PoolRouter public poolRouter;
 
     // Utilities
@@ -45,11 +43,10 @@ contract Deployer is Script {
         assetRegistry = new AssetRegistry(address(this));
         accounting = new Accounting(address(this));
         holdings = new Holdings(poolRegistry, address(this));
-
         singleShareClass = new SingleShareClass(poolRegistry, address(this));
-        poolManager =
-            new PoolManager(poolRegistry, assetRegistry, accounting, holdings, IGateway(ADDRESS_TO_FILE), address(this));
-        gateway = new Gateway(IAdapter(address(0 /* TODO */ )), poolManager, address(this));
+        gateway = new Gateway(address(this));
+        poolManager = new PoolManager(poolRegistry, assetRegistry, accounting, holdings, gateway, address(this));
+        messageProcessor = new MessageProcessor(gateway, poolManager, address(this));
         poolRouter = new PoolRouter(poolManager);
 
         transientValuation = new TransientValuation(assetRegistry, address(this));
@@ -61,7 +58,8 @@ contract Deployer is Script {
     }
 
     function _file() public {
-        poolManager.file("gateway", address(gateway));
+        poolManager.file("sender", address(messageProcessor));
+        gateway.file("handle", address(messageProcessor));
     }
 
     function _rely() private {
@@ -70,9 +68,12 @@ contract Deployer is Script {
         holdings.rely(address(poolManager));
         accounting.rely(address(poolManager));
         singleShareClass.rely(address(poolManager));
-        poolManager.rely(address(gateway));
-        poolManager.rely(address(poolRouter));
         gateway.rely(address(poolManager));
+        gateway.rely(address(messageProcessor));
+        poolManager.rely(address(messageProcessor));
+        poolManager.rely(address(poolRouter));
+        messageProcessor.rely(address(poolManager));
+        messageProcessor.rely(address(gateway));
     }
 
     function _initialConfig() private {
@@ -85,8 +86,9 @@ contract Deployer is Script {
         accounting.deny(address(this));
         holdings.deny(address(this));
         singleShareClass.deny(address(this));
-        poolManager.deny(address(this));
         gateway.deny(address(this));
+        messageProcessor.deny(address(this));
+        poolManager.deny(address(this));
 
         transientValuation.deny(address(this));
         identityValuation.deny(address(this));

--- a/script/pools/Deployer.s.sol
+++ b/script/pools/Deployer.s.sol
@@ -57,7 +57,7 @@ contract Deployer is Script {
         _initialConfig();
     }
 
-    function _file() public {
+    function _file() private {
         poolManager.file("sender", address(messageProcessor));
         gateway.file("handle", address(messageProcessor));
     }

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {Auth} from "src/misc/Auth.sol";
+
+import {MessageType, MessageLib} from "src/common/libraries/MessageLib.sol";
+import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+import {IMessageSender} from "src/common/interfaces/IMessageSender.sol";
+import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {IGateway} from "src/common/interfaces/IGateway.sol";
+
+contract Gateway is Auth, IGateway {
+    using MessageLib for *;
+    using BytesLib for bytes;
+    using CastLib for *;
+
+    IAdapter public adapter; // TODO: support multiple adapters
+    IMessageHandler public handler;
+
+    mapping(uint32 chainId => bytes) public /*transient*/ batch;
+    uint32[] public /*transient*/ chainIds;
+    bool public /*transient*/ isBatching;
+
+    /// @notice The payer of the transaction.
+    address public /*transient*/ payableSource;
+
+    constructor(address deployer) Auth(deployer) {}
+
+    function file(bytes32 what, address data) external auth {
+        if (what == "adapter") adapter = IAdapter(data);
+        else if (what == "handle") handler = IMessageHandler(data);
+        else revert FileUnrecognizedWhat();
+
+        emit File(what, data);
+    }
+
+    /// @inheritdoc IGateway
+    function setPayableSource(address source_) external {
+        payableSource = source_;
+    }
+
+    /// @inheritdoc IGateway
+    function startBatch() external auth {
+        isBatching = true;
+    }
+
+    /// @inheritdoc IGateway
+    function endBatch() external auth {
+        require(isBatching, NoBatched());
+
+        for (uint256 i; i < chainIds.length; i++) {
+            uint32 chainId = chainIds[i];
+            _send(chainId, batch[chainId]);
+            delete batch[chainId];
+            delete chainIds[i];
+        }
+
+        isBatching = false;
+    }
+
+    /// @inheritdoc IMessageHandler
+    function handle(bytes memory message) external auth {
+        // TODO: add some gateway stuff
+        while (message.length > 0) {
+            handler.handle(message);
+
+            uint16 messageLength = message.messageLength();
+
+            // TODO: remove this when registerAsset is merged
+            if (message.messageType() == MessageType.RegisterAsset) {
+                return;
+            }
+
+            // TODO: optimize with assembly to just shift the pointer in the array
+            message = message.slice(messageLength, message.length - messageLength);
+        }
+    }
+
+    /// @inheritdoc IMessageSender
+    function send(uint32 chainId_, bytes memory message) external auth {
+        if (isBatching) {
+            bytes storage previousMessage = batch[chainId_];
+            if (previousMessage.length == 0) {
+                chainIds.push(chainId_);
+                batch[chainId_] = message;
+            } else {
+                batch[chainId_] = bytes.concat(previousMessage, message);
+            }
+        } else {
+            _send(chainId_, message);
+        }
+    }
+
+    function _send(uint32 chainId, bytes memory message) private {
+        // TODO: some gateway stuff
+        adapter.send(chainId, message);
+    }
+}

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -37,7 +37,7 @@ contract Gateway is Auth, IGateway {
     }
 
     /// @inheritdoc IGateway
-    function setPayableSource(address source_) external {
+    function setPayableSource(address source_) external auth {
         payableSource = source_;
     }
 

--- a/src/common/interfaces/IAdapter.sol
+++ b/src/common/interfaces/IAdapter.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+interface IAdapter {
+    /// @notice Send a payload to Centrifuge Chain
+    function send(uint32 chainId, bytes calldata payload) external;
+
+    /// @notice Estimate the total cost in native gas tokens
+    function estimate(uint32 chainId, bytes calldata payload, uint256 baseCost) external view returns (uint256);
+
+    /// @notice Pay the gas cost
+    function pay(uint32 chainId, bytes calldata payload, address refund) external payable;
+}

--- a/src/common/interfaces/IAdapter.sol
+++ b/src/common/interfaces/IAdapter.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.28;
 
 interface IAdapter {
-    /// @notice Send a payload to Centrifuge Chain
+    /// @notice Send a payload to the destination chain
     function send(uint32 chainId, bytes calldata payload) external;
 
     /// @notice Estimate the total cost in native gas tokens

--- a/src/common/interfaces/IGateway.sol
+++ b/src/common/interfaces/IGateway.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+import {IMessageSender} from "src/common/interfaces/IMessageSender.sol";
+
+/// @notice Interface for dispatch-only gateway
+interface IGateway is IMessageHandler, IMessageSender {
+    /// @notice Emitted when a call to `file()` was performed.
+    event File(bytes32 indexed what, address addr);
+
+    /// @notice Dispatched when the `what` parameter of `file()` is not supported by the implementation.
+    error FileUnrecognizedWhat();
+
+    error NoBatched();
+
+    /// @notice Updates a contract parameter.
+    /// @param what Name of the parameter to update.
+    /// Accepts a `bytes32` representation of 'adapter' or 'handler' string values.
+    /// @param data New value given to the `what` parameter
+    function file(bytes32 what, address data) external;
+
+    /// @notice Set the payable source of the message.
+    /// @param  source Used to determine whether it is eligible for TX cost payment.
+    function setPayableSource(address source) external;
+
+    /// @notice Initialize batching message
+    function startBatch() external;
+
+    /// @notice Finalize batching messages and send the resulting batch message
+    function endBatch() external;
+}

--- a/src/common/interfaces/IMessageHandler.sol
+++ b/src/common/interfaces/IMessageHandler.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-/// @notice Generic interface for entities that receives messages
+/// @notice Generic interface for entities that handle incoming messages
 interface IMessageHandler {
     /// @notice Dispatched when an invalid message is trying to handle
     error InvalidMessage(uint8 code);

--- a/src/common/interfaces/IMessageSender.sol
+++ b/src/common/interfaces/IMessageSender.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+/// @notice Generic interface for entities that handles outgoing messages
+interface IMessageSender {
+    /// @notice Handling outgoing messages.
+    /// @param chainId Destination chain
+    function send(uint32 chainId, bytes memory message) external;
+}

--- a/src/pools/MessageProcessor.sol
+++ b/src/pools/MessageProcessor.sol
@@ -6,42 +6,40 @@ import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {Auth} from "src/misc/Auth.sol";
 
 import {MessageType, MessageLib} from "src/common/libraries/MessageLib.sol";
+import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+import {IMessageSender} from "src/common/interfaces/IMessageSender.sol";
 
 import {ShareClassId} from "src/pools/types/ShareClassId.sol";
 import {AssetId} from "src/pools/types/AssetId.sol";
 import {PoolId} from "src/pools/types/PoolId.sol";
-import {IGateway} from "src/pools/interfaces/IGateway.sol";
-import {IMessageHandler} from "src/pools/interfaces/IMessageHandler.sol";
-import {IAdapter} from "src/pools/interfaces/IAdapter.sol";
+import {IMessageProcessor} from "src/pools/interfaces/IMessageProcessor.sol";
 import {IPoolManagerHandler} from "src/pools/interfaces/IPoolManager.sol";
 
-contract Gateway is Auth, IGateway, IMessageHandler {
+contract MessageProcessor is Auth, IMessageProcessor {
     using MessageLib for *;
     using BytesLib for bytes;
     using CastLib for *;
 
-    IAdapter public adapter; // TODO: several adapters
-    IPoolManagerHandler public handler;
+    IPoolManagerHandler public immutable manager;
+    IMessageSender public immutable sender;
 
-    constructor(IAdapter adapter_, IPoolManagerHandler handler_, address deployer) Auth(deployer) {
-        adapter = adapter_;
-        handler = handler_;
+    constructor(IMessageSender sender_, IPoolManagerHandler manager_, address deployer) Auth(deployer) {
+        sender = sender_;
+        manager = manager_;
     }
 
-    /// @inheritdoc IGateway
-    function file(bytes32 what, address data) external auth {
-        if (what == "adapter") adapter = IAdapter(data);
-        else if (what == "handler") handler = IPoolManagerHandler(data);
-        else revert FileUnrecognizedWhat();
-
-        emit File(what, data);
-    }
-
+    /// @inheritdoc IMessageProcessor
     function sendNotifyPool(uint32 chainId, PoolId poolId) external auth {
-        // TODO: call directly to CV.poolManager if same chain (apply in all send*() methods)
-        _send(chainId, MessageLib.NotifyPool({poolId: poolId.raw()}).serialize());
+        // In case we want to optimize for the same network:
+        //if chainId == uint32(block.chainId) {
+        //    cv.poolManager.notifyPool(poolId);
+        //}
+        //else {
+        sender.send(chainId, MessageLib.NotifyPool({poolId: poolId.raw()}).serialize());
+        //}
     }
 
+    /// @inheritdoc IMessageProcessor
     function sendNotifyShareClass(
         uint32 chainId,
         PoolId poolId,
@@ -52,7 +50,7 @@ contract Gateway is Auth, IGateway, IMessageHandler {
         bytes32 salt,
         bytes32 hook
     ) external auth {
-        _send(
+        sender.send(
             chainId,
             MessageLib.NotifyShareClass({
                 poolId: poolId.raw(),
@@ -66,14 +64,16 @@ contract Gateway is Auth, IGateway, IMessageHandler {
         );
     }
 
+    /// @inheritdoc IMessageProcessor
     function sendNotifyAllowedAsset(PoolId poolId, ShareClassId scId, AssetId assetId, bool isAllowed) external auth {
         bytes memory message = isAllowed
             ? MessageLib.AllowAsset({poolId: poolId.raw(), scId: scId.raw(), assetId: assetId.raw()}).serialize()
             : MessageLib.DisallowAsset({poolId: poolId.raw(), scId: scId.raw(), assetId: assetId.raw()}).serialize();
 
-        _send(assetId.chainId(), message);
+        sender.send(assetId.chainId(), message);
     }
 
+    /// @inheritdoc IMessageProcessor
     function sendFulfilledDepositRequest(
         PoolId poolId,
         ShareClassId scId,
@@ -82,7 +82,7 @@ contract Gateway is Auth, IGateway, IMessageHandler {
         uint128 assetAmount,
         uint128 shareAmount
     ) external auth {
-        _send(
+        sender.send(
             assetId.chainId(),
             MessageLib.FulfilledDepositRequest({
                 poolId: poolId.raw(),
@@ -95,6 +95,7 @@ contract Gateway is Auth, IGateway, IMessageHandler {
         );
     }
 
+    /// @inheritdoc IMessageProcessor
     function sendFulfilledRedeemRequest(
         PoolId poolId,
         ShareClassId scId,
@@ -103,7 +104,7 @@ contract Gateway is Auth, IGateway, IMessageHandler {
         uint128 assetAmount,
         uint128 shareAmount
     ) external auth {
-        _send(
+        sender.send(
             assetId.chainId(),
             MessageLib.FulfilledRedeemRequest({
                 poolId: poolId.raw(),
@@ -116,6 +117,7 @@ contract Gateway is Auth, IGateway, IMessageHandler {
         );
     }
 
+    /// @inheritdoc IMessageProcessor
     function sendFulfilledCancelDepositRequest(
         PoolId poolId,
         ShareClassId scId,
@@ -123,7 +125,7 @@ contract Gateway is Auth, IGateway, IMessageHandler {
         bytes32 investor,
         uint128 cancelledAmount
     ) external auth {
-        _send(
+        sender.send(
             assetId.chainId(),
             MessageLib.FulfilledCancelDepositRequest({
                 poolId: poolId.raw(),
@@ -135,6 +137,7 @@ contract Gateway is Auth, IGateway, IMessageHandler {
         );
     }
 
+    /// @inheritdoc IMessageProcessor
     function sendFulfilledCancelRedeemRequest(
         PoolId poolId,
         ShareClassId scId,
@@ -142,7 +145,7 @@ contract Gateway is Auth, IGateway, IMessageHandler {
         bytes32 investor,
         uint128 cancelledShares
     ) external auth {
-        _send(
+        sender.send(
             assetId.chainId(),
             MessageLib.FulfilledCancelRedeemRequest({
                 poolId: poolId.raw(),
@@ -154,39 +157,35 @@ contract Gateway is Auth, IGateway, IMessageHandler {
         );
     }
 
-    function handle(bytes calldata message) external auth {
+    /// @inheritdoc IMessageHandler
+    function handle(bytes memory message) external auth {
         MessageType kind = message.messageType();
 
         if (kind == MessageType.RegisterAsset) {
             MessageLib.RegisterAsset memory m = message.deserializeRegisterAsset();
-            handler.registerAsset(AssetId.wrap(m.assetId), m.name, m.symbol.toString(), m.decimals);
+            manager.registerAsset(AssetId.wrap(m.assetId), m.name, m.symbol.toString(), m.decimals);
         } else if (kind == MessageType.DepositRequest) {
             MessageLib.DepositRequest memory m = message.deserializeDepositRequest();
-            handler.depositRequest(
+            manager.depositRequest(
                 PoolId.wrap(m.poolId), ShareClassId.wrap(m.scId), m.investor, AssetId.wrap(m.assetId), m.amount
             );
         } else if (kind == MessageType.RedeemRequest) {
             MessageLib.RedeemRequest memory m = message.deserializeRedeemRequest();
-            handler.redeemRequest(
+            manager.redeemRequest(
                 PoolId.wrap(m.poolId), ShareClassId.wrap(m.scId), m.investor, AssetId.wrap(m.assetId), m.amount
             );
         } else if (kind == MessageType.CancelDepositRequest) {
             MessageLib.CancelDepositRequest memory m = message.deserializeCancelDepositRequest();
-            handler.cancelDepositRequest(
+            manager.cancelDepositRequest(
                 PoolId.wrap(m.poolId), ShareClassId.wrap(m.scId), m.investor, AssetId.wrap(m.assetId)
             );
         } else if (kind == MessageType.CancelRedeemRequest) {
             MessageLib.CancelRedeemRequest memory m = message.deserializeCancelRedeemRequest();
-            handler.cancelRedeemRequest(
+            manager.cancelRedeemRequest(
                 PoolId.wrap(m.poolId), ShareClassId.wrap(m.scId), m.investor, AssetId.wrap(m.assetId)
             );
         } else {
             revert InvalidMessage(uint8(kind));
         }
-    }
-
-    function _send(uint32 chainId, bytes memory message) private {
-        // TODO: generate proofs and send message through handlers
-        adapter.send(chainId, message);
     }
 }

--- a/src/pools/PoolManager.sol
+++ b/src/pools/PoolManager.sol
@@ -8,17 +8,19 @@ import {IERC7726} from "src/misc/interfaces/IERC7726.sol";
 import {Auth} from "src/misc/Auth.sol";
 import {Multicall} from "src/misc/Multicall.sol";
 
+import {IGateway} from "src/common/interfaces/IGateway.sol";
+
 import {ShareClassId} from "src/pools/types/ShareClassId.sol";
 import {AssetId} from "src/pools/types/AssetId.sol";
 import {AccountId, newAccountId} from "src/pools/types/AccountId.sol";
 import {PoolId} from "src/pools/types/PoolId.sol";
 import {IAccounting} from "src/pools/interfaces/IAccounting.sol";
-import {IGateway} from "src/pools/interfaces/IGateway.sol";
 import {IPoolRegistry} from "src/pools/interfaces/IPoolRegistry.sol";
 import {IAssetRegistry} from "src/pools/interfaces/IAssetRegistry.sol";
 import {IShareClassManager} from "src/pools/interfaces/IShareClassManager.sol";
 import {ISingleShareClass} from "src/pools/interfaces/ISingleShareClass.sol";
 import {IHoldings} from "src/pools/interfaces/IHoldings.sol";
+import {IMessageProcessor} from "src/pools/interfaces/IMessageProcessor.sol";
 import {IPoolManager, IPoolManagerHandler, EscrowId, AccountType} from "src/pools/interfaces/IPoolManager.sol";
 
 // @inheritdoc IPoolManager
@@ -36,6 +38,7 @@ contract PoolManager is Auth, IPoolManager, IPoolManagerHandler {
     IAccounting public accounting;
     IHoldings public holdings;
     IGateway public gateway;
+    IMessageProcessor public sender;
 
     /// @dev A requirement for methods that needs to be called through `execute()`
     modifier poolUnlocked() {
@@ -54,8 +57,8 @@ contract PoolManager is Auth, IPoolManager, IPoolManagerHandler {
         poolRegistry = poolRegistry_;
         assetRegistry = assetRegistry_;
         accounting = accounting_;
-        holdings = holdings_;
         gateway = gateway_;
+        holdings = holdings_;
     }
 
     //----------------------------------------------------------------------------------------------
@@ -64,7 +67,8 @@ contract PoolManager is Auth, IPoolManager, IPoolManagerHandler {
 
     /// @inheritdoc IPoolManager
     function file(bytes32 what, address data) external auth {
-        if (what == "gateway") gateway = IGateway(data);
+        if (what == "sender") sender = IMessageProcessor(data);
+        else if (what == "gateway") gateway = IGateway(data);
         else if (what == "holdings") holdings = IHoldings(data);
         else if (what == "poolRegistry") poolRegistry = IPoolRegistry(data);
         else if (what == "assetRegistry") assetRegistry = IAssetRegistry(data);
@@ -79,6 +83,9 @@ contract PoolManager is Auth, IPoolManager, IPoolManagerHandler {
         require(unlockedPoolId.isNull(), IPoolManager.PoolAlreadyUnlocked());
         require(poolRegistry.isAdmin(poolId, admin), IPoolManager.NotAuthorizedAdmin());
 
+        gateway.setPayableSource(admin);
+        gateway.startBatch();
+
         accounting.unlock(poolId, "TODO");
         unlockedPoolId = poolId;
     }
@@ -87,6 +94,8 @@ contract PoolManager is Auth, IPoolManager, IPoolManagerHandler {
     function lock() external auth {
         accounting.lock();
         unlockedPoolId = PoolId.wrap(0);
+
+        gateway.endBatch();
     }
 
     //----------------------------------------------------------------------------------------------
@@ -107,7 +116,7 @@ contract PoolManager is Auth, IPoolManager, IPoolManagerHandler {
         IShareClassManager scm = poolRegistry.shareClassManager(poolId);
 
         (uint128 shares, uint128 tokens) = scm.claimDeposit(poolId, scId, investor, assetId);
-        gateway.sendFulfilledDepositRequest(poolId, scId, assetId, investor, tokens, shares);
+        sender.sendFulfilledDepositRequest(poolId, scId, assetId, investor, tokens, shares);
     }
 
     /// @inheritdoc IPoolManager
@@ -118,7 +127,7 @@ contract PoolManager is Auth, IPoolManager, IPoolManagerHandler {
 
         assetRegistry.burn(escrow(poolId, scId, EscrowId.PENDING_SHARE_CLASS), assetId.raw(), tokens);
 
-        gateway.sendFulfilledRedeemRequest(poolId, scId, assetId, investor, tokens, shares);
+        sender.sendFulfilledRedeemRequest(poolId, scId, assetId, investor, tokens, shares);
     }
 
     //----------------------------------------------------------------------------------------------
@@ -127,7 +136,7 @@ contract PoolManager is Auth, IPoolManager, IPoolManagerHandler {
 
     /// @inheritdoc IPoolManager
     function notifyPool(uint32 chainId) external auth poolUnlocked {
-        gateway.sendNotifyPool(chainId, unlockedPoolId);
+        sender.sendNotifyPool(chainId, unlockedPoolId);
     }
 
     /// @inheritdoc IPoolManager
@@ -138,7 +147,7 @@ contract PoolManager is Auth, IPoolManager, IPoolManagerHandler {
         (string memory name, string memory symbol, bytes32 salt) = ISingleShareClass(address(scm)).metadata(scId);
         uint8 decimals = assetRegistry.decimals(poolRegistry.currency(unlockedPoolId).raw());
 
-        gateway.sendNotifyShareClass(chainId, unlockedPoolId, scId, name, symbol, decimals, salt, hook);
+        sender.sendNotifyShareClass(chainId, unlockedPoolId, scId, name, symbol, decimals, salt, hook);
     }
 
     /// @inheritdoc IPoolManager
@@ -363,7 +372,7 @@ contract PoolManager is Auth, IPoolManager, IPoolManagerHandler {
         address pendingShareClassEscrow = escrow(poolId, scId, EscrowId.PENDING_SHARE_CLASS);
         assetRegistry.burn(pendingShareClassEscrow, depositAssetId.raw(), cancelledAssetAmount);
 
-        gateway.sendFulfilledCancelDepositRequest(poolId, scId, depositAssetId, investor, cancelledAssetAmount);
+        sender.sendFulfilledCancelDepositRequest(poolId, scId, depositAssetId, investor, cancelledAssetAmount);
     }
 
     /// @inheritdoc IPoolManagerHandler
@@ -374,7 +383,7 @@ contract PoolManager is Auth, IPoolManager, IPoolManagerHandler {
         IShareClassManager scm = poolRegistry.shareClassManager(poolId);
         uint128 cancelledShareAmount = scm.cancelRedeemRequest(poolId, scId, investor, payoutAssetId);
 
-        gateway.sendFulfilledCancelRedeemRequest(poolId, scId, payoutAssetId, investor, cancelledShareAmount);
+        sender.sendFulfilledCancelRedeemRequest(poolId, scId, payoutAssetId, investor, cancelledShareAmount);
     }
 
     //----------------------------------------------------------------------------------------------

--- a/src/pools/PoolRouter.sol
+++ b/src/pools/PoolRouter.sol
@@ -12,14 +12,9 @@ import {ShareClassId} from "src/pools/types/ShareClassId.sol";
 import {AssetId} from "src/pools/types/AssetId.sol";
 import {AccountId, newAccountId} from "src/pools/types/AccountId.sol";
 import {PoolId} from "src/pools/types/PoolId.sol";
-import {IAccounting} from "src/pools/interfaces/IAccounting.sol";
-import {IGateway} from "src/pools/interfaces/IGateway.sol";
 import {IPoolRegistry} from "src/pools/interfaces/IPoolRegistry.sol";
-import {IAssetRegistry} from "src/pools/interfaces/IAssetRegistry.sol";
 import {IShareClassManager} from "src/pools/interfaces/IShareClassManager.sol";
-import {ISingleShareClass} from "src/pools/interfaces/ISingleShareClass.sol";
-import {IHoldings} from "src/pools/interfaces/IHoldings.sol";
-import {IPoolManager, IPoolManagerHandler, EscrowId, AccountType} from "src/pools/interfaces/IPoolManager.sol";
+import {IPoolManager} from "src/pools/interfaces/IPoolManager.sol";
 import {IPoolRouter} from "src/pools/interfaces/IPoolRouter.sol";
 
 contract PoolRouter is Multicall, IPoolRouter {

--- a/src/pools/interfaces/IMessageProcessor.sol
+++ b/src/pools/interfaces/IMessageProcessor.sol
@@ -1,24 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
+import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+
 import {ShareClassId} from "src/pools/types/ShareClassId.sol";
 import {AssetId} from "src/pools/types/AssetId.sol";
 import {PoolId} from "src/pools/types/PoolId.sol";
 
 /// @notice Interface for dispatch-only gateway
-interface IGateway {
-    /// @notice Emitted when a call to `file()` was performed.
-    event File(bytes32 indexed what, address addr);
-
-    /// @notice Dispatched when the `what` parameter of `file()` is not supported by the implementation.
-    error FileUnrecognizedWhat();
-
-    /// @notice Updates a contract parameter.
-    /// @param what Name of the parameter to update.
-    /// Accepts a `bytes32` representation of 'adapter' or 'handler' string values.
-    /// @param data New value given to the `what` parameter
-    function file(bytes32 what, address data) external;
-
+interface IMessageProcessor is IMessageHandler {
     /// @notice Creates and send the message
     function sendNotifyPool(uint32 chainId, PoolId poolId) external;
 

--- a/src/pools/interfaces/IPoolManager.sol
+++ b/src/pools/interfaces/IPoolManager.sol
@@ -52,8 +52,8 @@ interface IPoolManager {
 
     /// @notice Updates a contract parameter.
     /// @param what Name of the parameter to update.
-    /// Accepts a `bytes32` representation of 'poolRegistry', 'assetRegistry', 'accounting', 'holdings', 'gateway' as
-    /// string value.
+    /// Accepts a `bytes32` representation of 'poolRegistry', 'assetRegistry', 'accounting', 'holdings', 'gateway' and '
+    /// sender' as string value.
     function file(bytes32 what, address data) external;
 
     /// @notice unlock a pool

--- a/test/pools/integration/Cases.t.sol
+++ b/test/pools/integration/Cases.t.sol
@@ -21,15 +21,29 @@ import {Deployer} from "script/pools/Deployer.s.sol";
 
 import {MockVaults} from "test/pools/mocks/MockVaults.sol";
 
-contract TestCommon is Deployer, Test {
+contract TestCases is Deployer, Test {
+    using CastLib for string;
+    using CastLib for bytes32;
+
     uint32 constant CHAIN_CP = 5;
     uint32 constant CHAIN_CV = 6;
+
+    string constant SC_NAME = "ExampleName";
+    string constant SC_SYMBOL = "ExampleSymbol";
+    bytes32 constant SC_SALT = bytes32("ExampleSalt");
+    bytes32 constant SC_HOOK = bytes32("ExampleHookData");
 
     address immutable FM = makeAddr("FM");
     address immutable ANY = makeAddr("Anyone");
     bytes32 immutable INVESTOR = bytes32("Investor");
 
     AssetId immutable USDC_C2 = newAssetId(CHAIN_CV, 1);
+
+    uint128 constant INVESTOR_AMOUNT = 100 * 1e6; // USDC_C2
+    uint128 constant SHARE_AMOUNT = 10 * 1e18; // Share from USD
+    uint128 constant APPROVED_INVESTOR_AMOUNT = INVESTOR_AMOUNT / 5;
+    uint128 constant APPROVED_SHARE_AMOUNT = SHARE_AMOUNT / 5;
+    D18 immutable NAV_PER_SHARE = d18(2, 1);
 
     MockVaults cv;
 
@@ -59,16 +73,6 @@ contract TestCommon is Deployer, Test {
         // We decide CP is located at CHAIN_CP for messaging
         vm.chainId(CHAIN_CP);
     }
-}
-
-contract TestConfiguration is TestCommon {
-    using CastLib for string;
-    using CastLib for bytes32;
-
-    string constant SC_NAME = "ExampleName";
-    string constant SC_SYMBOL = "ExampleSymbol";
-    bytes32 constant SC_SALT = bytes32("ExampleSalt");
-    bytes32 constant SC_HOOK = bytes32("ExampleHookData");
 
     /// forge-config: default.isolate = true
     function testPoolCreation() public returns (PoolId poolId, ShareClassId scId) {
@@ -113,14 +117,6 @@ contract TestConfiguration is TestCommon {
 
         cv.resetMessages();
     }
-}
-
-contract TestInvestments is TestConfiguration {
-    uint128 constant INVESTOR_AMOUNT = 100 * 1e6; // USDC_C2
-    uint128 constant SHARE_AMOUNT = 10 * 1e18; // Share from USD
-    uint128 constant APPROVED_INVESTOR_AMOUNT = INVESTOR_AMOUNT / 5;
-    uint128 constant APPROVED_SHARE_AMOUNT = SHARE_AMOUNT / 5;
-    D18 immutable NAV_PER_SHARE = d18(2, 1);
 
     /// forge-config: default.isolate = true
     function testDeposit() public returns (PoolId poolId, ShareClassId scId) {

--- a/test/pools/unit/PoolManager.t.sol
+++ b/test/pools/unit/PoolManager.t.sol
@@ -7,6 +7,8 @@ import {D18} from "src/misc/types/D18.sol";
 import {IERC7726} from "src/misc/interfaces/IERC7726.sol";
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 
+import {IGateway} from "src/common/interfaces/IGateway.sol";
+
 import {PoolId} from "src/pools/types/PoolId.sol";
 import {AssetId} from "src/pools/types/AssetId.sol";
 import {AccountId} from "src/pools/types/AccountId.sol";
@@ -16,7 +18,6 @@ import {IHoldings} from "src/pools/interfaces/IHoldings.sol";
 import {IAccounting} from "src/pools/interfaces/IAccounting.sol";
 import {IAssetRegistry} from "src/pools/interfaces/IAssetRegistry.sol";
 import {IShareClassManager} from "src/pools/interfaces/IShareClassManager.sol";
-import {IGateway} from "src/pools/interfaces/IGateway.sol";
 import {IPoolManager} from "src/pools/interfaces/IPoolManager.sol";
 import {PoolManager} from "src/pools/PoolManager.sol";
 
@@ -30,8 +31,8 @@ contract TestCommon is Test {
     IHoldings immutable holdings = IHoldings(makeAddr("Holdings"));
     IAccounting immutable accounting = IAccounting(makeAddr("Accounting"));
     IAssetRegistry immutable assetRegistry = IAssetRegistry(makeAddr("AssetRegistry"));
-    IGateway immutable gateway = IGateway(makeAddr("Gateway"));
     IShareClassManager immutable scm = IShareClassManager(makeAddr("ShareClassManager"));
+    IGateway immutable gateway = IGateway(makeAddr("Gateway"));
 
     PoolManager poolManager = new PoolManager(poolRegistry, assetRegistry, accounting, holdings, gateway, address(this));
 
@@ -45,6 +46,10 @@ contract TestCommon is Test {
         vm.mockCall(
             address(accounting), abi.encodeWithSelector(accounting.unlock.selector, POOL_A, "TODO"), abi.encode(true)
         );
+
+        vm.mockCall(address(gateway), abi.encodeWithSelector(gateway.setPayableSource.selector, ADMIN), abi.encode());
+        vm.mockCall(address(gateway), abi.encodeWithSelector(gateway.startBatch.selector), abi.encode());
+        vm.mockCall(address(gateway), abi.encodeWithSelector(gateway.endBatch.selector), abi.encode());
     }
 }
 


### PR DESCRIPTION
This PR adds full support for creating/reading batches in CP. CV will be in a follow-up PR.

It also set the new architecture to be used by CP and CV in order to process messages and optimize local chain communication. The message flow is the following:

```
                          Send a message ----------------->

pools/PoolManager <-> pools/MessageProcessor <-> common/Gateway <-> common/Adapters

                          <-------------- Receive a message
```

- `PoolManager` will send messages through a `MessageProcessor`. A small contract, easily migrated, that knows how `PoolManager` works and which message it sends and receives. A modification in a message only requires migrating this contract. Vaults will have a homologous for the vaults messages (follow up PR).

- `Gateway` will not be stored in common (factorizing vaults will go in a follow up PR). It contains the common gateway logic, and the logic for batching. Basically, will be the same as `vaults/Gateway` with batching logic and generic enough to work with CP and CV. Will be two deployed instances of this contract, for CP and CV.

- All contracts able to send ongoing messages will implement `IMessageSender`, and all contracts able to handle income message will implement `IMessageHandler`