### PR TITLE
Ref: split submessage files

### DIFF
--- a/script/adapters/Localhost.s.sol
+++ b/script/adapters/Localhost.s.sol
@@ -11,7 +11,8 @@ import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
 import {AccountId} from "src/common/types/AccountId.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
-import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
 
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 import {SyncDepositVault} from "src/spoke/vaults/SyncDepositVault.sol";
@@ -22,7 +23,7 @@ import {FullDeployer} from "script/FullDeployer.s.sol";
 // Script to deploy Hub and Vaults with a Localhost Adapter.
 contract LocalhostDeployer is FullDeployer {
     using CastLib for *;
-    using MessageLib for *;
+    using UpdateRestrictionMessageLib for *;
 
     function run() public {
         uint16 centrifugeId = uint16(vm.envUint("CENTRIFUGE_ID"));
@@ -122,8 +123,10 @@ contract LocalhostDeployer is FullDeployer {
             poolId,
             scId,
             centrifugeId,
-            MessageLib.UpdateRestrictionMember({user: bytes32(bytes20(msg.sender)), validUntil: type(uint64).max})
-                .serialize()
+            UpdateRestrictionMessageLib.UpdateRestrictionMember({
+                user: bytes32(bytes20(msg.sender)),
+                validUntil: type(uint64).max
+            }).serialize()
         );
 
         // Submit redeem request

--- a/src/common/libraries/MessageLib.sol
+++ b/src/common/libraries/MessageLib.sol
@@ -58,13 +58,6 @@ enum MessageType {
     MaxSharePriceAge
 }
 
-enum UpdateContractType {
-    /// @dev Placeholder for null update restriction type
-    Invalid,
-    Valuation,
-    SyncDepositMaxReserve
-}
-
 /// @dev Used internally in the UpdateVault message (not represent a submessage)
 enum VaultUpdateKind {
     DeployAndLink,
@@ -182,10 +175,6 @@ library MessageLib {
         } else {
             return message.messagePoolId().centrifugeId();
         }
-    }
-
-    function updateContractType(bytes memory message) internal pure returns (UpdateContractType) {
-        return UpdateContractType(message.toUint8(0));
     }
 
     //---------------------------------------
@@ -538,51 +527,6 @@ library MessageLib {
         return abi.encodePacked(
             MessageType.UpdateContract, t.poolId, t.scId, t.target, uint16(t.payload.length), t.payload
         );
-    }
-
-    //---------------------------------------
-    //   UpdateContract.Valuation (submsg)
-    //---------------------------------------
-
-    struct UpdateContractValuation {
-        bytes32 valuation;
-    }
-
-    function deserializeUpdateContractValuation(bytes memory data)
-        internal
-        pure
-        returns (UpdateContractValuation memory)
-    {
-        require(updateContractType(data) == UpdateContractType.Valuation, UnknownMessageType());
-
-        return UpdateContractValuation({valuation: data.toBytes32(1)});
-    }
-
-    function serialize(UpdateContractValuation memory t) internal pure returns (bytes memory) {
-        return abi.encodePacked(UpdateContractType.Valuation, t.valuation);
-    }
-
-    //---------------------------------------
-    //   UpdateContract.SyncDepositMaxReserve (submsg)
-    //---------------------------------------
-
-    struct UpdateContractSyncDepositMaxReserve {
-        uint128 assetId;
-        uint128 maxReserve;
-    }
-
-    function deserializeUpdateContractSyncDepositMaxReserve(bytes memory data)
-        internal
-        pure
-        returns (UpdateContractSyncDepositMaxReserve memory)
-    {
-        require(updateContractType(data) == UpdateContractType.SyncDepositMaxReserve, UnknownMessageType());
-
-        return UpdateContractSyncDepositMaxReserve({assetId: data.toUint128(1), maxReserve: data.toUint128(17)});
-    }
-
-    function serialize(UpdateContractSyncDepositMaxReserve memory t) internal pure returns (bytes memory) {
-        return abi.encodePacked(UpdateContractType.SyncDepositMaxReserve, t.assetId, t.maxReserve);
     }
 
     //---------------------------------------

--- a/src/common/libraries/MessageLib.sol
+++ b/src/common/libraries/MessageLib.sol
@@ -58,14 +58,6 @@ enum MessageType {
     MaxSharePriceAge
 }
 
-enum UpdateRestrictionType {
-    /// @dev Placeholder for null update restriction type
-    Invalid,
-    Member,
-    Freeze,
-    Unfreeze
-}
-
 enum UpdateContractType {
     /// @dev Placeholder for null update restriction type
     Invalid,
@@ -190,10 +182,6 @@ library MessageLib {
         } else {
             return message.messagePoolId().centrifugeId();
         }
-    }
-
-    function updateRestrictionType(bytes memory message) internal pure returns (UpdateRestrictionType) {
-        return UpdateRestrictionType(message.toUint8(0));
     }
 
     function updateContractType(bytes memory message) internal pure returns (UpdateContractType) {
@@ -522,73 +510,6 @@ library MessageLib {
 
     function serialize(UpdateRestriction memory t) internal pure returns (bytes memory) {
         return abi.encodePacked(MessageType.UpdateRestriction, t.poolId, t.scId, uint16(t.payload.length), t.payload);
-    }
-
-    //---------------------------------------
-    //    UpdateRestrictionMember (submsg)
-    //---------------------------------------
-
-    struct UpdateRestrictionMember {
-        bytes32 user;
-        uint64 validUntil;
-    }
-
-    function deserializeUpdateRestrictionMember(bytes memory data)
-        internal
-        pure
-        returns (UpdateRestrictionMember memory)
-    {
-        require(updateRestrictionType(data) == UpdateRestrictionType.Member, UnknownMessageType());
-
-        return UpdateRestrictionMember({user: data.toBytes32(1), validUntil: data.toUint64(33)});
-    }
-
-    function serialize(UpdateRestrictionMember memory t) internal pure returns (bytes memory) {
-        return abi.encodePacked(UpdateRestrictionType.Member, t.user, t.validUntil);
-    }
-
-    //---------------------------------------
-    //    UpdateRestrictionFreeze (submsg)
-    //---------------------------------------
-
-    struct UpdateRestrictionFreeze {
-        bytes32 user;
-    }
-
-    function deserializeUpdateRestrictionFreeze(bytes memory data)
-        internal
-        pure
-        returns (UpdateRestrictionFreeze memory)
-    {
-        require(updateRestrictionType(data) == UpdateRestrictionType.Freeze, UnknownMessageType());
-
-        return UpdateRestrictionFreeze({user: data.toBytes32(1)});
-    }
-
-    function serialize(UpdateRestrictionFreeze memory t) internal pure returns (bytes memory) {
-        return abi.encodePacked(UpdateRestrictionType.Freeze, t.user);
-    }
-
-    //---------------------------------------
-    //    UpdateRestrictionUnfreeze (submsg)
-    //---------------------------------------
-
-    struct UpdateRestrictionUnfreeze {
-        bytes32 user;
-    }
-
-    function deserializeUpdateRestrictionUnfreeze(bytes memory data)
-        internal
-        pure
-        returns (UpdateRestrictionUnfreeze memory)
-    {
-        require(updateRestrictionType(data) == UpdateRestrictionType.Unfreeze, UnknownMessageType());
-
-        return UpdateRestrictionUnfreeze({user: data.toBytes32(1)});
-    }
-
-    function serialize(UpdateRestrictionUnfreeze memory t) internal pure returns (bytes memory) {
-        return abi.encodePacked(UpdateRestrictionType.Unfreeze, t.user);
     }
 
     //---------------------------------------

--- a/src/hooks/FreezeOnly.sol
+++ b/src/hooks/FreezeOnly.sol
@@ -8,7 +8,7 @@ import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
 import {IERC165} from "src/misc/interfaces/IERC7575.sol";
 
 import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {UpdateRestrictionType, MessageLib} from "src/common/libraries/MessageLib.sol";
+import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import {ITransferHook, HookData} from "src/common/interfaces/ITransferHook.sol";
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
@@ -24,7 +24,7 @@ import {IFreezable} from "src/hooks/interfaces/IFreezable.sol";
 /// @dev    The last bit of hookData is used to denote whether the account is frozen.
 contract FreezeOnly is Auth, IFreezable, ITransferHook {
     using BitmapLib for *;
-    using MessageLib for *;
+    using UpdateRestrictionMessageLib for *;
     using BytesLib for bytes;
     using CastLib for bytes32;
 
@@ -92,10 +92,11 @@ contract FreezeOnly is Auth, IFreezable, ITransferHook {
         UpdateRestrictionType updateId = payload.updateRestrictionType();
 
         if (updateId == UpdateRestrictionType.Freeze) {
-            MessageLib.UpdateRestrictionFreeze memory m = payload.deserializeUpdateRestrictionFreeze();
+            UpdateRestrictionMessageLib.UpdateRestrictionFreeze memory m = payload.deserializeUpdateRestrictionFreeze();
             freeze(token, m.user.toAddress());
         } else if (updateId == UpdateRestrictionType.Unfreeze) {
-            MessageLib.UpdateRestrictionUnfreeze memory m = payload.deserializeUpdateRestrictionUnfreeze();
+            UpdateRestrictionMessageLib.UpdateRestrictionUnfreeze memory m =
+                payload.deserializeUpdateRestrictionUnfreeze();
             unfreeze(token, m.user.toAddress());
         } else {
             revert InvalidUpdate();

--- a/src/hooks/FullRestrictions.sol
+++ b/src/hooks/FullRestrictions.sol
@@ -7,7 +7,7 @@ import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
 import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {IERC165} from "src/misc/interfaces/IERC7575.sol";
 
-import {UpdateRestrictionType, MessageLib} from "src/common/libraries/MessageLib.sol";
+import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 import {IRoot} from "src/common/interfaces/IRoot.sol";
 
 import {ITransferHook, HookData, ESCROW_HOOK_ID} from "src/common/interfaces/ITransferHook.sol";
@@ -26,7 +26,7 @@ import {IMemberlist} from "src/hooks/interfaces/IMemberlist.sol";
 ///         the last bit is used to denote whether the account is frozen.
 contract FullRestrictions is Auth, IMemberlist, IFreezable, ITransferHook {
     using BitmapLib for *;
-    using MessageLib for *;
+    using UpdateRestrictionMessageLib for *;
     using BytesLib for bytes;
     using CastLib for bytes32;
 
@@ -103,13 +103,14 @@ contract FullRestrictions is Auth, IMemberlist, IFreezable, ITransferHook {
         UpdateRestrictionType updateId = payload.updateRestrictionType();
 
         if (updateId == UpdateRestrictionType.Member) {
-            MessageLib.UpdateRestrictionMember memory m = payload.deserializeUpdateRestrictionMember();
+            UpdateRestrictionMessageLib.UpdateRestrictionMember memory m = payload.deserializeUpdateRestrictionMember();
             updateMember(token, m.user.toAddress(), m.validUntil);
         } else if (updateId == UpdateRestrictionType.Freeze) {
-            MessageLib.UpdateRestrictionFreeze memory m = payload.deserializeUpdateRestrictionFreeze();
+            UpdateRestrictionMessageLib.UpdateRestrictionFreeze memory m = payload.deserializeUpdateRestrictionFreeze();
             freeze(token, m.user.toAddress());
         } else if (updateId == UpdateRestrictionType.Unfreeze) {
-            MessageLib.UpdateRestrictionUnfreeze memory m = payload.deserializeUpdateRestrictionUnfreeze();
+            UpdateRestrictionMessageLib.UpdateRestrictionUnfreeze memory m =
+                payload.deserializeUpdateRestrictionUnfreeze();
             unfreeze(token, m.user.toAddress());
         } else {
             revert InvalidUpdate();

--- a/src/hooks/RedemptionRestrictions.sol
+++ b/src/hooks/RedemptionRestrictions.sol
@@ -8,7 +8,7 @@ import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
 import {IERC165} from "src/misc/interfaces/IERC7575.sol";
 
 import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {UpdateRestrictionType, MessageLib} from "src/common/libraries/MessageLib.sol";
+import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import {ITransferHook, HookData, ESCROW_HOOK_ID} from "src/common/interfaces/ITransferHook.sol";
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
@@ -27,7 +27,7 @@ import {IMemberlist} from "src/hooks/interfaces/IMemberlist.sol";
 ///         the last bit is used to denote whether the account is frozen.
 contract RedemptionRestrictions is Auth, IMemberlist, IFreezable, ITransferHook {
     using BitmapLib for *;
-    using MessageLib for *;
+    using UpdateRestrictionMessageLib for *;
     using BytesLib for bytes;
     using CastLib for bytes32;
 
@@ -105,13 +105,14 @@ contract RedemptionRestrictions is Auth, IMemberlist, IFreezable, ITransferHook 
         UpdateRestrictionType updateId = payload.updateRestrictionType();
 
         if (updateId == UpdateRestrictionType.Member) {
-            MessageLib.UpdateRestrictionMember memory m = payload.deserializeUpdateRestrictionMember();
+            UpdateRestrictionMessageLib.UpdateRestrictionMember memory m = payload.deserializeUpdateRestrictionMember();
             updateMember(token, m.user.toAddress(), m.validUntil);
         } else if (updateId == UpdateRestrictionType.Freeze) {
-            MessageLib.UpdateRestrictionFreeze memory m = payload.deserializeUpdateRestrictionFreeze();
+            UpdateRestrictionMessageLib.UpdateRestrictionFreeze memory m = payload.deserializeUpdateRestrictionFreeze();
             freeze(token, m.user.toAddress());
         } else if (updateId == UpdateRestrictionType.Unfreeze) {
-            MessageLib.UpdateRestrictionUnfreeze memory m = payload.deserializeUpdateRestrictionUnfreeze();
+            UpdateRestrictionMessageLib.UpdateRestrictionUnfreeze memory m =
+                payload.deserializeUpdateRestrictionUnfreeze();
             unfreeze(token, m.user.toAddress());
         } else {
             revert InvalidUpdate();

--- a/src/hooks/libraries/UpdateRestrictionMessageLib.sol
+++ b/src/hooks/libraries/UpdateRestrictionMessageLib.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
+
+enum UpdateRestrictionType {
+    /// @dev Placeholder for null update restriction type
+    Invalid,
+    Member,
+    Freeze,
+    Unfreeze
+}
+
+library UpdateRestrictionMessageLib {
+    using UpdateRestrictionMessageLib for bytes;
+    using BytesLib for bytes;
+    using CastLib for *;
+
+    error UnknownMessageType();
+
+    function updateRestrictionType(bytes memory message) internal pure returns (UpdateRestrictionType) {
+        return UpdateRestrictionType(message.toUint8(0));
+    }
+
+    //---------------------------------------
+    //    UpdateRestrictionMember (submsg)
+    //---------------------------------------
+
+    struct UpdateRestrictionMember {
+        bytes32 user;
+        uint64 validUntil;
+    }
+
+    function deserializeUpdateRestrictionMember(bytes memory data)
+        internal
+        pure
+        returns (UpdateRestrictionMember memory)
+    {
+        require(updateRestrictionType(data) == UpdateRestrictionType.Member, UnknownMessageType());
+        return UpdateRestrictionMember({user: data.toBytes32(1), validUntil: data.toUint64(33)});
+    }
+
+    function serialize(UpdateRestrictionMember memory t) internal pure returns (bytes memory) {
+        return abi.encodePacked(UpdateRestrictionType.Member, t.user, t.validUntil);
+    }
+
+    //---------------------------------------
+    //    UpdateRestrictionFreeze (submsg)
+    //---------------------------------------
+
+    struct UpdateRestrictionFreeze {
+        bytes32 user;
+    }
+
+    function deserializeUpdateRestrictionFreeze(bytes memory data)
+        internal
+        pure
+        returns (UpdateRestrictionFreeze memory)
+    {
+        require(updateRestrictionType(data) == UpdateRestrictionType.Freeze, UnknownMessageType());
+        return UpdateRestrictionFreeze({user: data.toBytes32(1)});
+    }
+
+    function serialize(UpdateRestrictionFreeze memory t) internal pure returns (bytes memory) {
+        return abi.encodePacked(UpdateRestrictionType.Freeze, t.user);
+    }
+
+    //---------------------------------------
+    //    UpdateRestrictionUnfreeze (submsg)
+    //---------------------------------------
+
+    struct UpdateRestrictionUnfreeze {
+        bytes32 user;
+    }
+
+    function deserializeUpdateRestrictionUnfreeze(bytes memory data)
+        internal
+        pure
+        returns (UpdateRestrictionUnfreeze memory)
+    {
+        require(updateRestrictionType(data) == UpdateRestrictionType.Unfreeze, UnknownMessageType());
+        return UpdateRestrictionUnfreeze({user: data.toBytes32(1)});
+    }
+
+    function serialize(UpdateRestrictionUnfreeze memory t) internal pure returns (bytes memory) {
+        return abi.encodePacked(UpdateRestrictionType.Unfreeze, t.user);
+    }
+}

--- a/src/spoke/Spoke.sol
+++ b/src/spoke/Spoke.sol
@@ -13,7 +13,7 @@ import {Recoverable} from "src/misc/Recoverable.sol";
 import {IERC165} from "src/misc/interfaces/IERC7575.sol";
 import {ReentrancyProtection} from "src/misc/ReentrancyProtection.sol";
 
-import {VaultUpdateKind, MessageLib, UpdateContractType} from "src/common/libraries/MessageLib.sol";
+import {VaultUpdateKind, MessageLib} from "src/common/libraries/MessageLib.sol";
 import {IGateway} from "src/common/interfaces/IGateway.sol";
 import {ISpokeGatewayHandler} from "src/common/interfaces/IGatewayHandlers.sol";
 import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";

--- a/src/spoke/libraries/UpdateContractMessageLib.sol
+++ b/src/spoke/libraries/UpdateContractMessageLib.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "src/misc/libraries/CastLib.sol";
+
+enum UpdateContractType {
+    /// @dev Placeholder for null update restriction type
+    Invalid,
+    Valuation,
+    SyncDepositMaxReserve
+}
+
+library UpdateContractMessageLib {
+    using UpdateContractMessageLib for bytes;
+    using BytesLib for bytes;
+    using CastLib for *;
+
+    error UnknownMessageType();
+
+    function updateContractType(bytes memory message) internal pure returns (UpdateContractType) {
+        return UpdateContractType(message.toUint8(0));
+    }
+
+    //---------------------------------------
+    //   UpdateContract.Valuation (submsg)
+    //---------------------------------------
+
+    struct UpdateContractValuation {
+        bytes32 valuation;
+    }
+
+    function deserializeUpdateContractValuation(bytes memory data)
+        internal
+        pure
+        returns (UpdateContractValuation memory)
+    {
+        require(updateContractType(data) == UpdateContractType.Valuation, UnknownMessageType());
+        return UpdateContractValuation({valuation: data.toBytes32(1)});
+    }
+
+    function serialize(UpdateContractValuation memory t) internal pure returns (bytes memory) {
+        return abi.encodePacked(UpdateContractType.Valuation, t.valuation);
+    }
+
+    //---------------------------------------
+    //   UpdateContract.SyncDepositMaxReserve (submsg)
+    //---------------------------------------
+
+    struct UpdateContractSyncDepositMaxReserve {
+        uint128 assetId;
+        uint128 maxReserve;
+    }
+
+    function deserializeUpdateContractSyncDepositMaxReserve(bytes memory data)
+        internal
+        pure
+        returns (UpdateContractSyncDepositMaxReserve memory)
+    {
+        require(updateContractType(data) == UpdateContractType.SyncDepositMaxReserve, UnknownMessageType());
+        return UpdateContractSyncDepositMaxReserve({assetId: data.toUint128(1), maxReserve: data.toUint128(17)});
+    }
+
+    function serialize(UpdateContractSyncDepositMaxReserve memory t) internal pure returns (bytes memory) {
+        return abi.encodePacked(UpdateContractType.SyncDepositMaxReserve, t.assetId, t.maxReserve);
+    }
+}

--- a/test/common/unit/libraries/MessageLib.t.sol
+++ b/test/common/unit/libraries/MessageLib.t.sol
@@ -261,25 +261,6 @@ contract TestMessageLibIdentities is Test {
         assertEq(a.payload.length, uint8(a.serialize()[a.serialize().messageLength() - a.payload.length - 1]));
     }
 
-    function testUpdateContractValuation(bytes32 valuation) public pure {
-        MessageLib.UpdateContractValuation memory a = MessageLib.UpdateContractValuation({valuation: valuation});
-        MessageLib.UpdateContractValuation memory b = MessageLib.deserializeUpdateContractValuation(a.serialize());
-
-        assertEq(a.valuation, b.valuation);
-        // This message is a submessage and has not static message length defined
-    }
-
-    function testUpdateContractSyncDepositMaxReserve(uint128 assetId, uint128 maxReserve) public pure {
-        MessageLib.UpdateContractSyncDepositMaxReserve memory a =
-            MessageLib.UpdateContractSyncDepositMaxReserve({assetId: assetId, maxReserve: maxReserve});
-        MessageLib.UpdateContractSyncDepositMaxReserve memory b =
-            MessageLib.deserializeUpdateContractSyncDepositMaxReserve(a.serialize());
-
-        assertEq(a.assetId, b.assetId);
-        assertEq(a.maxReserve, b.maxReserve);
-        // This message is a submessage and has not static message length defined
-    }
-
     function testUpdateVault(uint64 poolId, bytes16 scId, bytes32 vaultOrFactory, uint128 assetId, uint8 kind)
         public
         pure

--- a/test/common/unit/libraries/MessageLib.t.sol
+++ b/test/common/unit/libraries/MessageLib.t.sol
@@ -243,35 +243,6 @@ contract TestMessageLibIdentities is Test {
         assertEq(a.payload.length, uint8(a.serialize()[a.serialize().messageLength() - a.payload.length - 1]));
     }
 
-    function testUpdateRestrictionMember(bytes32 user, uint64 validUntil) public pure {
-        MessageLib.UpdateRestrictionMember memory aa =
-            MessageLib.UpdateRestrictionMember({user: user, validUntil: validUntil});
-        MessageLib.UpdateRestrictionMember memory bb = MessageLib.deserializeUpdateRestrictionMember(aa.serialize());
-
-        assertEq(aa.user, bb.user);
-        assertEq(aa.validUntil, bb.validUntil);
-
-        // This message is a submessage and has not static message length defined
-    }
-
-    function testUpdateRestrictionFreeze(bytes32 user) public pure {
-        MessageLib.UpdateRestrictionFreeze memory aa = MessageLib.UpdateRestrictionFreeze({user: user});
-        MessageLib.UpdateRestrictionFreeze memory bb = MessageLib.deserializeUpdateRestrictionFreeze(aa.serialize());
-
-        assertEq(aa.user, bb.user);
-
-        // This message is a submessage and has not static message length defined
-    }
-
-    function testUpdateRestrictionUnfreeze(bytes32 user) public pure {
-        MessageLib.UpdateRestrictionUnfreeze memory aa = MessageLib.UpdateRestrictionUnfreeze({user: user});
-        MessageLib.UpdateRestrictionUnfreeze memory bb = MessageLib.deserializeUpdateRestrictionUnfreeze(aa.serialize());
-
-        assertEq(aa.user, bb.user);
-
-        // This message is a submessage and has not static message length defined
-    }
-
     function testUpdateContract(uint64 poolId, bytes16 scId, bytes32 target, bytes memory payload) public pure {
         MessageLib.UpdateContract memory a =
             MessageLib.UpdateContract({poolId: poolId, scId: scId, target: target, payload: payload});

--- a/test/hooks/unit/libraries/UpdateRestrictionManagerLib.t.sol
+++ b/test/hooks/unit/libraries/UpdateRestrictionManagerLib.t.sol
@@ -22,8 +22,6 @@ contract TestUpdateRestrictionMessageLibIdentities is Test {
 
         assertEq(aa.user, bb.user);
         assertEq(aa.validUntil, bb.validUntil);
-
-        // This message is a submessage and has not static message length defined
     }
 
     function testUpdateRestrictionFreeze(bytes32 user) public pure {
@@ -33,8 +31,6 @@ contract TestUpdateRestrictionMessageLibIdentities is Test {
             UpdateRestrictionMessageLib.deserializeUpdateRestrictionFreeze(aa.serialize());
 
         assertEq(aa.user, bb.user);
-
-        // This message is a submessage and has not static message length defined
     }
 
     function testUpdateRestrictionUnfreeze(bytes32 user) public pure {
@@ -44,7 +40,5 @@ contract TestUpdateRestrictionMessageLibIdentities is Test {
             UpdateRestrictionMessageLib.deserializeUpdateRestrictionUnfreeze(aa.serialize());
 
         assertEq(aa.user, bb.user);
-
-        // This message is a submessage and has not static message length defined
     }
 }

--- a/test/hooks/unit/libraries/UpdateRestrictionManagerLib.t.sol
+++ b/test/hooks/unit/libraries/UpdateRestrictionManagerLib.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {AccountId} from "src/common/types/AccountId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+
+import "forge-std/Test.sol";
+
+// The following tests check that the function composition of deserializing and serializing equals to the identity:
+//       I = deserialize º serialize
+// NOTE. To fully ensure a good testing, use different values for each field.
+contract TestUpdateRestrictionMessageLibIdentities is Test {
+    using UpdateRestrictionMessageLib for *;
+
+    function testUpdateRestrictionMember(bytes32 user, uint64 validUntil) public pure {
+        UpdateRestrictionMessageLib.UpdateRestrictionMember memory aa =
+            UpdateRestrictionMessageLib.UpdateRestrictionMember({user: user, validUntil: validUntil});
+        UpdateRestrictionMessageLib.UpdateRestrictionMember memory bb =
+            UpdateRestrictionMessageLib.deserializeUpdateRestrictionMember(aa.serialize());
+
+        assertEq(aa.user, bb.user);
+        assertEq(aa.validUntil, bb.validUntil);
+
+        // This message is a submessage and has not static message length defined
+    }
+
+    function testUpdateRestrictionFreeze(bytes32 user) public pure {
+        UpdateRestrictionMessageLib.UpdateRestrictionFreeze memory aa =
+            UpdateRestrictionMessageLib.UpdateRestrictionFreeze({user: user});
+        UpdateRestrictionMessageLib.UpdateRestrictionFreeze memory bb =
+            UpdateRestrictionMessageLib.deserializeUpdateRestrictionFreeze(aa.serialize());
+
+        assertEq(aa.user, bb.user);
+
+        // This message is a submessage and has not static message length defined
+    }
+
+    function testUpdateRestrictionUnfreeze(bytes32 user) public pure {
+        UpdateRestrictionMessageLib.UpdateRestrictionUnfreeze memory aa =
+            UpdateRestrictionMessageLib.UpdateRestrictionUnfreeze({user: user});
+        UpdateRestrictionMessageLib.UpdateRestrictionUnfreeze memory bb =
+            UpdateRestrictionMessageLib.deserializeUpdateRestrictionUnfreeze(aa.serialize());
+
+        assertEq(aa.user, bb.user);
+
+        // This message is a submessage and has not static message length defined
+    }
+}

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -19,6 +19,7 @@ import {Guardian} from "src/common/Guardian.sol";
 import {Root} from "src/common/Root.sol";
 import {Gateway} from "src/common/Gateway.sol";
 import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import {Hub} from "src/hub/Hub.sol";
 import {HubRegistry} from "src/hub/HubRegistry.sol";
@@ -219,10 +220,13 @@ contract EndToEndDeployment is Test {
 /// Common and generic utilities ready to be used in different tests
 contract EndToEndUtils is EndToEndDeployment {
     using CastLib for *;
-    using MessageLib for *;
+    using UpdateRestrictionMessageLib for *;
 
     function updateRestrictionMemberMsg(address addr) internal pure returns (bytes memory) {
-        return MessageLib.UpdateRestrictionMember({user: addr.toBytes32(), validUntil: type(uint64).max}).serialize();
+        return UpdateRestrictionMessageLib.UpdateRestrictionMember({
+            user: addr.toBytes32(),
+            validUntil: type(uint64).max
+        }).serialize();
     }
 }
 

--- a/test/spoke/integration/BalanceSheet.t.sol
+++ b/test/spoke/integration/BalanceSheet.t.sol
@@ -7,7 +7,7 @@ import {IAuth} from "src/misc/interfaces/IAuth.sol";
 import {CastLib} from "src/misc/libraries/CastLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
 
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
+import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
 import {ShareClassId} from "src/common/types/ShareClassId.sol";
 import {AssetId} from "src/common/types/AssetId.sol";
@@ -16,7 +16,7 @@ import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
 import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
 
 contract BalanceSheetTest is BaseTest {
-    using MessageLib for *;
+    using UpdateRestrictionMessageLib for *;
     using CastLib for *;
 
     uint128 defaultAmount;
@@ -52,7 +52,10 @@ contract BalanceSheetTest is BaseTest {
         spoke.updateRestriction(
             POOL_A,
             defaultTypedShareClassId,
-            MessageLib.UpdateRestrictionMember({user: address(this).toBytes32(), validUntil: MAX_UINT64}).serialize()
+            UpdateRestrictionMessageLib.UpdateRestrictionMember({
+                user: address(this).toBytes32(),
+                validUntil: MAX_UINT64
+            }).serialize()
         );
     }
 

--- a/test/spoke/mocks/MockCentrifugeChain.sol
+++ b/test/spoke/mocks/MockCentrifugeChain.sol
@@ -9,6 +9,7 @@ import {D18, d18} from "src/misc/types/D18.sol";
 
 import {MessageType, MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
 import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
 import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
@@ -26,6 +27,7 @@ contract MockCentrifugeChain is Test {
     using CastLib for *;
     using MessageLib for *;
     using UpdateRestrictionMessageLib for *;
+    using UpdateContractMessageLib for *;
 
     IAdapter[] public adapters;
     Spoke public spoke;
@@ -79,7 +81,7 @@ contract MockCentrifugeChain is Test {
                 poolId: poolId,
                 scId: scId,
                 target: bytes32(bytes20(address(syncRequestManager))),
-                payload: MessageLib.UpdateContractSyncDepositMaxReserve({
+                payload: UpdateContractMessageLib.UpdateContractSyncDepositMaxReserve({
                     assetId: vaultDetails.assetId.raw(),
                     maxReserve: maxReserve
                 }).serialize()

--- a/test/spoke/mocks/MockCentrifugeChain.sol
+++ b/test/spoke/mocks/MockCentrifugeChain.sol
@@ -8,6 +8,7 @@ import {BytesLib} from "src/misc/libraries/BytesLib.sol";
 import {D18, d18} from "src/misc/types/D18.sol";
 
 import {MessageType, MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 import {IAdapter} from "src/common/interfaces/IAdapter.sol";
 import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
 import {PoolId} from "src/common/types/PoolId.sol";
@@ -24,6 +25,7 @@ interface AdapterLike {
 contract MockCentrifugeChain is Test {
     using CastLib for *;
     using MessageLib for *;
+    using UpdateRestrictionMessageLib for *;
 
     IAdapter[] public adapters;
     Spoke public spoke;
@@ -147,7 +149,7 @@ contract MockCentrifugeChain is Test {
             MessageLib.UpdateRestriction({
                 poolId: poolId,
                 scId: scId,
-                payload: MessageLib.UpdateRestrictionMember(user.toBytes32(), validUntil).serialize()
+                payload: UpdateRestrictionMessageLib.UpdateRestrictionMember(user.toBytes32(), validUntil).serialize()
             }).serialize()
         );
     }
@@ -203,7 +205,7 @@ contract MockCentrifugeChain is Test {
             MessageLib.UpdateRestriction({
                 poolId: poolId,
                 scId: scId,
-                payload: MessageLib.UpdateRestrictionFreeze(user.toBytes32()).serialize()
+                payload: UpdateRestrictionMessageLib.UpdateRestrictionFreeze(user.toBytes32()).serialize()
             }).serialize()
         );
     }
@@ -213,7 +215,7 @@ contract MockCentrifugeChain is Test {
             MessageLib.UpdateRestriction({
                 poolId: poolId,
                 scId: scId,
-                payload: MessageLib.UpdateRestrictionUnfreeze(user.toBytes32()).serialize()
+                payload: UpdateRestrictionMessageLib.UpdateRestrictionUnfreeze(user.toBytes32()).serialize()
             }).serialize()
         );
     }

--- a/test/spoke/unit/libraries/UpdateContractMessageLib.t.sol
+++ b/test/spoke/unit/libraries/UpdateContractMessageLib.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {UpdateContractType, UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import {AccountId} from "src/common/types/AccountId.sol";
+import {AssetId} from "src/common/types/AssetId.sol";
+import {PoolId} from "src/common/types/PoolId.sol";
+
+import "forge-std/Test.sol";
+
+// The following tests check that the function composition of deserializing and serializing equals to the identity:
+//       I = deserialize º serialize
+// NOTE. To fully ensure a good testing, use different values for each field.
+contract TestUpdateContractMessageLibIdentities is Test {
+    using UpdateContractMessageLib for *;
+
+    function testUpdateContractValuation(bytes32 valuation) public pure {
+        UpdateContractMessageLib.UpdateContractValuation memory a =
+            UpdateContractMessageLib.UpdateContractValuation({valuation: valuation});
+        UpdateContractMessageLib.UpdateContractValuation memory b =
+            UpdateContractMessageLib.deserializeUpdateContractValuation(a.serialize());
+
+        assertEq(a.valuation, b.valuation);
+    }
+
+    function testUpdateContractSyncDepositMaxReserve(uint128 assetId, uint128 maxReserve) public pure {
+        UpdateContractMessageLib.UpdateContractSyncDepositMaxReserve memory a =
+            UpdateContractMessageLib.UpdateContractSyncDepositMaxReserve({assetId: assetId, maxReserve: maxReserve});
+        UpdateContractMessageLib.UpdateContractSyncDepositMaxReserve memory b =
+            UpdateContractMessageLib.deserializeUpdateContractSyncDepositMaxReserve(a.serialize());
+
+        assertEq(a.assetId, b.assetId);
+        assertEq(a.maxReserve, b.maxReserve);
+    }
+}


### PR DESCRIPTION
- `UpdateRestriction` submessages moved to `src/hooks/libraries/UpdateRestrictionMessageLib.sol`
- `UpdateContract` submessages moved to `src/spoke/libraries/UpdateContractrMessageLib.sol`

I think this can help a lot for integrators to know the scope of the messages and look for them easily.