### PR TITLE
Typed hooks

### DIFF
--- a/script/HooksDeployer.s.sol
+++ b/script/HooksDeployer.s.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-
 import {Spoke} from "src/spoke/Spoke.sol";
 
 import {FreezeOnly} from "src/hooks/FreezeOnly.sol";
@@ -16,36 +14,36 @@ import "forge-std/Script.sol";
 
 struct HooksReport {
     SpokeReport spoke;
-    address freezeOnlyHook;
-    address redemptionRestrictionsHook;
-    address fullRestrictionsHook;
+    FreezeOnly freezeOnlyHook;
+    FullRestrictions fullRestrictionsHook;
+    RedemptionRestrictions redemptionRestrictionsHook;
 }
 
 contract HooksActionBatcher is SpokeActionBatcher {
     function engageHooks(HooksReport memory report) public unlocked {
         // Rely Spoke
-        IAuth(report.freezeOnlyHook).rely(address(report.spoke.spoke));
-        IAuth(report.fullRestrictionsHook).rely(address(report.spoke.spoke));
-        IAuth(report.redemptionRestrictionsHook).rely(address(report.spoke.spoke));
+        report.freezeOnlyHook.rely(address(report.spoke.spoke));
+        report.fullRestrictionsHook.rely(address(report.spoke.spoke));
+        report.redemptionRestrictionsHook.rely(address(report.spoke.spoke));
 
         // Rely Root
-        IAuth(report.freezeOnlyHook).rely(address(report.spoke.common.root));
-        IAuth(report.fullRestrictionsHook).rely(address(report.spoke.common.root));
-        IAuth(report.redemptionRestrictionsHook).rely(address(report.spoke.common.root));
+        report.freezeOnlyHook.rely(address(report.spoke.common.root));
+        report.fullRestrictionsHook.rely(address(report.spoke.common.root));
+        report.redemptionRestrictionsHook.rely(address(report.spoke.common.root));
     }
 
     function revokeHooks(HooksReport memory report) public unlocked {
-        IAuth(report.freezeOnlyHook).deny(address(this));
-        IAuth(report.fullRestrictionsHook).deny(address(this));
-        IAuth(report.redemptionRestrictionsHook).deny(address(this));
+        report.freezeOnlyHook.deny(address(this));
+        report.fullRestrictionsHook.deny(address(this));
+        report.redemptionRestrictionsHook.deny(address(this));
     }
 }
 
 contract HooksDeployer is SpokeDeployer {
     // TODO: Add typed interfaces instead of addresses (only current reason is avoid test refactor)
-    address public freezeOnlyHook;
-    address public redemptionRestrictionsHook;
-    address public fullRestrictionsHook;
+    FreezeOnly public freezeOnlyHook;
+    FullRestrictions public fullRestrictionsHook;
+    RedemptionRestrictions public redemptionRestrictionsHook;
 
     function deployHooks(CommonInput memory input, HooksActionBatcher batcher) public {
         _preDeployHooks(input, batcher);
@@ -55,19 +53,25 @@ contract HooksDeployer is SpokeDeployer {
     function _preDeployHooks(CommonInput memory input, HooksActionBatcher batcher) internal {
         _preDeploySpoke(input, batcher);
 
-        freezeOnlyHook = create3(
-            generateSalt("freezeOnlyHook"),
-            abi.encodePacked(type(FreezeOnly).creationCode, abi.encode(address(root), batcher))
+        freezeOnlyHook = FreezeOnly(
+            create3(
+                generateSalt("freezeOnlyHook"),
+                abi.encodePacked(type(FreezeOnly).creationCode, abi.encode(address(root), batcher))
+            )
         );
 
-        fullRestrictionsHook = create3(
-            generateSalt("fullRestrictionsHook"),
-            abi.encodePacked(type(FullRestrictions).creationCode, abi.encode(address(root), batcher))
+        fullRestrictionsHook = FullRestrictions(
+            create3(
+                generateSalt("fullRestrictionsHook"),
+                abi.encodePacked(type(FullRestrictions).creationCode, abi.encode(address(root), batcher))
+            )
         );
 
-        redemptionRestrictionsHook = create3(
-            generateSalt("redemptionRestrictionsHook"),
-            abi.encodePacked(type(RedemptionRestrictions).creationCode, abi.encode(address(root), batcher))
+        redemptionRestrictionsHook = RedemptionRestrictions(
+            create3(
+                generateSalt("redemptionRestrictionsHook"),
+                abi.encodePacked(type(RedemptionRestrictions).creationCode, abi.encode(address(root), batcher))
+            )
         );
 
         batcher.engageHooks(_hooksReport());
@@ -88,6 +92,6 @@ contract HooksDeployer is SpokeDeployer {
     }
 
     function _hooksReport() internal view returns (HooksReport memory) {
-        return HooksReport(_spokeReport(), freezeOnlyHook, redemptionRestrictionsHook, fullRestrictionsHook);
+        return HooksReport(_spokeReport(), freezeOnlyHook, fullRestrictionsHook, redemptionRestrictionsHook);
     }
 }

--- a/script/HooksDeployer.s.sol
+++ b/script/HooksDeployer.s.sol
@@ -40,7 +40,6 @@ contract HooksActionBatcher is SpokeActionBatcher {
 }
 
 contract HooksDeployer is SpokeDeployer {
-    // TODO: Add typed interfaces instead of addresses (only current reason is avoid test refactor)
     FreezeOnly public freezeOnlyHook;
     FullRestrictions public fullRestrictionsHook;
     RedemptionRestrictions public redemptionRestrictionsHook;

--- a/script/TestData.s.sol
+++ b/script/TestData.s.sol
@@ -28,6 +28,7 @@ import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
 import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
 import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
 
+import {RedemptionRestrictions} from "src/hooks/RedemptionRestrictions.sol";
 import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import {FullDeployer} from "script/FullDeployer.s.sol";
@@ -55,7 +56,8 @@ contract LocalhostDeployer is FullDeployer {
         spoke = Spoke(vm.parseJsonAddress(config, "$.contracts.spoke"));
         hub = Hub(vm.parseJsonAddress(config, "$.contracts.hub"));
         shareClassManager = ShareClassManager(vm.parseJsonAddress(config, "$.contracts.shareClassManager"));
-        redemptionRestrictionsHook = vm.parseJsonAddress(config, "$.contracts.redemptionRestrictionsHook");
+        redemptionRestrictionsHook =
+            RedemptionRestrictions(vm.parseJsonAddress(config, "$.contracts.redemptionRestrictionsHook"));
         identityValuation = IdentityValuation(vm.parseJsonAddress(config, "$.contracts.identityValuation"));
         asyncVaultFactory = AsyncVaultFactory(vm.parseJsonAddress(config, "$.contracts.asyncVaultFactory"));
         syncDepositVaultFactory =
@@ -94,7 +96,7 @@ contract LocalhostDeployer is FullDeployer {
         hub.setPoolMetadata(poolId, bytes("Testing pool"));
         hub.addShareClass(poolId, "Tokenized MMF", "MMF", bytes32(bytes("1")));
         hub.notifyPool(poolId, centrifugeId);
-        hub.notifyShareClass(poolId, scId, centrifugeId, bytes32(bytes20(redemptionRestrictionsHook)));
+        hub.notifyShareClass(poolId, scId, centrifugeId, address(redemptionRestrictionsHook).toBytes32());
 
         hub.setRequestManager(poolId, scId, assetId, address(asyncRequestManager).toBytes32());
         hub.updateBalanceSheetManager(centrifugeId, poolId, address(asyncRequestManager).toBytes32(), true);
@@ -220,7 +222,7 @@ contract LocalhostDeployer is FullDeployer {
         hub.setPoolMetadata(poolId, bytes("Testing pool"));
         hub.addShareClass(poolId, "RWA Portfolio", "RWA", bytes32(bytes("2")));
         hub.notifyPool(poolId, centrifugeId);
-        hub.notifyShareClass(poolId, scId, centrifugeId, bytes32(bytes20(redemptionRestrictionsHook)));
+        hub.notifyShareClass(poolId, scId, centrifugeId, address(redemptionRestrictionsHook).toBytes32());
 
         hub.setRequestManager(poolId, scId, assetId, address(asyncRequestManager).toBytes32());
         hub.updateBalanceSheetManager(centrifugeId, poolId, address(asyncRequestManager).toBytes32(), true);

--- a/test/hooks/Deployment.t.sol
+++ b/test/hooks/Deployment.t.sol
@@ -3,8 +3,6 @@ pragma solidity 0.8.28;
 
 import {IAuth} from "src/misc/interfaces/IAuth.sol";
 
-import {FreezeOnly} from "src/hooks/FreezeOnly.sol";
-
 import {HooksDeployer, HooksActionBatcher} from "script/HooksDeployer.s.sol";
 
 import {CommonDeploymentInputTest} from "test/common/Deployment.t.sol";
@@ -28,7 +26,7 @@ contract VaultsDeploymentTest is HooksDeployer, CommonDeploymentInputTest {
         assertEq(IAuth(freezeOnlyHook).wards(nonWard), 0);
 
         // dependencies set correctly
-        assertEq(address(FreezeOnly(freezeOnlyHook).root()), address(root));
+        assertEq(address(freezeOnlyHook.root()), address(root));
     }
 
     function testRedemptionRestriction(address nonWard) public view {
@@ -36,12 +34,12 @@ contract VaultsDeploymentTest is HooksDeployer, CommonDeploymentInputTest {
         vm.assume(nonWard != address(root));
         vm.assume(nonWard != address(spoke));
 
-        assertEq(IAuth(redemptionRestrictionsHook).wards(address(root)), 1);
-        assertEq(IAuth(redemptionRestrictionsHook).wards(address(spoke)), 1);
-        assertEq(IAuth(redemptionRestrictionsHook).wards(nonWard), 0);
+        assertEq(redemptionRestrictionsHook.wards(address(root)), 1);
+        assertEq(redemptionRestrictionsHook.wards(address(spoke)), 1);
+        assertEq(redemptionRestrictionsHook.wards(nonWard), 0);
 
         // dependencies set correctly
-        assertEq(address(FreezeOnly(redemptionRestrictionsHook).root()), address(root));
+        assertEq(address(redemptionRestrictionsHook.root()), address(root));
     }
 
     function testFullRestriction(address nonWard) public view {
@@ -54,6 +52,6 @@ contract VaultsDeploymentTest is HooksDeployer, CommonDeploymentInputTest {
         assertEq(IAuth(fullRestrictionsHook).wards(nonWard), 0);
 
         // dependencies set correctly
-        assertEq(address(FreezeOnly(fullRestrictionsHook).root()), address(root));
+        assertEq(address(fullRestrictionsHook.root()), address(root));
     }
 }

--- a/test/hooks/integration/FreelyTransferable.t.sol
+++ b/test/hooks/integration/FreelyTransferable.t.sol
@@ -15,8 +15,9 @@ contract RedemptionRestrictionsTest is BaseTest {
     function testRedemptionRestrictionsHook(uint256 amount) public {
         amount = uint128(bound(amount, 2, MAX_UINT128 / 2));
 
-        (, address vault_, uint128 assetId) =
-            deployVault(VaultKind.Async, 6, redemptionRestrictionsHook, bytes16(bytes("1")), address(erc20), 0, 0);
+        (, address vault_, uint128 assetId) = deployVault(
+            VaultKind.Async, 6, address(redemptionRestrictionsHook), bytes16(bytes("1")), address(erc20), 0, 0
+        );
         AsyncVault vault = AsyncVault(vault_);
         RedemptionRestrictions hook = RedemptionRestrictions(redemptionRestrictionsHook);
         IShareToken shareToken = IShareToken(address(vault.share()));

--- a/test/managers/integration/MerkleProofManager.t.sol
+++ b/test/managers/integration/MerkleProofManager.t.sol
@@ -51,7 +51,7 @@ abstract contract MerkleProofManagerBaseTest is BaseTest {
             "tsc",
             defaultDecimals,
             bytes32(""),
-            fullRestrictionsHook
+            address(fullRestrictionsHook)
         );
         spoke.updatePricePoolPerShare(
             POOL_A, defaultTypedShareClassId, defaultPricePoolPerShare.raw(), uint64(block.timestamp)

--- a/test/managers/integration/OnOfframpManager.t.sol
+++ b/test/managers/integration/OnOfframpManager.t.sol
@@ -53,7 +53,7 @@ abstract contract OnOfframpManagerBaseTest is BaseTest {
             "tsc",
             defaultDecimals,
             bytes32(""),
-            fullRestrictionsHook
+            address(fullRestrictionsHook)
         );
         spoke.updatePricePoolPerShare(
             POOL_A, defaultTypedShareClassId, defaultPricePoolPerShare.raw(), uint64(block.timestamp)

--- a/test/spoke/BaseTest.sol
+++ b/test/spoke/BaseTest.sol
@@ -226,8 +226,9 @@ contract BaseTest is ExtendedSpokeDeployer, Test, ExtendedSpokeActionBatcher {
         public
         returns (uint64 poolId, address vaultAddress, uint128 assetId)
     {
-        return
-            deployVault(vaultKind, decimals, fullRestrictionsHook, scId, address(erc20), erc20TokenId, OTHER_CHAIN_ID);
+        return deployVault(
+            vaultKind, decimals, address(fullRestrictionsHook), scId, address(erc20), erc20TokenId, OTHER_CHAIN_ID
+        );
     }
 
     function deploySimpleVault(VaultKind vaultKind)
@@ -235,7 +236,13 @@ contract BaseTest is ExtendedSpokeDeployer, Test, ExtendedSpokeActionBatcher {
         returns (uint64 poolId, address vaultAddress, uint128 assetId)
     {
         return deployVault(
-            vaultKind, 6, fullRestrictionsHook, bytes16(bytes("1")), address(erc20), erc20TokenId, OTHER_CHAIN_ID
+            vaultKind,
+            6,
+            address(fullRestrictionsHook),
+            bytes16(bytes("1")),
+            address(erc20),
+            erc20TokenId,
+            OTHER_CHAIN_ID
         );
     }
 

--- a/test/spoke/integration/AssetShareConversion.t.sol
+++ b/test/spoke/integration/AssetShareConversion.t.sol
@@ -9,8 +9,9 @@ contract AssetShareConversionTest is BaseTest {
         uint8 SHARE_TOKEN_DECIMALS = 18; // Like DAI
 
         ERC20 asset = _newErc20("Asset", "A", INVESTMENT_CURRENCY_DECIMALS);
-        (uint64 poolId, address vault_, uint128 assetId) =
-            deployVault(VaultKind.Async, SHARE_TOKEN_DECIMALS, fullRestrictionsHook, scId, address(asset), 0, 0);
+        (uint64 poolId, address vault_, uint128 assetId) = deployVault(
+            VaultKind.Async, SHARE_TOKEN_DECIMALS, address(fullRestrictionsHook), scId, address(asset), 0, 0
+        );
         AsyncVault vault = AsyncVault(vault_);
         IShareToken shareToken = IShareToken(address(AsyncVault(vault_).share()));
 
@@ -74,8 +75,9 @@ contract AssetShareConversionTest is BaseTest {
         uint8 SHARE_TOKEN_DECIMALS = 6; // Like USDC
 
         ERC20 asset = _newErc20("Currency", "CR", INVESTMENT_CURRENCY_DECIMALS);
-        (uint64 poolId, address vault_, uint128 assetId) =
-            deployVault(VaultKind.Async, SHARE_TOKEN_DECIMALS, fullRestrictionsHook, scId, address(asset), 0, 0);
+        (uint64 poolId, address vault_, uint128 assetId) = deployVault(
+            VaultKind.Async, SHARE_TOKEN_DECIMALS, address(fullRestrictionsHook), scId, address(asset), 0, 0
+        );
         AsyncVault vault = AsyncVault(vault_);
         IShareToken shareToken = IShareToken(address(AsyncVault(vault_).share()));
         centrifugeChain.updatePricePoolPerShare(poolId, scId, 1000000, uint64(block.timestamp));
@@ -118,8 +120,9 @@ contract AssetShareConversionTest is BaseTest {
         uint8 SHARE_TOKEN_DECIMALS = 18; // Like DAI
 
         ERC20 asset = _newErc20("Asset", "A", INVESTMENT_CURRENCY_DECIMALS);
-        (uint64 poolId, address vault_, uint128 assetId) =
-            deployVault(VaultKind.Async, SHARE_TOKEN_DECIMALS, fullRestrictionsHook, scId, address(asset), 0, 0);
+        (uint64 poolId, address vault_, uint128 assetId) = deployVault(
+            VaultKind.Async, SHARE_TOKEN_DECIMALS, address(fullRestrictionsHook), scId, address(asset), 0, 0
+        );
         AsyncVault vault = AsyncVault(vault_);
         IShareToken(address(vault.share()));
 

--- a/test/spoke/integration/Deposit.t.sol
+++ b/test/spoke/integration/Deposit.t.sol
@@ -173,7 +173,13 @@ contract DepositTest is BaseTest {
 
         ERC20 asset = _newErc20("Currency", "CR", INVESTMENT_CURRENCY_DECIMALS);
         (uint64 poolId, address vault_, uint128 assetId) = deployVault(
-            VaultKind.Async, SHARE_TOKEN_DECIMALS, fullRestrictionsHook, bytes16(bytes("1")), address(asset), 0, 0
+            VaultKind.Async,
+            SHARE_TOKEN_DECIMALS,
+            address(fullRestrictionsHook),
+            bytes16(bytes("1")),
+            address(asset),
+            0,
+            0
         );
         AsyncVault vault = AsyncVault(vault_);
         centrifugeChain.updatePricePoolPerShare(
@@ -443,7 +449,13 @@ contract DepositTest is BaseTest {
 
         ERC20 asset = _newErc20("Currency", "CR", INVESTMENT_CURRENCY_DECIMALS);
         (uint64 poolId, address vault_, uint128 assetId) = deployVault(
-            VaultKind.Async, SHARE_TOKEN_DECIMALS, fullRestrictionsHook, bytes16(bytes("1")), address(asset), 0, 0
+            VaultKind.Async,
+            SHARE_TOKEN_DECIMALS,
+            address(fullRestrictionsHook),
+            bytes16(bytes("1")),
+            address(asset),
+            0,
+            0
         );
         AsyncVault vault = AsyncVault(vault_);
         centrifugeChain.updatePricePoolPerShare(
@@ -510,7 +522,7 @@ contract DepositTest is BaseTest {
     function testDepositAndRedeemPrecisionWithInverseDecimals(bytes16 scId) public {
         ERC20 asset = _newErc20("Currency", "CR", 18);
         (uint64 poolId, address vault_, uint128 assetId) =
-            deployVault(VaultKind.Async, 6, fullRestrictionsHook, scId, address(asset), 0, 0);
+            deployVault(VaultKind.Async, 6, address(fullRestrictionsHook), scId, address(asset), 0, 0);
         AsyncVault vault = AsyncVault(vault_);
         IShareToken shareToken = IShareToken(address(vault.share()));
         centrifugeChain.updatePricePoolPerShare(poolId, scId, 1000000000000000000000000000, uint64(block.timestamp));
@@ -581,8 +593,9 @@ contract DepositTest is BaseTest {
         uint8 SHARE_TOKEN_DECIMALS = 18; // Like DAI
 
         ERC20 asset = _newErc20("Currency", "CR", INVESTMENT_CURRENCY_DECIMALS);
-        (uint64 poolId, address vault_, uint128 assetId) =
-            deployVault(VaultKind.Async, SHARE_TOKEN_DECIMALS, fullRestrictionsHook, scId, address(asset), 0, 0);
+        (uint64 poolId, address vault_, uint128 assetId) = deployVault(
+            VaultKind.Async, SHARE_TOKEN_DECIMALS, address(fullRestrictionsHook), scId, address(asset), 0, 0
+        );
         AsyncVault vault = AsyncVault(vault_);
 
         // price = (100*10**18) /  (99 * 10**18) = 101.010101 * 10**18
@@ -620,8 +633,9 @@ contract DepositTest is BaseTest {
         uint8 SHARE_TOKEN_DECIMALS = 6; // Like USDC
 
         ERC20 asset = _newErc20("Currency", "CR", INVESTMENT_CURRENCY_DECIMALS);
-        (uint64 poolId, address vault_, uint128 assetId) =
-            deployVault(VaultKind.Async, SHARE_TOKEN_DECIMALS, fullRestrictionsHook, scId, address(asset), 0, 0);
+        (uint64 poolId, address vault_, uint128 assetId) = deployVault(
+            VaultKind.Async, SHARE_TOKEN_DECIMALS, address(fullRestrictionsHook), scId, address(asset), 0, 0
+        );
         AsyncVault vault = AsyncVault(vault_);
 
         // price = (100*10**18) /  (99 * 10**18) = 101.010101 * 10**18

--- a/test/spoke/integration/DepositRedeem.t.sol
+++ b/test/spoke/integration/DepositRedeem.t.sol
@@ -11,8 +11,9 @@ contract DepositRedeem is BaseTest {
         uint8 INVESTMENT_CURRENCY_DECIMALS = 6; // 6, like USDC
 
         ERC20 asset = _newErc20("Currency", "CR", INVESTMENT_CURRENCY_DECIMALS);
-        (uint64 poolId, address vault_, uint128 assetId) =
-            deployVault(VaultKind.Async, SHARE_TOKEN_DECIMALS, fullRestrictionsHook, scId, address(asset), 0, 0);
+        (uint64 poolId, address vault_, uint128 assetId) = deployVault(
+            VaultKind.Async, SHARE_TOKEN_DECIMALS, address(fullRestrictionsHook), scId, address(asset), 0, 0
+        );
         AsyncVault vault = AsyncVault(vault_);
 
         centrifugeChain.updatePricePoolPerShare(poolId, scId, 1e18, uint64(block.timestamp));

--- a/test/spoke/integration/Spoke.t.sol
+++ b/test/spoke/integration/Spoke.t.sol
@@ -438,7 +438,7 @@ contract SpokeTest is BaseTest, SpokeTestHelper {
         vm.prank(randomUser);
         spoke.updateShareHook(poolId, scId, newHook);
 
-        assertEq(shareToken.hook(), fullRestrictionsHook);
+        assertEq(shareToken.hook(), address(fullRestrictionsHook));
 
         spoke.updateShareHook(poolId, scId, newHook);
         assertEq(shareToken.hook(), newHook);

--- a/test/spoke/integration/VaultRouter.t.sol
+++ b/test/spoke/integration/VaultRouter.t.sol
@@ -444,7 +444,7 @@ contract VaultRouterTest is BaseTest {
         vm.assume(amount % 2 == 0);
 
         (, address vault_, uint128 assetId) =
-            deployVault(VaultKind.Async, 6, fullRestrictionsHook, bytes16(bytes("1")), address(erc20), 0, 0);
+            deployVault(VaultKind.Async, 6, address(fullRestrictionsHook), bytes16(bytes("1")), address(erc20), 0, 0);
         AsyncVault vault = AsyncVault(vault_);
         vm.label(vault_, "vault");
 
@@ -547,9 +547,9 @@ contract VaultRouterTest is BaseTest {
         vm.label(address(erc20X), "erc20X");
         vm.label(address(erc20Y), "erc20Y");
         (, address vault1_,) =
-            deployVault(VaultKind.Async, 6, fullRestrictionsHook, bytes16(bytes("1")), address(erc20X), 0, 0);
+            deployVault(VaultKind.Async, 6, address(fullRestrictionsHook), bytes16(bytes("1")), address(erc20X), 0, 0);
         (, address vault2_,) =
-            deployVault(VaultKind.Async, 6, fullRestrictionsHook, bytes16(bytes("2")), address(erc20Y), 0, 0);
+            deployVault(VaultKind.Async, 6, address(fullRestrictionsHook), bytes16(bytes("2")), address(erc20Y), 0, 0);
         vault1 = AsyncVault(vault1_);
         vault2 = AsyncVault(vault2_);
         vm.label(vault1_, "vault1");

--- a/test/spoke/unit/factories/TokenFactory.t.sol
+++ b/test/spoke/unit/factories/TokenFactory.t.sol
@@ -41,7 +41,7 @@ contract FactoryTest is Test {
             testSetup1.deployVault(
                 VaultKind.Async,
                 18,
-                testSetup1.fullRestrictionsHook(),
+                address(testSetup1.fullRestrictionsHook()),
                 bytes16(bytes("1")),
                 address(testSetup1.erc20()),
                 0,
@@ -56,7 +56,7 @@ contract FactoryTest is Test {
             testSetup2.deployVault(
                 VaultKind.Async,
                 18,
-                testSetup2.fullRestrictionsHook(),
+                address(testSetup2.fullRestrictionsHook()),
                 bytes16(bytes("1")),
                 address(testSetup2.erc20()),
                 0,


### PR DESCRIPTION
Hooks were treated as plain addresses in the deployers/tests. This PR adds typed hooks

Blocker: https://github.com/centrifuge/protocol-v3/pull/486