### PR TITLE
Ref: Normalize d18.raw

### DIFF
--- a/src/misc/types/D18.sol
+++ b/src/misc/types/D18.sol
@@ -35,11 +35,6 @@ function mulD18(D18 d1, D18 d2) pure returns (D18) {
     return D18.wrap(MathLib.mulDiv(D18.unwrap(d1), D18.unwrap(d2), 1e18).toUint128());
 }
 
-/// @dev sugar for getting the inner representation of a D18
-function inner(D18 d1) pure returns (uint128) {
-    return D18.unwrap(d1);
-}
-
 /// @dev Returns the reciprocal of a D18 decimal, i.e. 1 / d.
 ///      Example: if d = 2.0 (2e18 internally), reciprocal(d) = 0.5 (5e17 internally).
 function reciprocal(D18 d) pure returns (D18) {
@@ -70,7 +65,7 @@ function mulUint256(D18 d, uint256 value, MathLib.Rounding rounding) pure return
 /// - value (integer):  100_000_000_000_000_000_000
 /// - result (integer): 50_000_000_000_000_000_000
 function reciprocalMulUint128(D18 d, uint128 value, MathLib.Rounding rounding) pure returns (uint128) {
-    return MathLib.mulDiv(value, 1e18, d.inner(), rounding).toUint128();
+    return MathLib.mulDiv(value, 1e18, d.raw(), rounding).toUint128();
 }
 
 /// @dev  Divides an integer by a decimal, i.e.
@@ -79,7 +74,7 @@ function reciprocalMulUint128(D18 d, uint128 value, MathLib.Rounding rounding) p
 /// - value (integer):  100_000_000_000_000_000_000
 /// - result (integer): 50_000_000_000_000_000_000
 function reciprocalMulUint256(D18 d, uint256 value, MathLib.Rounding rounding) pure returns (uint256) {
-    return MathLib.mulDiv(value, 1e18, d.inner(), rounding);
+    return MathLib.mulDiv(value, 1e18, d.raw(), rounding);
 }
 
 /// @dev Easy way to construct a decimal number
@@ -104,7 +99,6 @@ using {
     add as +,
     sub as -,
     divD18 as /,
-    inner,
     eq,
     mulD18 as *,
     mulUint128,

--- a/test/hub/integration/Cases.t.sol
+++ b/test/hub/integration/Cases.t.sol
@@ -253,14 +253,14 @@ contract TestCases is BaseTest {
         assertEq(m0.poolId, poolId.raw());
         assertEq(m0.scId, scId.raw());
         assertEq(m0.assetId, EUR_STABLE_C2.raw());
-        assertEq(m0.price, poolPerEurPrice.inner(), "EUR price mismatch");
+        assertEq(m0.price, poolPerEurPrice.raw(), "EUR price mismatch");
         assertEq(m0.timestamp, block.timestamp.toUint64());
 
         MessageLib.NotifyPricePoolPerAsset memory m1 = MessageLib.deserializeNotifyPricePoolPerAsset(cv.popMessage());
         assertEq(m1.poolId, poolId.raw());
         assertEq(m1.scId, scId.raw());
         assertEq(m1.assetId, USDC_C2.raw());
-        assertEq(m1.price, identityPrice.inner(), "USDC price mismatch");
+        assertEq(m1.price, identityPrice.raw(), "USDC price mismatch");
         assertEq(m1.timestamp, block.timestamp.toUint64());
 
         MessageLib.NotifyPricePoolPerShare memory m2 = MessageLib.deserializeNotifyPricePoolPerShare(cv.popMessage());

--- a/test/hub/unit/ShareClassManager.t.sol
+++ b/test/hub/unit/ShareClassManager.t.sol
@@ -264,7 +264,7 @@ contract ShareClassManagerSimpleTest is ShareClassManagerBaseTest {
     function testDefaultGetShareClassNavPerShare() public view {
         (uint128 totalIssuance, D18 navPerShare) = shareClass.metrics(scId);
         assertEq(totalIssuance, 0);
-        assertEq(navPerShare.inner(), 0);
+        assertEq(navPerShare.raw(), 0);
     }
 
     function testExistence() public view {
@@ -334,7 +334,7 @@ contract ShareClassManagerSimpleTest is ShareClassManagerBaseTest {
 
         (uint128 totalIssuance_, D18 navPerShareMetric) = shareClass.metrics(scId);
         assertEq(totalIssuance_, amount);
-        assertEq(navPerShareMetric.inner(), 0, "navPerShare metric should not be updated");
+        assertEq(navPerShareMetric.raw(), 0, "navPerShare metric should not be updated");
     }
 
     function testDecreaseShareClassIssuance(uint128 amount) public {
@@ -345,7 +345,7 @@ contract ShareClassManagerSimpleTest is ShareClassManagerBaseTest {
 
         (uint128 totalIssuance_, D18 navPerShareMetric) = shareClass.metrics(scId);
         assertEq(totalIssuance_, 0, "TotalIssuance should be reset");
-        assertEq(navPerShareMetric.inner(), 0, "navPerShare metric should not be updated");
+        assertEq(navPerShareMetric.raw(), 0, "navPerShare metric should not be updated");
     }
 
     function testMaxDepositClaims() public {
@@ -1544,7 +1544,7 @@ contract ShareClassManagerDepositRedeem is ShareClassManagerBaseTest {
         uint128 redeemApprovedShares
     ) public {
         D18 navPerShareDeposit = d18(uint128(bound(navPerShare_, 1e10, type(uint128).max / 1e18)));
-        D18 navPerShareRedeem = d18(uint128(bound(navPerShare_, 1e10, navPerShareDeposit.inner())));
+        D18 navPerShareRedeem = d18(uint128(bound(navPerShare_, 1e10, navPerShareDeposit.raw())));
         uint128 shares = navPerShareDeposit.reciprocalMulUint128(
             _intoPoolAmount(USDC, MAX_REQUEST_AMOUNT_USDC), MathLib.Rounding.Down
         );
@@ -1599,7 +1599,7 @@ contract ShareClassManagerDepositRedeem is ShareClassManagerBaseTest {
         shareClass.revokeShares(poolId, scId, USDC, epochId - 1, navPerShareRedeem);
         shares -= redeemApprovedShares;
         (, D18 navPerShare) = shareClass.metrics(scId);
-        assertEq(navPerShare.inner(), 0, "Metrics nav should only be set in updateShareClass");
+        assertEq(navPerShare.raw(), 0, "Metrics nav should only be set in updateShareClass");
 
         // Step 2f: Claim deposit and redeem
         epochId += 1;

--- a/test/misc/unit/libraries/D18.t.sol
+++ b/test/misc/unit/libraries/D18.t.sol
@@ -12,14 +12,14 @@ contract D18Test is Test {
         vm.assume(b <= type(uint128).max / 2);
 
         D18 c = d18(a) + d18(b);
-        assertEqDecimal(c.inner(), a + b, 18);
+        assertEqDecimal(c.raw(), a + b, 18);
     }
 
     function testFuzzSub(uint128 a, uint128 b) public pure {
         vm.assume(a >= b);
 
         D18 c = d18(a) - d18(b);
-        assertEqDecimal(c.inner(), a - b, 18);
+        assertEqDecimal(c.raw(), a - b, 18);
     }
 
     function testMulUint128() public pure {
@@ -86,7 +86,7 @@ contract D18Test is Test {
         D18 divisor = d18(uint128(bound(divisor_, 1e4, 1e20)));
         multiplier = uint128(bound(multiplier, 0, type(uint128).max / 1e18));
 
-        uint128 expectedDown = multiplier * 1e18 / divisor.inner();
+        uint128 expectedDown = multiplier * 1e18 / divisor.raw();
         uint128 expectedUp = (multiplier * 1e18 % divisor.raw()) == 0 ? expectedDown : expectedDown + 1;
 
         assertEq(divisor.reciprocalMulUint128(multiplier, MathLib.Rounding.Down), expectedDown);
@@ -105,7 +105,7 @@ contract D18Test is Test {
         D18 divisor = d18(uint128(bound(divisor_, 1e4, 1e20)));
         multiplier = bound(multiplier, 0, type(uint256).max / 1e18);
 
-        uint256 expectedDown = multiplier * 1e18 / divisor.inner();
+        uint256 expectedDown = multiplier * 1e18 / divisor.raw();
         uint256 expectedUp = (multiplier * 1e18 % divisor.raw()) == 0 ? expectedDown : expectedDown + 1;
 
         assertEq(divisor.reciprocalMulUint256(multiplier, MathLib.Rounding.Down), expectedDown);
@@ -116,28 +116,28 @@ contract D18Test is Test {
         D18 left = d18(50e18);
         D18 right = d18(2e19);
 
-        assertEq(mulD18(left, right).inner(), 100e19);
+        assertEq(mulD18(left, right).raw(), 100e19);
     }
 
     function testFuzzMulD18(uint128 left_, uint128 right_) public pure {
         D18 left = d18(uint128(bound(left_, 1, type(uint128).max)));
-        D18 right = d18(uint128(bound(right_, 0, type(uint128).max / left.inner())));
+        D18 right = d18(uint128(bound(right_, 0, type(uint128).max / left.raw())));
 
-        assertEq(mulD18(left, right).inner(), left.inner() * right.inner() / 1e18);
+        assertEq(mulD18(left, right).raw(), left.raw() * right.raw() / 1e18);
     }
 
     function testDivD18() public pure {
         D18 numerator = d18(50e18);
         D18 denominator = d18(2e19);
 
-        assertEq(divD18(numerator, denominator).inner(), 25e17);
+        assertEq(divD18(numerator, denominator).raw(), 25e17);
     }
 
     function testFuzzDivD18(uint128 numerator_, uint128 denominator_) public pure {
         D18 numerator = d18(uint128(bound(numerator_, 1, 1e20)));
         D18 denominator = d18(uint128(bound(denominator_, 1, 1e20)));
 
-        assertEq(divD18(numerator, denominator).inner(), numerator.inner() * 1e18 / denominator.inner());
+        assertEq(divD18(numerator, denominator).raw(), numerator.raw() * 1e18 / denominator.raw());
     }
 
     function testEqD18() public pure {
@@ -164,18 +164,18 @@ contract D18ReciprocalTest is Test {
         D18 result = input.reciprocal();
 
         uint128 expected = 1e36 / val;
-        assertApproxEqAbs(result.inner(), expected, 1, "Reciprocal calculation mismatch");
+        assertApproxEqAbs(result.raw(), expected, 1, "Reciprocal calculation mismatch");
 
         D18 roundTrip = input * result;
         uint128 tolerance = 1e3; // very small relative error (~1e-15)
-        assertApproxEqAbs(roundTrip.inner(), 1e18, tolerance, "Round-trip multiplication failed");
+        assertApproxEqAbs(roundTrip.raw(), 1e18, tolerance, "Round-trip multiplication failed");
     }
 
     /// @dev Explicitly test edge case for reciprocal(1e18) == 1e18
     function testReciprocalOne() public pure {
         D18 one = D18.wrap(1e18);
         D18 result = one.reciprocal();
-        assertEq(result.inner(), 1e18, "Reciprocal of 1e18 should be 1e18");
+        assertEq(result.raw(), 1e18, "Reciprocal of 1e18 should be 1e18");
     }
 
     /// @dev Explicitly test rounding edge cases close to 1
@@ -186,7 +186,7 @@ contract D18ReciprocalTest is Test {
         D18 resultUp = almostOneUp.reciprocal();
         D18 resultDown = almostOneDown.reciprocal();
 
-        assertApproxEqAbs(resultUp.inner(), 1e18 - 1, 1, "Rounding error (upward case)");
-        assertApproxEqAbs(resultDown.inner(), 1e18 + 1, 1, "Rounding error (downward case)");
+        assertApproxEqAbs(resultUp.raw(), 1e18 - 1, 1, "Rounding error (upward case)");
+        assertApproxEqAbs(resultDown.raw(), 1e18 + 1, 1, "Rounding error (downward case)");
     }
 }

--- a/test/misc/unit/libraries/PricingLib.t.sol
+++ b/test/misc/unit/libraries/PricingLib.t.sol
@@ -33,7 +33,7 @@ contract ConvertWithPriceTest is PricingLibBaseTest {
         uint128 baseAmount = 4e10;
         D18 priceQuotePerBase = d18(2e10);
 
-        uint256 expected = priceQuotePerBase.inner() * baseAmount * 10 ** (quoteDecimals - baseDecimals) / 1e18;
+        uint256 expected = priceQuotePerBase.raw() * baseAmount * 10 ** (quoteDecimals - baseDecimals) / 1e18;
 
         assertEq(expected, 8e18);
         assertEq(
@@ -73,10 +73,10 @@ contract ConvertWithPriceTest is PricingLibBaseTest {
 
         uint256 underestimate = price.mulUint256(scaledBase, MathLib.Rounding.Down);
         uint256 expectedDown = MathLib.mulDiv(
-            baseAmount * 10 ** quoteDecimals, price.inner(), 10 ** baseDecimals * 1e18, MathLib.Rounding.Down
+            baseAmount * 10 ** quoteDecimals, price.raw(), 10 ** baseDecimals * 1e18, MathLib.Rounding.Down
         );
         uint256 expectedUp = MathLib.mulDiv(
-            baseAmount * 10 ** quoteDecimals, price.inner(), 10 ** baseDecimals * 1e18, MathLib.Rounding.Up
+            baseAmount * 10 ** quoteDecimals, price.raw(), 10 ** baseDecimals * 1e18, MathLib.Rounding.Up
         );
         uint256 result = PricingLib.convertWithPrice(baseAmount, baseDecimals, quoteDecimals, price);
 
@@ -137,7 +137,7 @@ contract ConvertWithReciprocalPriceTest is PricingLibBaseTest {
         uint128 baseAmount = 8e10;
         D18 priceBasePerQuote = d18(2e10);
 
-        uint256 expected = baseAmount * 10 ** quoteDecimals * 1e18 / (10 ** baseDecimals * priceBasePerQuote.inner());
+        uint256 expected = baseAmount * 10 ** quoteDecimals * 1e18 / (10 ** baseDecimals * priceBasePerQuote.raw());
 
         assertEq(expected, 4e34);
         assertEq(
@@ -177,10 +177,10 @@ contract ConvertWithReciprocalPriceTest is PricingLibBaseTest {
 
         uint256 underestimate = price.reciprocalMulUint256(scaledBase, MathLib.Rounding.Down);
         uint256 expectedDown = MathLib.mulDiv(
-            baseAmount * 10 ** quoteDecimals, 1e18, 10 ** baseDecimals * price.inner(), MathLib.Rounding.Down
+            baseAmount * 10 ** quoteDecimals, 1e18, 10 ** baseDecimals * price.raw(), MathLib.Rounding.Down
         );
         uint256 expectedUp = MathLib.mulDiv(
-            baseAmount * 10 ** quoteDecimals, 1e18, 10 ** baseDecimals * price.inner(), MathLib.Rounding.Up
+            baseAmount * 10 ** quoteDecimals, 1e18, 10 ** baseDecimals * price.raw(), MathLib.Rounding.Up
         );
         uint256 result =
             PricingLib.convertWithReciprocalPrice(baseAmount, baseDecimals, quoteDecimals, price, MathLib.Rounding.Down);
@@ -257,7 +257,7 @@ contract ConvertWithPricesTest is PricingLibBaseTest {
         D18 priceDenominator = d18(8e10);
 
         uint256 expected =
-            priceNumerator.inner() * baseAmount * 10 ** quoteDecimals / (10 ** baseDecimals * priceDenominator.inner());
+            priceNumerator.raw() * baseAmount * 10 ** quoteDecimals / (10 ** baseDecimals * priceDenominator.raw());
 
         assertEq(expected, 1e26);
         assertEq(
@@ -278,7 +278,7 @@ contract ConvertWithPricesTest is PricingLibBaseTest {
         D18 priceDenominator = d18(uint128(bound(priceDenominatorRaw, MIN_PRICE, MAX_PRICE_POOL_PER_ASSET)));
 
         uint256 expected =
-            MathLib.mulDiv(priceNumerator.inner(), baseAmount, priceDenominator.inner(), MathLib.Rounding.Down);
+            MathLib.mulDiv(priceNumerator.raw(), baseAmount, priceDenominator.raw(), MathLib.Rounding.Down);
         uint256 result =
             PricingLib.convertWithPrices(baseAmount, 18, 18, priceNumerator, priceDenominator, MathLib.Rounding.Down);
         assertEq(result, expected);
@@ -305,17 +305,17 @@ contract ConvertWithPricesTest is PricingLibBaseTest {
         }
 
         uint256 underestimate =
-            MathLib.mulDiv(priceNumerator.inner(), scaledBase, priceDenominator.inner(), MathLib.Rounding.Down);
+            MathLib.mulDiv(priceNumerator.raw(), scaledBase, priceDenominator.raw(), MathLib.Rounding.Down);
         uint256 expectedDown = MathLib.mulDiv(
-            priceNumerator.inner(),
+            priceNumerator.raw(),
             baseAmount * 10 ** quoteDecimals,
-            10 ** baseDecimals * priceDenominator.inner(),
+            10 ** baseDecimals * priceDenominator.raw(),
             MathLib.Rounding.Down
         );
         uint256 expectedUp = MathLib.mulDiv(
-            priceNumerator.inner(),
+            priceNumerator.raw(),
             baseAmount * 10 ** quoteDecimals,
-            10 ** baseDecimals * priceDenominator.inner(),
+            10 ** baseDecimals * priceDenominator.raw(),
             MathLib.Rounding.Up
         );
         uint256 result = PricingLib.convertWithPrices(
@@ -414,14 +414,14 @@ contract AssetToShareAmountTest is PricingLibBaseTest {
         );
         uint256 expectedDown = MathLib.mulDiv(
             assetAmount * 10 ** SHARE_DECIMALS,
-            pricePoolPerAsset.inner(),
-            10 ** assetDecimals * pricePoolPerShare.inner(),
+            pricePoolPerAsset.raw(),
+            10 ** assetDecimals * pricePoolPerShare.raw(),
             MathLib.Rounding.Down
         );
         uint256 expectedUp = MathLib.mulDiv(
             assetAmount * 10 ** SHARE_DECIMALS,
-            pricePoolPerAsset.inner(),
-            10 ** assetDecimals * pricePoolPerShare.inner(),
+            pricePoolPerAsset.raw(),
+            10 ** assetDecimals * pricePoolPerShare.raw(),
             MathLib.Rounding.Up
         );
 
@@ -500,14 +500,14 @@ contract ShareToAssetToShareTest is PricingLibBaseTest {
         );
         uint256 expectedDown = MathLib.mulDiv(
             shareAmount * 10 ** assetDecimals,
-            pricePoolPerShare.inner(),
-            10 ** SHARE_DECIMALS * pricePoolPerAsset.inner(),
+            pricePoolPerShare.raw(),
+            10 ** SHARE_DECIMALS * pricePoolPerAsset.raw(),
             MathLib.Rounding.Down
         );
         uint256 expectedUp = MathLib.mulDiv(
             shareAmount * 10 ** assetDecimals,
-            pricePoolPerShare.inner(),
-            10 ** SHARE_DECIMALS * pricePoolPerAsset.inner(),
+            pricePoolPerShare.raw(),
+            10 ** SHARE_DECIMALS * pricePoolPerAsset.raw(),
             MathLib.Rounding.Up
         );
 
@@ -557,10 +557,10 @@ contract PoolToAssetAmountTest is PricingLibBaseTest {
             MathLib.Rounding.Down
         );
         uint256 expectedDown = uint256(poolAmount).mulDiv(
-            10 ** (assetDecimals + 18), 10 ** POOL_DECIMALS * pricePoolPerAsset.inner(), MathLib.Rounding.Down
+            10 ** (assetDecimals + 18), 10 ** POOL_DECIMALS * pricePoolPerAsset.raw(), MathLib.Rounding.Down
         );
         uint256 expectedUp = uint256(poolAmount).mulDiv(
-            10 ** (assetDecimals + 18), 10 ** POOL_DECIMALS * pricePoolPerAsset.inner(), MathLib.Rounding.Up
+            10 ** (assetDecimals + 18), 10 ** POOL_DECIMALS * pricePoolPerAsset.raw(), MathLib.Rounding.Up
         );
 
         uint256 result = PricingLib.poolToAssetAmount(

--- a/test/spoke/integration/SyncDeposit.t.sol
+++ b/test/spoke/integration/SyncDeposit.t.sol
@@ -37,14 +37,10 @@ contract SyncDepositTestHelper is BaseTest {
         syncVault = SyncDepositVault(syncVault_);
 
         centrifugeChain.updatePricePoolPerShare(
-            syncVault.poolId().raw(), syncVault.scId().raw(), pricePoolPerShare.inner(), uint64(block.timestamp)
+            syncVault.poolId().raw(), syncVault.scId().raw(), pricePoolPerShare.raw(), uint64(block.timestamp)
         );
         centrifugeChain.updatePricePoolPerAsset(
-            syncVault.poolId().raw(),
-            syncVault.scId().raw(),
-            assetId,
-            pricePoolPerAsset.inner(),
-            uint64(block.timestamp)
+            syncVault.poolId().raw(), syncVault.scId().raw(), assetId, pricePoolPerAsset.raw(), uint64(block.timestamp)
         );
     }
 

--- a/test/spoke/integration/SyncRequestManager.t.sol
+++ b/test/spoke/integration/SyncRequestManager.t.sol
@@ -34,14 +34,10 @@ contract SyncRequestManagerBaseTest is BaseTest {
         syncVault = SyncDepositVault(syncVault_);
 
         centrifugeChain.updatePricePoolPerShare(
-            syncVault.poolId().raw(), syncVault.scId().raw(), pricePoolPerShare.inner(), uint64(block.timestamp)
+            syncVault.poolId().raw(), syncVault.scId().raw(), pricePoolPerShare.raw(), uint64(block.timestamp)
         );
         centrifugeChain.updatePricePoolPerAsset(
-            syncVault.poolId().raw(),
-            syncVault.scId().raw(),
-            assetId,
-            pricePoolPerAsset.inner(),
-            uint64(block.timestamp)
+            syncVault.poolId().raw(), syncVault.scId().raw(), assetId, pricePoolPerAsset.raw(), uint64(block.timestamp)
         );
     }
 
@@ -202,15 +198,15 @@ contract SyncRequestManagerUnauthorizedTest is SyncRequestManagerBaseTest {
 contract SyncRequestManagerPrices is SyncRequestManagerBaseTest {
     function testPricesWithoutValuation(uint128 pricePoolPerShare_, uint128 pricePoolPerAsset_) public {
         D18 pricePoolPerShare = d18(uint128(bound(pricePoolPerShare_, 1e6, 1e24)));
-        D18 pricePoolPerAsset = d18(uint128(bound(pricePoolPerAsset_, 1e4, pricePoolPerShare.inner())));
+        D18 pricePoolPerAsset = d18(uint128(bound(pricePoolPerAsset_, 1e4, pricePoolPerShare.raw())));
         D18 priceAssetPerShare = pricePoolPerShare / pricePoolPerAsset;
 
         (SyncDepositVault syncVault, uint128 assetId) = _deploySyncDepositVault(pricePoolPerShare, pricePoolPerAsset);
 
         Prices memory prices = syncRequestManager.prices(syncVault.poolId(), syncVault.scId(), AssetId.wrap(assetId));
-        assertEq(prices.assetPerShare.inner(), priceAssetPerShare.inner(), "priceAssetPerShare mismatch");
-        assertEq(prices.poolPerShare.inner(), pricePoolPerShare.inner(), "pricePoolPerShare mismatch");
-        assertEq(prices.poolPerAsset.inner(), pricePoolPerAsset.inner(), "pricePoolPerAsset mismatch");
+        assertEq(prices.assetPerShare.raw(), priceAssetPerShare.raw(), "priceAssetPerShare mismatch");
+        assertEq(prices.poolPerShare.raw(), pricePoolPerShare.raw(), "pricePoolPerShare mismatch");
+        assertEq(prices.poolPerAsset.raw(), pricePoolPerAsset.raw(), "pricePoolPerAsset mismatch");
     }
 }
 
@@ -236,12 +232,12 @@ contract SyncRequestManagerUpdateValuation is SyncRequestManagerBaseTest {
         Prices memory prices = syncRequestManager.prices(syncVault.poolId(), syncVault.scId(), AssetId.wrap(assetId));
 
         D18 pricePost = syncRequestManager.pricePoolPerShare(syncVault.poolId(), syncVault.scId());
-        assertNotEq(prePoolPerShare.inner(), pricePost.inner(), "Price should be changed by valuation");
-        assertEq(expected.poolPerShare.inner(), prices.poolPerShare.inner(), "poolPerShare mismatch");
-        assertEq(expected.poolPerShare.inner(), pricePost.inner(), "poolPerShare vs pricePost mismatch");
+        assertNotEq(prePoolPerShare.raw(), pricePost.raw(), "Price should be changed by valuation");
+        assertEq(expected.poolPerShare.raw(), prices.poolPerShare.raw(), "poolPerShare mismatch");
+        assertEq(expected.poolPerShare.raw(), pricePost.raw(), "poolPerShare vs pricePost mismatch");
 
-        assertEq(expected.poolPerAsset.inner(), prices.poolPerAsset.inner(), "poolPerAsset mismatch");
-        assertEq(expected.assetPerShare.inner(), prices.assetPerShare.inner(), "assetPerShare mismatch");
+        assertEq(expected.poolPerAsset.raw(), prices.poolPerAsset.raw(), "poolPerAsset mismatch");
+        assertEq(expected.assetPerShare.raw(), prices.assetPerShare.raw(), "assetPerShare mismatch");
     }
 
     function testSetValuationERC20() public {
@@ -280,10 +276,10 @@ contract SyncRequestManagerUpdateValuation is SyncRequestManagerBaseTest {
         uint8 multiplier_
     ) public {
         D18 pricePoolPerShare = d18(uint128(bound(pricePoolPerShare_, 1e8, 1e24)));
-        D18 pricePoolPerAsset = d18(uint128(bound(pricePoolPerAsset_, 1e6, pricePoolPerShare.inner())));
+        D18 pricePoolPerAsset = d18(uint128(bound(pricePoolPerAsset_, 1e6, pricePoolPerShare.raw())));
         D18 priceAssetPerShare = pricePoolPerShare / pricePoolPerAsset;
         uint128 multiplier = uint128(bound(multiplier_, 2, 10));
-        vm.assume(priceAssetPerShare.inner() % multiplier == 0);
+        vm.assume(priceAssetPerShare.raw() % multiplier == 0);
 
         (SyncDepositVault syncVault, uint128 assetId) = _deploySyncDepositVault(pricePoolPerShare, pricePoolPerAsset);
         D18 pricePre = syncRequestManager.pricePoolPerShare(syncVault.poolId(), syncVault.scId());
@@ -291,7 +287,7 @@ contract SyncRequestManagerUpdateValuation is SyncRequestManagerBaseTest {
         _setValuation(syncVault, valuation_);
 
         // Change pricePoolPerShare
-        pricePoolPerShare = d18(pricePoolPerShare.inner() * multiplier);
+        pricePoolPerShare = d18(pricePoolPerShare.raw() * multiplier);
         priceAssetPerShare = pricePoolPerShare / pricePoolPerAsset;
 
         // Mock valuation and perform checks


### PR DESCRIPTION
We have in `D18` both `.raw()` and `.inner()` that are exactly the same. I removed `inner()` and I left `raw()` as is the pattern used for other custom defined types