### PR TITLE
ref: switch price param order in shareToAssetAmount

### DIFF
--- a/src/common/libraries/PricingLib.sol
+++ b/src/common/libraries/PricingLib.sol
@@ -94,8 +94,8 @@ library PricingLib {
         uint128 shareAmount,
         address asset,
         uint256 tokenId,
-        D18 pricePoolPerAsset,
         D18 pricePoolPerShare,
+        D18 pricePoolPerAsset,
         MathLib.Rounding rounding
     ) internal view returns (uint128 shares) {
         if (shareAmount == 0 || pricePoolPerShare.raw() == 0 || pricePoolPerAsset.raw() == 0) {
@@ -107,7 +107,7 @@ library PricingLib {
 
         // NOTE: Pool and share denomination are always equal by design
         return PricingLib.shareToAssetAmount(
-            shareAmount, shareDecimals, assetDecimals, pricePoolPerAsset, pricePoolPerShare, rounding
+            shareAmount, shareDecimals, assetDecimals, pricePoolPerShare, pricePoolPerAsset, rounding
         ).toUint128();
     }
 
@@ -232,8 +232,8 @@ library PricingLib {
         uint256 shareAmount,
         uint8 shareDecimals,
         uint8 assetDecimals,
-        D18 pricePoolPerAsset,
         D18 pricePoolPerShare,
+        D18 pricePoolPerAsset,
         MathLib.Rounding rounding
     ) internal pure returns (uint128 assetAmount) {
         return

--- a/src/hub/ShareClassManager.sol
+++ b/src/hub/ShareClassManager.sol
@@ -301,8 +301,8 @@ contract ShareClassManager is Auth, IShareClassManager {
             epochAmounts.approvedShareAmount,
             hubRegistry.decimals(poolId),
             hubRegistry.decimals(payoutAssetId),
-            epochAmounts.pricePoolPerAsset,
             epochAmounts.navPoolPerShare,
+            epochAmounts.pricePoolPerAsset,
             MathLib.Rounding.Down
         );
         revokedShareAmount = epochAmounts.approvedShareAmount;
@@ -496,8 +496,8 @@ contract ShareClassManager is Auth, IShareClassManager {
                 paymentShareAmount,
                 hubRegistry.decimals(poolId),
                 hubRegistry.decimals(payoutAssetId),
-                epochAmounts.pricePoolPerAsset,
                 epochAmounts.navPoolPerShare,
+                epochAmounts.pricePoolPerAsset,
                 MathLib.Rounding.Down
             ).toUint128();
 

--- a/src/vaults/BaseRequestManager.sol
+++ b/src/vaults/BaseRequestManager.sol
@@ -158,8 +158,8 @@ abstract contract BaseRequestManager is Auth, Recoverable, IBaseRequestManager {
             shares.toUint128(),
             vaultDetails.asset,
             vaultDetails.tokenId,
-            pricePoolPerAsset,
             pricePoolPerShare,
+            pricePoolPerAsset,
             rounding
         );
     }

--- a/test/misc/unit/libraries/PricingLib.t.sol
+++ b/test/misc/unit/libraries/PricingLib.t.sol
@@ -480,7 +480,7 @@ contract AssetToShareAmountTest is PricingLibBaseTest {
             assetAmount, assetDecimals, POOL_DECIMALS, pricePoolPerAsset, pricePoolPerShare, MathLib.Rounding.Down
         );
         uint256 assetRoundTrip = PricingLib.shareToAssetAmount(
-            shareAmount, POOL_DECIMALS, assetDecimals, pricePoolPerAsset, pricePoolPerShare, MathLib.Rounding.Down
+            shareAmount, POOL_DECIMALS, assetDecimals, pricePoolPerShare, pricePoolPerAsset, MathLib.Rounding.Down
         );
 
         assertApproxEqAbs(assetRoundTrip, assetAmount, 1e20, "Asset->Share->Asset roundtrip target precision excess");
@@ -513,7 +513,7 @@ contract ShareToAssetToShareTest is PricingLibBaseTest {
         );
 
         uint256 assetAmount = PricingLib.shareToAssetAmount(
-            shareAmount, POOL_DECIMALS, assetDecimals, pricePoolPerAsset, pricePoolPerShare, MathLib.Rounding.Down
+            shareAmount, POOL_DECIMALS, assetDecimals, pricePoolPerShare, pricePoolPerAsset, MathLib.Rounding.Down
         );
         uint256 shareRoundTrip = PricingLib.assetToShareAmount(
             assetAmount, assetDecimals, POOL_DECIMALS, pricePoolPerAsset, pricePoolPerShare, MathLib.Rounding.Down
@@ -560,7 +560,7 @@ contract ShareToAssetToShareTest is PricingLibBaseTest {
         );
 
         uint256 result = PricingLib.shareToAssetAmount(
-            shareAmount, POOL_DECIMALS, assetDecimals, pricePoolPerAsset, pricePoolPerShare, MathLib.Rounding.Down
+            shareAmount, POOL_DECIMALS, assetDecimals, pricePoolPerShare, pricePoolPerAsset, MathLib.Rounding.Down
         );
 
         assertGe(result, underestimate, "shareToAssetAmount should be at least as large as underestimate");
@@ -578,11 +578,11 @@ contract ShareToAssetToShareTest is PricingLibBaseTest {
         assertEq(result, 0, "Zero share amount should return 0");
 
         // Test zero pricePoolPerShare
-        result = PricingLib.shareToAssetAmount(shareToken, 1e18, asset, 0, d18(1e18), d18(0), MathLib.Rounding.Down);
+        result = PricingLib.shareToAssetAmount(shareToken, 1e18, asset, 0, d18(0), d18(1e18), MathLib.Rounding.Down);
         assertEq(result, 0, "Zero pricePoolPerShare should return 0");
 
         // Test zero pricePoolPerAsset
-        result = PricingLib.shareToAssetAmount(shareToken, 1e18, asset, 0, d18(0), d18(1e18), MathLib.Rounding.Down);
+        result = PricingLib.shareToAssetAmount(shareToken, 1e18, asset, 0, d18(1e18), d18(0), MathLib.Rounding.Down);
         assertEq(result, 0, "Zero pricePoolPerAsset should return 0");
 
         // Test all zeros


### PR DESCRIPTION
Follow up from #432 requested by @lemunozm ([ref](https://github.com/centrifuge/protocol-v3/pull/432#issuecomment-2941707773)) which turned out to be smaller than expected, thus not postponed