### PR TITLE
Ref: remove gateway ward from escrow

### DIFF
--- a/script/CommonDeployer.s.sol
+++ b/script/CommonDeployer.s.sol
@@ -60,7 +60,7 @@ abstract contract CommonDeployer is Script, JsonRegistry {
         messageProcessor = new MessageProcessor(root, tokenRecoverer, deployer);
 
         gasService = new GasService(maxBatchSize, messageGasLimit);
-        gateway = new Gateway(root, gasService, deployer);
+        gateway = new Gateway(root, tokenRecoverer, gasService, deployer);
         multiAdapter = new MultiAdapter(centrifugeId, gateway, deployer);
 
         messageDispatcher = new MessageDispatcher(centrifugeId, root, gateway, tokenRecoverer, deployer);
@@ -103,6 +103,7 @@ abstract contract CommonDeployer is Script, JsonRegistry {
         messageProcessor.rely(address(gateway));
         tokenRecoverer.rely(address(messageDispatcher));
         tokenRecoverer.rely(address(messageProcessor));
+        tokenRecoverer.rely(address(gateway));
     }
 
     function _commonFile() private {

--- a/script/SpokeDeployer.s.sol
+++ b/script/SpokeDeployer.s.sol
@@ -186,7 +186,7 @@ contract SpokeDeployer is CommonDeployer {
         balanceSheet.file("gateway", address(gateway));
         balanceSheet.file("poolEscrowProvider", address(poolEscrowFactory));
 
-        poolEscrowFactory.file("gateway", address(gateway));
+        poolEscrowFactory.file("tokenRecoverer", address(tokenRecoverer));
         poolEscrowFactory.file("balanceSheet", address(balanceSheet));
 
         address[] memory tokenWards = new address[](2);

--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "959932",
-  "requestDeposit": "533535"
+  "fulfillDepositRequest": "959985",
+  "requestDeposit": "533557"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "1161874",
+  "claimDeposit": "1161927",
   "enable": "60953",
   "lockDepositRequest": "95607",
-  "requestDeposit": "572494",
-  "requestRedeem": "2110994"
+  "requestDeposit": "572582",
+  "requestRedeem": "2111245"
 }

--- a/src/common/TokenRecoverer.sol
+++ b/src/common/TokenRecoverer.sol
@@ -22,14 +22,21 @@ contract TokenRecoverer is Auth, ITokenRecoverer {
     {
         root.relyContract(address(target), address(this));
 
+        withdrawTokens(target, token, tokenId, to, amount);
+
+        root.denyContract(address(target), address(this));
+
+        emit RecoverTokens(target, token, tokenId, to, amount);
+    }
+
+    function withdrawTokens(IRecoverable target, address token, uint256 tokenId, address to, uint256 amount)
+        public
+        auth
+    {
         if (tokenId == 0) {
             target.recoverTokens(token, to, amount);
         } else {
             target.recoverTokens(token, tokenId, to, amount);
         }
-
-        root.denyContract(address(target), address(this));
-
-        emit RecoverTokens(target, token, tokenId, to, amount);
     }
 }

--- a/src/common/interfaces/ITokenRecoverer.sol
+++ b/src/common/interfaces/ITokenRecoverer.sol
@@ -8,5 +8,9 @@ interface ITokenRecoverer {
         IRecoverable indexed target, address indexed token, uint256 tokenId, address indexed to, uint256 amount
     );
 
+    /// @notice Allow to recover any token from any contract that rely on Root
     function recoverTokens(IRecoverable target, address token, uint256 tokenId, address to, uint256 amount) external;
+
+    /// @notice Allow to withdraw any token from a contract that rely on TokenRecoverer
+    function withdrawTokens(IRecoverable target, address token, uint256 tokenId, address to, uint256 amount) external;
 }

--- a/src/spoke/factories/PoolEscrowFactory.sol
+++ b/src/spoke/factories/PoolEscrowFactory.sol
@@ -12,7 +12,7 @@ import {PoolEscrow} from "src/spoke/Escrow.sol";
 contract PoolEscrowFactory is Auth, IPoolEscrowFactory {
     address public immutable root;
 
-    address public gateway;
+    address public tokenRecoverer;
     address public balanceSheet;
 
     constructor(address root_, address deployer) Auth(deployer) {
@@ -21,7 +21,7 @@ contract PoolEscrowFactory is Auth, IPoolEscrowFactory {
 
     /// @inheritdoc IPoolEscrowFactory
     function file(bytes32 what, address data) external auth {
-        if (what == "gateway") gateway = data;
+        if (what == "tokenRecoverer") tokenRecoverer = data;
         else if (what == "balanceSheet") balanceSheet = data;
         else revert FileUnrecognizedParam();
         emit File(what, data);
@@ -32,7 +32,7 @@ contract PoolEscrowFactory is Auth, IPoolEscrowFactory {
         PoolEscrow escrow_ = new PoolEscrow{salt: bytes32(uint256(poolId.raw()))}(poolId, address(this));
 
         escrow_.rely(root);
-        escrow_.rely(gateway);
+        escrow_.rely(tokenRecoverer);
         escrow_.rely(balanceSheet);
 
         escrow_.deny(address(this));

--- a/test/spoke/unit/factories/PoolEscrowFactory.t.sol
+++ b/test/spoke/unit/factories/PoolEscrowFactory.t.sol
@@ -16,13 +16,13 @@ contract PoolEscrowFactoryTest is Test {
 
     address deployer = address(this);
     address root = makeAddr("root");
-    address gateway = makeAddr("gateway");
+    address tokenRecoverer = makeAddr("tokenRecoverer");
     address balanceSheet = makeAddr("balanceSheet");
     address randomUser = makeAddr("randomUser");
 
     function setUp() public {
         factory = new PoolEscrowFactory(root, deployer);
-        factory.file("gateway", gateway);
+        factory.file("tokenRecoverer", tokenRecoverer);
         factory.file("balanceSheet", balanceSheet);
     }
 
@@ -40,13 +40,13 @@ contract PoolEscrowFactoryTest is Test {
     }
 
     function testEscrowHasCorrectPermissions(PoolId poolId, address nonWard) public {
-        vm.assume(nonWard != root && nonWard != gateway && nonWard != balanceSheet);
+        vm.assume(nonWard != root && nonWard != tokenRecoverer && nonWard != balanceSheet);
         address escrowAddr = address(factory.newEscrow(poolId));
 
         PoolEscrow escrow = PoolEscrow(payable(escrowAddr));
 
         assertEq(escrow.wards(root), 1, "root not authorized");
-        assertEq(escrow.wards(gateway), 1, "gateway not authorized");
+        assertEq(escrow.wards(tokenRecoverer), 1, "tokenRecoverer not authorized");
         assertEq(escrow.wards(balanceSheet), 1, "balanceSheet not authorized");
 
         assertEq(escrow.wards(address(factory)), 0, "factory still authorized");


### PR DESCRIPTION
Thread: https://kflabs.slack.com/archives/C04HF8SHRRC/p1749645728300619?thread_ts=1748869090.686359&cid=C04HF8SHRRC

The `gateway` ward from escrow is highly migratable, instead `tokenRecoverer` is an immutable contract that should never be migrated.

NOTE: I would like to create an EndToEnd with the whole refunding cycle, it is:

1. Sending an overpaid message
2. Get the PoolEscrow refunded
3. Send a second message to reuse those funds.

In this PR or in a follow one