### PR TITLE
fix: total redeem property

### DIFF
--- a/test/hub/fuzzing/recon-hub/Properties.sol
+++ b/test/hub/fuzzing/recon-hub/Properties.sol
@@ -51,10 +51,10 @@ abstract contract Properties is BeforeAfter, Asserts {
         }
     }
 
-    /// @dev Property: The total pending redeem amount pendingRedeem[..] is always >= the sum of pending user redeem amounts redeemRequest[..]
+    /// @dev Property: The the sum of pending user redeem amounts redeemRequest[..] is always >= total pending redeem amount pendingRedeem[..]
     /// @dev Property: The total pending redeem amount pendingRedeem[..] is always >= the approved redeem amount epochRedeemAmounts[..].approvedShareAmount
     // TODO: come back to this to check if accounting for case is correct
-    function property_total_pending_redeem_geq_sum_pending_user_redeem() public {
+    function property_sum_pending_user_redeem_geq_total_pending_redeem() public {
         address[] memory _actors = _getActors();
 
         for (uint256 i = 0; i < createdPools.length; i++) {
@@ -91,7 +91,7 @@ abstract contract Properties is BeforeAfter, Asserts {
                     // in this case, the totalPendingUserRedeem will be greater than the pendingRedeemCurrent for this epoch 
                     if(claimableAssetAmountPrevious > 0) {
                         // check that the pending redeem is >= the total pending user redeem
-                        gte(pendingRedeemCurrent, totalPendingUserRedeem, "pending redeem is < total pending user redeems");
+                        gte(totalPendingUserRedeem, pendingRedeemCurrent, "total pending user redeems is < pending redeem");
                     }
                 }
                 

--- a/test/integration/recon-end-to-end/CryticToFoundry.sol
+++ b/test/integration/recon-end-to-end/CryticToFoundry.sol
@@ -219,9 +219,9 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
 
     }
 
-    // forge test --match-test test_property_total_pending_redeem_geq_sum_pending_user_redeem_20 -vvv 
+    // forge test --match-test test_property_sum_pending_user_redeem_geq_total_pending_redeem_20 -vvv 
     // NOTE: if a user cancels after a redeem has been approved, the user's pending redeem amount is not updated
-    function test_property_total_pending_redeem_geq_sum_pending_user_redeem_20() public {
+    function test_property_sum_pending_user_redeem_geq_total_pending_redeem_20() public {
 
         shortcut_deployNewTokenPoolAndShare(2,1,true,false,true);
 
@@ -233,7 +233,7 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
 
         shortcut_cancel_redeem_immediately_issue_and_revoke_clamped(1,0,0);
 
-        property_total_pending_redeem_geq_sum_pending_user_redeem();
+        property_sum_pending_user_redeem_geq_total_pending_redeem();
 
     }
 
@@ -432,8 +432,8 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
 
     }
 
-    // forge test --match-test test_property_total_pending_redeem_geq_sum_pending_user_redeem_12 -vvv 
-    function test_property_total_pending_redeem_geq_sum_pending_user_redeem_12() public {
+    // forge test --match-test test_property_sum_pending_user_redeem_geq_total_pending_redeem_12 -vvv 
+    function test_property_sum_pending_user_redeem_geq_total_pending_redeem_12() public {
 
         shortcut_deployNewTokenPoolAndShare(2,1,true,false,true);
 
@@ -441,7 +441,7 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
 
         shortcut_cancel_redeem_clamped(1,0,0);
 
-        property_total_pending_redeem_geq_sum_pending_user_redeem();
+        property_sum_pending_user_redeem_geq_total_pending_redeem();
 
     }
 

--- a/test/integration/recon-end-to-end/properties-table.md
+++ b/test/integration/recon-end-to-end/properties-table.md
@@ -2,13 +2,13 @@
 |----|--------------|---------------------|----------|
 | 1 | hub_depositRequest | after successfully calling requestDeposit for an investor, their depositRequest[..].lastUpdate equals the current nowDepositEpoch | |
 | 2 | hub_depositRequest | _updateDepositRequest should never revert due to underflow | |
-| 3 | hub_depositRequest | The total pending deposit amount pendingDeposit[..] is always >= the sum of pending user deposit amounts depositRequest[..] | |
+| 3 | hub_depositRequest | The sum of pending user deposit amounts depositRequest[..] is always >= the total pending deposit amount pendingDeposit[..] | |
 | 4 | vault_requestDeposit_clamped | After successfully calling requestRedeem for an investor, their redeemRequest[..].lastUpdate equals nowRedeemEpoch | |
 | 5 | vault_requestRedeem_clamped | after successfully calling cancelDepositRequest for an investor, their depositRequest[..].lastUpdate equals the current nowDepositEpoch | |
 | 6 | vault_requestRedeem_clamped | after successfully calling cancelDepositRequest for an investor, their depositRequest[..].pending is zero | |
 | 7 | vault_requestRedeem_clamped | cancelDepositRequest absolute value should never be higher than pendingDeposit (would result in underflow revert) | |
 | 8 | vault_requestRedeem_clamped | _updateDepositRequest should never revert due to underflow | |
-| 9 | vault_requestRedeem_clamped | The total pending deposit amount pendingDeposit[..] is always >= the sum of pending user deposit amounts depositRequest[..] | |
+| 9 | vault_requestRedeem_clamped | The sum of pending user deposit amounts depositRequest[..] is always >= the total pending deposit amount pendingDeposit[..] | |
 | 10 | vault_cancelDepositRequest | After successfully calling cancelRedeemRequest for an investor, their redeemRequest[..].lastUpdate equals the current nowRedeemEpoch | |
 | 11 | vault_cancelDepositRequest | After successfully calling cancelRedeemRequest for an investor, their redeemRequest[..].pending is zero | |
 | 12 | vault_cancelDepositRequest | cancelRedeemRequest absolute value should never be higher than pendingRedeem (would result in underflow revert) | |
@@ -48,9 +48,9 @@
 | 46 | property_actor_pending_and_queued_redemptions | escrow reserved must be >= holding | |
 | 47 | property_escrow_solvency | The price per share used in the entire system is ALWAYS provided by the admin | |
 | 48 | property_price_per_share_overall | The total pending asset amount pendingDeposit[..] is always >= the approved asset epochInvestAmounts[..].approvedAssetAmount | |
-| 49 | property_total_pending_and_approved | The total pending redeem amount pendingRedeem[..] is always >= the sum of pending user redeem amounts redeemRequest[..] | |
+| 49 | property_total_pending_and_approved | The the sum of pending user redeem amounts redeemRequest[..] is always >= total pending redeem amount pendingRedeem[..] | |
 | 50 | property_total_pending_and_approved | The total pending redeem amount pendingRedeem[..] is always >= the approved redeem amount epochRedeemAmounts[..].approvedShareAmount | |
-| 51 | property_total_pending_redeem_geq_sum_pending_user_redeem | The epoch of a pool epochId[poolId] can increase at most by one within the same transaction (i.e. multicall/execute) independent of the number of approvals | |
+| 51 | property_sum_pending_user_redeem_geq_total_pending_redeem | The epoch of a pool epochId[poolId] can increase at most by one within the same transaction (i.e. multicall/execute) independent of the number of approvals | |
 | 52 | property_epochId_can_increase_by_one_within_same_transaction | account.totalDebit and account.totalCredit is always less than uint128(type(int128).max) | |
 | 53 | property_account_totalDebit_and_totalCredit_leq_max_int128 | Any decrease in valuation should not result in an increase in accountValue | |
 | 54 | property_decrease_valuation_no_increase_in_accountValue | Value of Holdings == accountValue(Asset) | |

--- a/test/integration/recon-end-to-end/properties/Properties.sol
+++ b/test/integration/recon-end-to-end/properties/Properties.sol
@@ -553,9 +553,9 @@ abstract contract Properties is BeforeAfter, Asserts, AsyncVaultCentrifugeProper
         gte(pendingDeposit, pendingAssetAmount, "pendingDeposit < pendingAssetAmount");
     }
 
-    /// @dev Property: The total pending redeem amount pendingRedeem[..] is always >= the sum of pending user redeem amounts redeemRequest[..]
+    /// @dev Property: The sum of pending user redeem amounts redeemRequest[..] is always >= total pending redeem amount pendingRedeem[..]
     /// @dev Property: The total pending redeem amount pendingRedeem[..] is always >= the approved redeem amount epochRedeemAmounts[..].approvedShareAmount
-    function property_total_pending_redeem_geq_sum_pending_user_redeem() public {
+    function property_sum_pending_user_redeem_geq_total_pending_redeem() public {
         address[] memory _actors = _getActors();
         IBaseVault vault = IBaseVault(_getVault());
         PoolId poolId = vault.poolId();
@@ -577,15 +577,15 @@ abstract contract Properties is BeforeAfter, Asserts, AsyncVaultCentrifugeProper
         }
         
         // check that the pending redeem is >= the total pending user redeem
-        gte(pendingRedeem, totalPendingUserRedeem, "pending redeem is < total pending user redeems");
+        gte(totalPendingUserRedeem, pendingRedeem, "total pending user redeems is < pending redeem");
         // check that the pending redeem is >= the approved redeem
         gte(pendingRedeem, approvedShareAmount, "pending redeem is < approved redeem");
     }  
 
-    /// @dev Property: The total pending redeem amount pendingRedeem[..] is always >= the sum of pending user redeem amounts redeemRequest[..]
+    /// @dev Property: The sum of pending user redeem amounts redeemRequest[..] is always >= total pending redeem amount pendingRedeem[..]
     /// @dev Property: The total pending redeem amount pendingRedeem[..] is always >= the approved redeem amount epochRedeemAmounts[..].approvedShareAmount
     // NOTE: previous implementation of the above property
-    // function property_total_pending_redeem_geq_sum_pending_user_redeem() public {
+    // function property_sum_pending_user_redeem_geq_total_pending_redeem() public {
     //     address[] memory _actors = _getActors();
     //     IBaseVault vault = IBaseVault(_getVault());
     //     PoolId poolId = vault.poolId();
@@ -619,7 +619,7 @@ abstract contract Properties is BeforeAfter, Asserts, AsyncVaultCentrifugeProper
             
     //         if(payoutAssetAmountPrevious > 0) {
     //             // check that the pending redeem is >= the total pending user redeem
-    //             gte(pendingRedeemCurrent, totalPendingUserRedeem, "pending redeem is < total pending user redeems");
+    //             gte(totalPendingUserRedeem, pendingRedeemCurrent, "total pending user redeems is < pending redeem");
     //         }
     //     }
         


### PR DESCRIPTION
Fixes `test_property_total_pending_redeem_geq_sum_pending_user_redeem_20` on base branch

The error roots in the original invariant property defined by myself which stated
> The total pending {deposit, redeem} amount `pending{Deposit, Redeem}[..]` is always geq the sum of pending user {deposit, redeem} amounts `{deposit, redeem}Request[..]`

However, this statement is correct if you switch `geq` with `leq` (or respectively left and right side of the equation):
> The **sum of pending user {deposit, redeem} amounts `{deposit, redeem}Request[..]`** is always geq the **total pending {deposit, redeem} amount `pending{Deposit, Redeem}[..]`**

I couldn't find the corresponding property for deposits, so I just fixed the redeem code and properties table