### PR TITLE
Feat: Legacay Migration Needs - V1

### DIFF
--- a/src/vaults/BalanceSheet.sol
+++ b/src/vaults/BalanceSheet.sol
@@ -214,6 +214,7 @@ contract BalanceSheet is Auth, Recoverable, IBalanceSheet, IBalanceSheetGatewayH
         TransientStorageLib.tstore(keccak256(abi.encode("pricePoolPerShareIsSet", poolId, scId)), true);
     }
     /// @inheritdoc IBalanceSheet
+
     function resetPricePoolPerShare(PoolId poolId, ShareClassId scId) external authOrManager(poolId) {
         TransientStorageLib.tstore(keccak256(abi.encode("pricePoolPerShareIsSet", poolId, scId)), false);
     }

--- a/src/vaults/PoolManager.sol
+++ b/src/vaults/PoolManager.sol
@@ -224,9 +224,8 @@ contract PoolManager is
             shareToken_.file("hook", hook);
         }
 
-        pool.shareClasses[scId].shareToken = shareToken_;
-
-        emit AddShareClass(poolId, scId, shareToken_);
+        // Allows to migrate v2 tokens to v3 by making it a separate step
+        linkShareToken(shareToken_);
     }
 
     /// @inheritdoc IPoolManagerGatewayHandler
@@ -362,6 +361,17 @@ contract PoolManager is
         } else {
             revert UnknownUpdateContractType();
         }
+    }
+
+    /// @inheritdoc IPoolManager
+    function linkShareToken(IShareToken, shareToken_) public auth {
+        // Prevent misconfigured tokens to be linked
+        require(IAuth(shareToken_).wards(address(this)), InvalidShareTokenWards());
+        require(IAuth(shareToken_).wards(balanceSheet), InvalidShareTokenWards());
+
+        pool.shareClasses[scId].shareToken = shareToken_;
+
+        emit AddShareClass(poolId, scId, shareToken_);
     }
 
     /// @inheritdoc IPoolManager

--- a/src/vaults/interfaces/IPoolManager.sol
+++ b/src/vaults/interfaces/IPoolManager.sol
@@ -151,6 +151,7 @@ interface IPoolManager {
     error MalformedVaultUpdateMessage();
     error UnknownToken();
     error InvalidFactory();
+    error InvalidShareTokenWards();
     error InvalidPrice();
     error AssetMissingDecimals();
     error ShareTokenDoesNotExist();

--- a/src/vaults/legacy/LegacyVaultAdapterFactory.sol
+++ b/src/vaults/legacy/LegacyVaultAdapterFactory.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {Auth} from "src/misc/Auth.sol";
+
+import {PoolId} from "src/common/types/PoolId.sol";
+import {ShareClassId} from "src/common/types/ShareClassId.sol";
+
+import {AsyncVault} from "src/vaults/AsyncVault.sol";
+import {IVaultFactory} from "src/vaults/interfaces/factories/IVaultFactory.sol";
+import {IPoolEscrowProvider} from "src/vaults/interfaces/factories/IPoolEscrowFactory.sol";
+import {IShareToken} from "src/vaults/interfaces/token/IShareToken.sol";
+import {IAsyncRequestManager} from "src/vaults/interfaces/investments/IAsyncRequestManager.sol";
+import {IBaseVault} from "src/vaults/interfaces/IBaseVaults.sol";
+import {ILegacyVault} from "src/vaults/legacy/interfaces/ILegacyVault.sol";
+import {LegacyVaultAdapter} from "src/vaults/legacy/LegacyVaultAdapter.sol";
+
+/// @title  ERC7540 Vault Factory
+/// @dev    Utility for deploying new vault contracts
+contract LegacyVaultAdapterFactory is Auth, IVaultFactory {
+    address public immutable root;
+    IAsyncRequestManager public immutable asyncRequestManager;
+
+    mapping(PoolId newPoolId => mapping(ShareClassId newScId => mapping(address asset => ILegacyVault))) legacyVault;
+
+    constructor(address root_, IAsyncRequestManager asyncRequestManager_, address deployer) Auth(deployer) {
+        root = root_;
+        asyncRequestManager = asyncRequestManager_;
+    }
+
+    /// @inheritdoc ILegacyVaultAdapterFactory
+    function addLegacyVault(PoolId newPoolId, ShareClassId newScId, address asset, ILegacyVault legacyVault_)
+        public
+        auth
+    {
+        // All checks for legacy vault adapter setup against asset, poolId, etc. are done in the constructor of
+        // LegacyVaultAdapter
+        legacyVault[newPoolId][newScId][asset] = legacyVault_;
+    }
+
+    /// @inheritdoc IVaultFactory
+    function newVault(
+        PoolId poolId,
+        ShareClassId scId,
+        address asset,
+        uint256 tokenId,
+        IShareToken token,
+        address[] calldata wards_
+    ) public auth returns (IBaseVault) {
+        require(tokenId == 0, UnsupportedTokenId());
+        ILegacyVault legacyVault_ = legacyVault[newPoolId][newScId][asset];
+        require(legacyVault_ != address(0), LegacyVaultNotAdded());
+
+        ILegacyVaultAdapter vault = new LegacyVaultAdapter(
+            legacyVault_,
+            poolId,
+            legacyVault_.poolId(),
+            scId,
+            legacyVault_.trancheId(),
+            asset,
+            token,
+            root,
+            asyncRequestManager
+        );
+
+        vault.rely(root);
+        vault.rely(address(asyncRequestManager));
+        uint256 wardsCount = wards_.length;
+        for (uint256 i; i < wardsCount; i++) {
+            vault.rely(wards_[i]);
+        }
+
+        vault.deny(address(this));
+        return vault;
+    }
+}


### PR DESCRIPTION
Adds
* `LegacyVaultAdapterFactory` so that legacy vaults can be add through the normal flow during a migration
* Cuts out linking of share token so that we can run it during a spell 

Migration process of share tokens and vaults see [notion](https://www.notion.so/Protocol-Feature-Board-19d2eac24e1780ae9be7fb5be82cf430?p=1f52eac24e178099a1aced305d3da058&pm=s)