### PR TITLE
Allow protocol-v3 to be used as dependency of other projects

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -2,3 +2,5 @@ forge-std/=lib/forge-std/src/
 @chimera/=lib/chimera/src/
 createx-forge/=lib/createx-forge/
 centrifuge-v3/src/=src/
+centrifuge-v3/test/=test/
+centrifuge-v3/script/=script/

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,3 +1,4 @@
 forge-std/=lib/forge-std/src/
 @chimera/=lib/chimera/src/
 createx-forge/=lib/createx-forge/
+centrifuge-v3/src/=src/

--- a/script/AdaptersDeployer.s.sol
+++ b/script/AdaptersDeployer.s.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {AxelarAdapter} from "src/common/adapters/AxelarAdapter.sol";
-import {WormholeAdapter} from "src/common/adapters/WormholeAdapter.sol";
+import {AxelarAdapter} from "centrifuge-v3/src/common/adapters/AxelarAdapter.sol";
+import {WormholeAdapter} from "centrifuge-v3/src/common/adapters/WormholeAdapter.sol";
 
 import {CommonDeployer, CommonInput, CommonReport, CommonActionBatcher} from "script/CommonDeployer.s.sol";
 

--- a/script/AdaptersDeployer.s.sol
+++ b/script/AdaptersDeployer.s.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 import {AxelarAdapter} from "centrifuge-v3/src/common/adapters/AxelarAdapter.sol";
 import {WormholeAdapter} from "centrifuge-v3/src/common/adapters/WormholeAdapter.sol";
 
-import {CommonDeployer, CommonInput, CommonReport, CommonActionBatcher} from "script/CommonDeployer.s.sol";
+import {CommonDeployer, CommonInput, CommonReport, CommonActionBatcher} from "centrifuge-v3/script/CommonDeployer.s.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/AdaptersDeployer.s.sol
+++ b/script/AdaptersDeployer.s.sol
@@ -4,7 +4,9 @@ pragma solidity 0.8.28;
 import {AxelarAdapter} from "centrifuge-v3/src/common/adapters/AxelarAdapter.sol";
 import {WormholeAdapter} from "centrifuge-v3/src/common/adapters/WormholeAdapter.sol";
 
-import {CommonDeployer, CommonInput, CommonReport, CommonActionBatcher} from "centrifuge-v3/script/CommonDeployer.s.sol";
+import {
+    CommonDeployer, CommonInput, CommonReport, CommonActionBatcher
+} from "centrifuge-v3/script/CommonDeployer.s.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/CommonDeployer.s.sol
+++ b/script/CommonDeployer.s.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Root} from "src/common/Root.sol";
-import {Gateway} from "src/common/Gateway.sol";
-import {GasService} from "src/common/GasService.sol";
-import {Guardian, ISafe} from "src/common/Guardian.sol";
-import {TokenRecoverer} from "src/common/TokenRecoverer.sol";
-import {MessageProcessor} from "src/common/MessageProcessor.sol";
-import {MultiAdapter} from "src/common/adapters/MultiAdapter.sol";
-import {MessageDispatcher} from "src/common/MessageDispatcher.sol";
-import {PoolEscrowFactory} from "src/common/factories/PoolEscrowFactory.sol";
+import {Root} from "centrifuge-v3/src/common/Root.sol";
+import {Gateway} from "centrifuge-v3/src/common/Gateway.sol";
+import {GasService} from "centrifuge-v3/src/common/GasService.sol";
+import {Guardian, ISafe} from "centrifuge-v3/src/common/Guardian.sol";
+import {TokenRecoverer} from "centrifuge-v3/src/common/TokenRecoverer.sol";
+import {MessageProcessor} from "centrifuge-v3/src/common/MessageProcessor.sol";
+import {MultiAdapter} from "centrifuge-v3/src/common/adapters/MultiAdapter.sol";
+import {MessageDispatcher} from "centrifuge-v3/src/common/MessageDispatcher.sol";
+import {PoolEscrowFactory} from "centrifuge-v3/src/common/factories/PoolEscrowFactory.sol";
 
 import {JsonRegistry} from "script/utils/JsonRegistry.s.sol";
 

--- a/script/CommonDeployer.s.sol
+++ b/script/CommonDeployer.s.sol
@@ -11,7 +11,7 @@ import {MultiAdapter} from "centrifuge-v3/src/common/adapters/MultiAdapter.sol";
 import {MessageDispatcher} from "centrifuge-v3/src/common/MessageDispatcher.sol";
 import {PoolEscrowFactory} from "centrifuge-v3/src/common/factories/PoolEscrowFactory.sol";
 
-import {JsonRegistry} from "script/utils/JsonRegistry.s.sol";
+import {JsonRegistry} from "centrifuge-v3/script/utils/JsonRegistry.s.sol";
 
 import "forge-std/Script.sol";
 import {CreateXScript} from "createx-forge/script/CreateXScript.sol";

--- a/script/ExtendedSpokeDeployer.s.sol
+++ b/script/ExtendedSpokeDeployer.s.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CommonInput} from "script/CommonDeployer.s.sol";
-import {HooksDeployer, HooksActionBatcher} from "script/HooksDeployer.s.sol";
-import {VaultsDeployer, VaultsActionBatcher} from "script/VaultsDeployer.s.sol";
-import {ManagersDeployer, ManagersActionBatcher} from "script/ManagersDeployer.s.sol";
+import {CommonInput} from "centrifuge-v3/script/CommonDeployer.s.sol";
+import {HooksDeployer, HooksActionBatcher} from "centrifuge-v3/script/HooksDeployer.s.sol";
+import {VaultsDeployer, VaultsActionBatcher} from "centrifuge-v3/script/VaultsDeployer.s.sol";
+import {ManagersDeployer, ManagersActionBatcher} from "centrifuge-v3/script/ManagersDeployer.s.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/FullDeployer.s.sol
+++ b/script/FullDeployer.s.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.28;
 
 import {ISafe} from "centrifuge-v3/src/common/interfaces/IGuardian.sol";
 
-import {CommonInput} from "script/CommonDeployer.s.sol";
-import {HubDeployer, HubActionBatcher} from "script/HubDeployer.s.sol";
-import {ExtendedSpokeDeployer, ExtendedSpokeActionBatcher} from "script/ExtendedSpokeDeployer.s.sol";
+import {CommonInput} from "centrifuge-v3/script/CommonDeployer.s.sol";
+import {HubDeployer, HubActionBatcher} from "centrifuge-v3/script/HubDeployer.s.sol";
+import {ExtendedSpokeDeployer, ExtendedSpokeActionBatcher} from "centrifuge-v3/script/ExtendedSpokeDeployer.s.sol";
 
 import "forge-std/Script.sol";
 
@@ -15,7 +15,7 @@ import {
     AdaptersInput,
     AdaptersDeployer,
     AdaptersActionBatcher
-} from "script/AdaptersDeployer.s.sol";
+} from "centrifuge-v3/script/AdaptersDeployer.s.sol";
 
 contract FullActionBatcher is HubActionBatcher, ExtendedSpokeActionBatcher, AdaptersActionBatcher {}
 

--- a/script/FullDeployer.s.sol
+++ b/script/FullDeployer.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ISafe} from "src/common/interfaces/IGuardian.sol";
+import {ISafe} from "centrifuge-v3/src/common/interfaces/IGuardian.sol";
 
 import {CommonInput} from "script/CommonDeployer.s.sol";
 import {HubDeployer, HubActionBatcher} from "script/HubDeployer.s.sol";

--- a/script/HooksDeployer.s.sol
+++ b/script/HooksDeployer.s.sol
@@ -8,8 +8,8 @@ import {FullRestrictions} from "centrifuge-v3/src/hooks/FullRestrictions.sol";
 import {FreelyTransferable} from "centrifuge-v3/src/hooks/FreelyTransferable.sol";
 import {RedemptionRestrictions} from "centrifuge-v3/src/hooks/RedemptionRestrictions.sol";
 
-import {CommonInput} from "script/CommonDeployer.s.sol";
-import {SpokeDeployer, SpokeReport, SpokeActionBatcher} from "script/SpokeDeployer.s.sol";
+import {CommonInput} from "centrifuge-v3/script/CommonDeployer.s.sol";
+import {SpokeDeployer, SpokeReport, SpokeActionBatcher} from "centrifuge-v3/script/SpokeDeployer.s.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/HooksDeployer.s.sol
+++ b/script/HooksDeployer.s.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Spoke} from "src/spoke/Spoke.sol";
+import {Spoke} from "centrifuge-v3/src/spoke/Spoke.sol";
 
-import {FreezeOnly} from "src/hooks/FreezeOnly.sol";
-import {FullRestrictions} from "src/hooks/FullRestrictions.sol";
-import {FreelyTransferable} from "src/hooks/FreelyTransferable.sol";
-import {RedemptionRestrictions} from "src/hooks/RedemptionRestrictions.sol";
+import {FreezeOnly} from "centrifuge-v3/src/hooks/FreezeOnly.sol";
+import {FullRestrictions} from "centrifuge-v3/src/hooks/FullRestrictions.sol";
+import {FreelyTransferable} from "centrifuge-v3/src/hooks/FreelyTransferable.sol";
+import {RedemptionRestrictions} from "centrifuge-v3/src/hooks/RedemptionRestrictions.sol";
 
 import {CommonInput} from "script/CommonDeployer.s.sol";
 import {SpokeDeployer, SpokeReport, SpokeActionBatcher} from "script/SpokeDeployer.s.sol";

--- a/script/HubDeployer.s.sol
+++ b/script/HubDeployer.s.sol
@@ -12,7 +12,7 @@ import {HubHelpers} from "centrifuge-v3/src/hub/HubHelpers.sol";
 import {HubRegistry} from "centrifuge-v3/src/hub/HubRegistry.sol";
 import {ShareClassManager} from "centrifuge-v3/src/hub/ShareClassManager.sol";
 
-import {CommonDeployer, CommonInput, CommonReport, CommonActionBatcher} from "script/CommonDeployer.s.sol";
+import {CommonDeployer, CommonInput, CommonReport, CommonActionBatcher} from "centrifuge-v3/script/CommonDeployer.s.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/HubDeployer.s.sol
+++ b/script/HubDeployer.s.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IdentityValuation} from "src/misc/IdentityValuation.sol";
+import {IdentityValuation} from "centrifuge-v3/src/misc/IdentityValuation.sol";
 
-import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
+import {AssetId, newAssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
 
-import {Hub} from "src/hub/Hub.sol";
-import {Holdings} from "src/hub/Holdings.sol";
-import {Accounting} from "src/hub/Accounting.sol";
-import {HubHelpers} from "src/hub/HubHelpers.sol";
-import {HubRegistry} from "src/hub/HubRegistry.sol";
-import {ShareClassManager} from "src/hub/ShareClassManager.sol";
+import {Hub} from "centrifuge-v3/src/hub/Hub.sol";
+import {Holdings} from "centrifuge-v3/src/hub/Holdings.sol";
+import {Accounting} from "centrifuge-v3/src/hub/Accounting.sol";
+import {HubHelpers} from "centrifuge-v3/src/hub/HubHelpers.sol";
+import {HubRegistry} from "centrifuge-v3/src/hub/HubRegistry.sol";
+import {ShareClassManager} from "centrifuge-v3/src/hub/ShareClassManager.sol";
 
 import {CommonDeployer, CommonInput, CommonReport, CommonActionBatcher} from "script/CommonDeployer.s.sol";
 

--- a/script/HubDeployer.s.sol
+++ b/script/HubDeployer.s.sol
@@ -12,7 +12,9 @@ import {HubHelpers} from "centrifuge-v3/src/hub/HubHelpers.sol";
 import {HubRegistry} from "centrifuge-v3/src/hub/HubRegistry.sol";
 import {ShareClassManager} from "centrifuge-v3/src/hub/ShareClassManager.sol";
 
-import {CommonDeployer, CommonInput, CommonReport, CommonActionBatcher} from "centrifuge-v3/script/CommonDeployer.s.sol";
+import {
+    CommonDeployer, CommonInput, CommonReport, CommonActionBatcher
+} from "centrifuge-v3/script/CommonDeployer.s.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/ManagersDeployer.s.sol
+++ b/script/ManagersDeployer.s.sol
@@ -6,8 +6,8 @@ import {CircleDecoder} from "centrifuge-v3/src/managers/decoders/CircleDecoder.s
 import {OnOfframpManagerFactory} from "centrifuge-v3/src/managers/OnOfframpManager.sol";
 import {MerkleProofManagerFactory} from "centrifuge-v3/src/managers/MerkleProofManager.sol";
 
-import {CommonInput} from "script/CommonDeployer.s.sol";
-import {SpokeDeployer, SpokeReport, SpokeActionBatcher} from "script/SpokeDeployer.s.sol";
+import {CommonInput} from "centrifuge-v3/script/CommonDeployer.s.sol";
+import {SpokeDeployer, SpokeReport, SpokeActionBatcher} from "centrifuge-v3/script/SpokeDeployer.s.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/ManagersDeployer.s.sol
+++ b/script/ManagersDeployer.s.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {VaultDecoder} from "src/managers/decoders/VaultDecoder.sol";
-import {CircleDecoder} from "src/managers/decoders/CircleDecoder.sol";
-import {OnOfframpManagerFactory} from "src/managers/OnOfframpManager.sol";
-import {MerkleProofManagerFactory} from "src/managers/MerkleProofManager.sol";
+import {VaultDecoder} from "centrifuge-v3/src/managers/decoders/VaultDecoder.sol";
+import {CircleDecoder} from "centrifuge-v3/src/managers/decoders/CircleDecoder.sol";
+import {OnOfframpManagerFactory} from "centrifuge-v3/src/managers/OnOfframpManager.sol";
+import {MerkleProofManagerFactory} from "centrifuge-v3/src/managers/MerkleProofManager.sol";
 
 import {CommonInput} from "script/CommonDeployer.s.sol";
 import {SpokeDeployer, SpokeReport, SpokeActionBatcher} from "script/SpokeDeployer.s.sol";

--- a/script/SpokeDeployer.s.sol
+++ b/script/SpokeDeployer.s.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Spoke} from "src/spoke/Spoke.sol";
-import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
-import {ContractUpdater} from "src/spoke/ContractUpdater.sol";
-import {TokenFactory} from "src/spoke/factories/TokenFactory.sol";
+import {Spoke} from "centrifuge-v3/src/spoke/Spoke.sol";
+import {BalanceSheet} from "centrifuge-v3/src/spoke/BalanceSheet.sol";
+import {ContractUpdater} from "centrifuge-v3/src/spoke/ContractUpdater.sol";
+import {TokenFactory} from "centrifuge-v3/src/spoke/factories/TokenFactory.sol";
 
 import {CommonDeployer, CommonInput, CommonReport, CommonActionBatcher} from "script/CommonDeployer.s.sol";
 

--- a/script/SpokeDeployer.s.sol
+++ b/script/SpokeDeployer.s.sol
@@ -6,7 +6,7 @@ import {BalanceSheet} from "centrifuge-v3/src/spoke/BalanceSheet.sol";
 import {ContractUpdater} from "centrifuge-v3/src/spoke/ContractUpdater.sol";
 import {TokenFactory} from "centrifuge-v3/src/spoke/factories/TokenFactory.sol";
 
-import {CommonDeployer, CommonInput, CommonReport, CommonActionBatcher} from "script/CommonDeployer.s.sol";
+import {CommonDeployer, CommonInput, CommonReport, CommonActionBatcher} from "centrifuge-v3/script/CommonDeployer.s.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/SpokeDeployer.s.sol
+++ b/script/SpokeDeployer.s.sol
@@ -6,7 +6,9 @@ import {BalanceSheet} from "centrifuge-v3/src/spoke/BalanceSheet.sol";
 import {ContractUpdater} from "centrifuge-v3/src/spoke/ContractUpdater.sol";
 import {TokenFactory} from "centrifuge-v3/src/spoke/factories/TokenFactory.sol";
 
-import {CommonDeployer, CommonInput, CommonReport, CommonActionBatcher} from "centrifuge-v3/script/CommonDeployer.s.sol";
+import {
+    CommonDeployer, CommonInput, CommonReport, CommonActionBatcher
+} from "centrifuge-v3/script/CommonDeployer.s.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/TestData.s.sol
+++ b/script/TestData.s.sol
@@ -32,7 +32,7 @@ import {SyncDepositVaultFactory} from "centrifuge-v3/src/vaults/factories/SyncDe
 import {RedemptionRestrictions} from "centrifuge-v3/src/hooks/RedemptionRestrictions.sol";
 import {UpdateRestrictionMessageLib} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
-import {FullDeployer} from "script/FullDeployer.s.sol";
+import {FullDeployer} from "centrifuge-v3/script/FullDeployer.s.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/TestData.s.sol
+++ b/script/TestData.s.sol
@@ -1,36 +1,36 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ERC20} from "src/misc/ERC20.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {IdentityValuation} from "src/misc/IdentityValuation.sol";
+import {ERC20} from "centrifuge-v3/src/misc/ERC20.sol";
+import {D18, d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {IdentityValuation} from "centrifuge-v3/src/misc/IdentityValuation.sol";
 
-import {Guardian} from "src/common/Guardian.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
-import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {Guardian} from "centrifuge-v3/src/common/Guardian.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AccountId} from "centrifuge-v3/src/common/types/AccountId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {AssetId, newAssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {VaultUpdateKind} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
 
-import {Hub} from "src/hub/Hub.sol";
-import {HubRegistry} from "src/hub/HubRegistry.sol";
-import {ShareClassManager} from "src/hub/ShareClassManager.sol";
+import {Hub} from "centrifuge-v3/src/hub/Hub.sol";
+import {HubRegistry} from "centrifuge-v3/src/hub/HubRegistry.sol";
+import {ShareClassManager} from "centrifuge-v3/src/hub/ShareClassManager.sol";
 
-import {Spoke} from "src/spoke/Spoke.sol";
-import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import {Spoke} from "centrifuge-v3/src/spoke/Spoke.sol";
+import {BalanceSheet} from "centrifuge-v3/src/spoke/BalanceSheet.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
+import {UpdateContractMessageLib} from "centrifuge-v3/src/spoke/libraries/UpdateContractMessageLib.sol";
 
-import {SyncManager} from "src/vaults/SyncManager.sol";
-import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {AsyncRequestManager} from "src/vaults/AsyncRequestManager.sol";
-import {AsyncVaultFactory} from "src/vaults/factories/AsyncVaultFactory.sol";
-import {SyncDepositVaultFactory} from "src/vaults/factories/SyncDepositVaultFactory.sol";
+import {SyncManager} from "centrifuge-v3/src/vaults/SyncManager.sol";
+import {SyncDepositVault} from "centrifuge-v3/src/vaults/SyncDepositVault.sol";
+import {IAsyncVault} from "centrifuge-v3/src/vaults/interfaces/IAsyncVault.sol";
+import {AsyncRequestManager} from "centrifuge-v3/src/vaults/AsyncRequestManager.sol";
+import {AsyncVaultFactory} from "centrifuge-v3/src/vaults/factories/AsyncVaultFactory.sol";
+import {SyncDepositVaultFactory} from "centrifuge-v3/src/vaults/factories/SyncDepositVaultFactory.sol";
 
-import {RedemptionRestrictions} from "src/hooks/RedemptionRestrictions.sol";
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {RedemptionRestrictions} from "centrifuge-v3/src/hooks/RedemptionRestrictions.sol";
+import {UpdateRestrictionMessageLib} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import {FullDeployer} from "script/FullDeployer.s.sol";
 

--- a/script/VaultsDeployer.s.sol
+++ b/script/VaultsDeployer.s.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Escrow} from "src/misc/Escrow.sol";
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
+import {Escrow} from "centrifuge-v3/src/misc/Escrow.sol";
+import {IEscrow} from "centrifuge-v3/src/misc/interfaces/IEscrow.sol";
 
-import {Spoke} from "src/spoke/Spoke.sol";
+import {Spoke} from "centrifuge-v3/src/spoke/Spoke.sol";
 
-import {SyncManager} from "src/vaults/SyncManager.sol";
-import {VaultRouter} from "src/vaults/VaultRouter.sol";
-import {AsyncRequestManager} from "src/vaults/AsyncRequestManager.sol";
-import {AsyncVaultFactory} from "src/vaults/factories/AsyncVaultFactory.sol";
-import {SyncDepositVaultFactory} from "src/vaults/factories/SyncDepositVaultFactory.sol";
+import {SyncManager} from "centrifuge-v3/src/vaults/SyncManager.sol";
+import {VaultRouter} from "centrifuge-v3/src/vaults/VaultRouter.sol";
+import {AsyncRequestManager} from "centrifuge-v3/src/vaults/AsyncRequestManager.sol";
+import {AsyncVaultFactory} from "centrifuge-v3/src/vaults/factories/AsyncVaultFactory.sol";
+import {SyncDepositVaultFactory} from "centrifuge-v3/src/vaults/factories/SyncDepositVaultFactory.sol";
 
 import {CommonInput} from "script/CommonDeployer.s.sol";
 import {SpokeDeployer, SpokeReport, SpokeActionBatcher} from "script/SpokeDeployer.s.sol";

--- a/script/VaultsDeployer.s.sol
+++ b/script/VaultsDeployer.s.sol
@@ -12,8 +12,8 @@ import {AsyncRequestManager} from "centrifuge-v3/src/vaults/AsyncRequestManager.
 import {AsyncVaultFactory} from "centrifuge-v3/src/vaults/factories/AsyncVaultFactory.sol";
 import {SyncDepositVaultFactory} from "centrifuge-v3/src/vaults/factories/SyncDepositVaultFactory.sol";
 
-import {CommonInput} from "script/CommonDeployer.s.sol";
-import {SpokeDeployer, SpokeReport, SpokeActionBatcher} from "script/SpokeDeployer.s.sol";
+import {CommonInput} from "centrifuge-v3/script/CommonDeployer.s.sol";
+import {SpokeDeployer, SpokeReport, SpokeActionBatcher} from "centrifuge-v3/script/SpokeDeployer.s.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/WireAdapters.s.sol
+++ b/script/WireAdapters.s.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Guardian} from "src/common/Guardian.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IAxelarAdapter} from "src/common/interfaces/adapters/IAxelarAdapter.sol";
-import {IWormholeAdapter} from "src/common/interfaces/adapters/IWormholeAdapter.sol";
+import {Guardian} from "centrifuge-v3/src/common/Guardian.sol";
+import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
+import {IAxelarAdapter} from "centrifuge-v3/src/common/interfaces/adapters/IAxelarAdapter.sol";
+import {IWormholeAdapter} from "centrifuge-v3/src/common/interfaces/adapters/IWormholeAdapter.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/deploy/setup.sh
+++ b/script/deploy/setup.sh
@@ -217,7 +217,7 @@ check_python() {
                     echo "  💡 To use Homebrew Python, add to your shell config (~/.zshrc or ~/.bash_profile):"
                     echo "     export PATH=\"/opt/homebrew/bin:\$PATH\""
                     echo "     alias python3=\"/opt/homebrew/bin/python3\""
-                    echo "  🔄 Or run: source ~/.zshrc && ./script/deploy/setup.sh"
+                    echo "  🔄 Or run: source ~/.zshrc && ./centrifuge-v3/script/deploy/setup.sh"
                 else
                     echo "  ⚠ Homebrew Python $HOMEBREW_VERSION also needs upgrading"
                 fi
@@ -229,7 +229,7 @@ check_python() {
                     print_fixed "Python version upgrade"
                 else
                     echo "  2. Install manually: brew install python@$REQUIRED_PYTHON_VERSION"
-                    echo "  3. Fix PATH manually and re-run this script"
+                    echo "  3. Fix PATH manually and re-run this centrifuge-v3/script"
                     return 1
                 fi
             fi
@@ -631,8 +631,8 @@ main() {
         echo -e "${GREEN}You're ready to use the Centrifuge deployment tool.${NC}"
         echo
         echo -e "${BLUE}Next steps:${NC}"
-        echo -e "  ${BLUE}•${NC} Run: python3 script/deploy/deploy.py --help"
-        echo -e "  ${BLUE}•${NC} Example: python3 script/deploy/deploy.py sepolia deploy:protocol"
+        echo -e "  ${BLUE}•${NC} Run: python3 centrifuge-v3/script/deploy/deploy.py --help"
+        echo -e "  ${BLUE}•${NC} Example: python3 centrifuge-v3/script/deploy/deploy.py sepolia deploy:protocol"
     else
 
         echo -e "${RED}❌ Found $ISSUES_FOUND issue(s) that need attention${NC}"

--- a/script/utils/fix_imports.py
+++ b/script/utils/fix_imports.py
@@ -16,8 +16,8 @@ IMPORT_PRIORITY = [
     "centrifuge-v3/src/vaults",
     "centrifuge-v3/src/hooks",
     "centrifuge-v3/src/managers",
-    "script",
-    "test"
+    "centrifuge-v3/script",
+    "centrifuge-v3/test"
 ]
 
 def get_all_solidity_files() -> List[str]:

--- a/script/utils/fix_imports.py
+++ b/script/utils/fix_imports.py
@@ -9,13 +9,13 @@ import sys
 
 # Priority order for imports
 IMPORT_PRIORITY = [
-    "src/misc",
-    "src/common",
-    "src/hub",
-    "src/spoke",
-    "src/vaults",
-    "src/hooks",
-    "src/managers",
+    "centrifuge-v3/src/misc",
+    "centrifuge-v3/src/common",
+    "centrifuge-v3/src/hub",
+    "centrifuge-v3/src/spoke",
+    "centrifuge-v3/src/vaults",
+    "centrifuge-v3/src/hooks",
+    "centrifuge-v3/src/managers",
     "script",
     "test"
 ]
@@ -495,7 +495,7 @@ def organize_all_imports():
                         path_match = re.search(r'import\s+"([^"]+)"', import_stmt)
                     if path_match:
                         path = path_match.group(1)
-                        if path.startswith('src/') and not any(path.startswith(p) for p in IMPORT_PRIORITY):
+                        if path.startswith('centrifuge-v3/src/') and not any(path.startswith(p) for p in IMPORT_PRIORITY):
                             other_import_paths.add(path.split('/')[1] if '/' in path else path)
             except:
                 pass
@@ -508,7 +508,7 @@ def organize_all_imports():
     if other_import_paths:
         print(f"\nOther import paths found beyond the specified ones:")
         for path in sorted(other_import_paths):
-            print(f"  - src/{path}")
+            print(f"  - centrifuge-v3/src/{path}")
 
 def main():
     """Main function"""

--- a/src/common/BaseValuation.sol
+++ b/src/common/BaseValuation.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {IERC6909Decimals} from "centrifuge-v3/src/misc/interfaces/IERC6909.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IBaseValuation} from "src/common/interfaces/IBaseValuation.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {IBaseValuation} from "centrifuge-v3/src/common/interfaces/IBaseValuation.sol";
 
 abstract contract BaseValuation is Auth, IBaseValuation {
     /// @notice ERC6909 dependency.

--- a/src/common/GasService.sol
+++ b/src/common/GasService.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IGasService} from "src/common/interfaces/IGasService.sol";
-import {MessageLib, MessageType, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {IGasService} from "centrifuge-v3/src/common/interfaces/IGasService.sol";
+import {MessageLib, MessageType, VaultUpdateKind} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
 
 /// @title  GasService
 /// @notice This contract stores the gas limits (in gas units) for cross-chain message execution.

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -1,21 +1,21 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {TransientArrayLib} from "src/misc/libraries/TransientArrayLib.sol";
-import {TransientBytesLib} from "src/misc/libraries/TransientBytesLib.sol";
-import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
-import {Recoverable, IRecoverable, ETH_ADDRESS} from "src/misc/Recoverable.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
+import {TransientArrayLib} from "centrifuge-v3/src/misc/libraries/TransientArrayLib.sol";
+import {TransientBytesLib} from "centrifuge-v3/src/misc/libraries/TransientBytesLib.sol";
+import {TransientStorageLib} from "centrifuge-v3/src/misc/libraries/TransientStorageLib.sol";
+import {Recoverable, IRecoverable, ETH_ADDRESS} from "centrifuge-v3/src/misc/Recoverable.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {IGasService} from "src/common/interfaces/IGasService.sol";
-import {IMessageSender} from "src/common/interfaces/IMessageSender.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {IMessageProcessor} from "src/common/interfaces/IMessageProcessor.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {IRoot} from "centrifuge-v3/src/common/interfaces/IRoot.sol";
+import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
+import {IGateway} from "centrifuge-v3/src/common/interfaces/IGateway.sol";
+import {IGasService} from "centrifuge-v3/src/common/interfaces/IGasService.sol";
+import {IMessageSender} from "centrifuge-v3/src/common/interfaces/IMessageSender.sol";
+import {IMessageHandler} from "centrifuge-v3/src/common/interfaces/IMessageHandler.sol";
+import {IMessageProcessor} from "centrifuge-v3/src/common/interfaces/IMessageProcessor.sol";
 
 /// @title  Gateway
 /// @notice Routing contract that forwards outgoing messages to multiple adapters (1 full message, n-1 proofs)

--- a/src/common/Guardian.sol
+++ b/src/common/Guardian.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IGuardian, ISafe} from "src/common/interfaces/IGuardian.sol";
-import {IRootMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {IHubGuardianActions} from "src/common/interfaces/IGuardianActions.sol";
-import {IMultiAdapter} from "src/common/interfaces/adapters/IMultiAdapter.sol";
-import {IAxelarAdapter} from "src/common/interfaces/adapters/IAxelarAdapter.sol";
-import {IWormholeAdapter} from "src/common/interfaces/adapters/IWormholeAdapter.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {IRoot} from "centrifuge-v3/src/common/interfaces/IRoot.sol";
+import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
+import {IGuardian, ISafe} from "centrifuge-v3/src/common/interfaces/IGuardian.sol";
+import {IRootMessageSender} from "centrifuge-v3/src/common/interfaces/IGatewaySenders.sol";
+import {IHubGuardianActions} from "centrifuge-v3/src/common/interfaces/IGuardianActions.sol";
+import {IMultiAdapter} from "centrifuge-v3/src/common/interfaces/adapters/IMultiAdapter.sol";
+import {IAxelarAdapter} from "centrifuge-v3/src/common/interfaces/adapters/IAxelarAdapter.sol";
+import {IWormholeAdapter} from "centrifuge-v3/src/common/interfaces/adapters/IWormholeAdapter.sol";
 
 contract Guardian is IGuardian {
     using CastLib for address;

--- a/src/common/MessageDispatcher.sol
+++ b/src/common/MessageDispatcher.sol
@@ -1,29 +1,29 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18} from "src/misc/types/D18.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
+import {IRecoverable} from "centrifuge-v3/src/misc/interfaces/IRecoverable.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {ITokenRecoverer} from "src/common/interfaces/ITokenRecoverer.sol";
-import {IMessageDispatcher} from "src/common/interfaces/IMessageDispatcher.sol";
-import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
-import {ISpokeMessageSender, IHubMessageSender, IRootMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {IRoot} from "centrifuge-v3/src/common/interfaces/IRoot.sol";
+import {IGateway} from "centrifuge-v3/src/common/interfaces/IGateway.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {ITokenRecoverer} from "centrifuge-v3/src/common/interfaces/ITokenRecoverer.sol";
+import {IMessageDispatcher} from "centrifuge-v3/src/common/interfaces/IMessageDispatcher.sol";
+import {MessageLib, VaultUpdateKind} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
+import {ISpokeMessageSender, IHubMessageSender, IRootMessageSender} from "centrifuge-v3/src/common/interfaces/IGatewaySenders.sol";
 
 import {
     ISpokeGatewayHandler,
     IBalanceSheetGatewayHandler,
     IHubGatewayHandler,
     IUpdateContractGatewayHandler
-} from "src/common/interfaces/IGatewayHandlers.sol";
+} from "centrifuge-v3/src/common/interfaces/IGatewayHandlers.sol";
 
 contract MessageDispatcher is Auth, IMessageDispatcher {
     using CastLib for *;

--- a/src/common/MessageDispatcher.sol
+++ b/src/common/MessageDispatcher.sol
@@ -16,7 +16,11 @@ import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 import {ITokenRecoverer} from "centrifuge-v3/src/common/interfaces/ITokenRecoverer.sol";
 import {IMessageDispatcher} from "centrifuge-v3/src/common/interfaces/IMessageDispatcher.sol";
 import {MessageLib, VaultUpdateKind} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
-import {ISpokeMessageSender, IHubMessageSender, IRootMessageSender} from "centrifuge-v3/src/common/interfaces/IGatewaySenders.sol";
+import {
+    ISpokeMessageSender,
+    IHubMessageSender,
+    IRootMessageSender
+} from "centrifuge-v3/src/common/interfaces/IGatewaySenders.sol";
 
 import {
     ISpokeGatewayHandler,

--- a/src/common/MessageProcessor.sol
+++ b/src/common/MessageProcessor.sol
@@ -1,28 +1,28 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18} from "src/misc/types/D18.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
+import {IRecoverable} from "centrifuge-v3/src/misc/interfaces/IRecoverable.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {ITokenRecoverer} from "src/common/interfaces/ITokenRecoverer.sol";
-import {IMessageProcessor} from "src/common/interfaces/IMessageProcessor.sol";
-import {IMessageProperties} from "src/common/interfaces/IMessageProperties.sol";
-import {MessageType, MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {IRoot} from "centrifuge-v3/src/common/interfaces/IRoot.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {IMessageHandler} from "centrifuge-v3/src/common/interfaces/IMessageHandler.sol";
+import {ITokenRecoverer} from "centrifuge-v3/src/common/interfaces/ITokenRecoverer.sol";
+import {IMessageProcessor} from "centrifuge-v3/src/common/interfaces/IMessageProcessor.sol";
+import {IMessageProperties} from "centrifuge-v3/src/common/interfaces/IMessageProperties.sol";
+import {MessageType, MessageLib, VaultUpdateKind} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
 
 import {
     ISpokeGatewayHandler,
     IBalanceSheetGatewayHandler,
     IHubGatewayHandler,
     IUpdateContractGatewayHandler
-} from "src/common/interfaces/IGatewayHandlers.sol";
+} from "centrifuge-v3/src/common/interfaces/IGatewayHandlers.sol";
 
 contract MessageProcessor is Auth, IMessageProcessor {
     using CastLib for *;

--- a/src/common/PoolEscrow.sol
+++ b/src/common/PoolEscrow.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Escrow} from "src/misc/Escrow.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
+import {Escrow} from "centrifuge-v3/src/misc/Escrow.sol";
+import {Recoverable} from "centrifuge-v3/src/misc/Recoverable.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {Holding, IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {Holding, IPoolEscrow} from "centrifuge-v3/src/common/interfaces/IPoolEscrow.sol";
 
 /// @title  Escrow
 /// @notice Escrow contract that holds assets for a specific pool separated by share classes.

--- a/src/common/Root.sol
+++ b/src/common/Root.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
 
-import {IRoot} from "src/common/interfaces/IRoot.sol";
+import {IRoot} from "centrifuge-v3/src/common/interfaces/IRoot.sol";
 
 /// @title  Root
 /// @notice Core contract that is a ward on all other deployed contracts.

--- a/src/common/TokenRecoverer.sol
+++ b/src/common/TokenRecoverer.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {IRecoverable} from "centrifuge-v3/src/misc/interfaces/IRecoverable.sol";
 
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ITokenRecoverer} from "src/common/interfaces/ITokenRecoverer.sol";
+import {IRoot} from "centrifuge-v3/src/common/interfaces/IRoot.sol";
+import {ITokenRecoverer} from "centrifuge-v3/src/common/interfaces/ITokenRecoverer.sol";
 
 contract TokenRecoverer is Auth, ITokenRecoverer {
     IRoot public immutable root;

--- a/src/common/adapters/AxelarAdapter.sol
+++ b/src/common/adapters/AxelarAdapter.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
 
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+import {IMessageHandler} from "centrifuge-v3/src/common/interfaces/IMessageHandler.sol";
 
 import {
     IAxelarAdapter,
@@ -14,7 +14,7 @@ import {
     AxelarSource,
     AxelarDestination,
     IAxelarExecutable
-} from "src/common/interfaces/adapters/IAxelarAdapter.sol";
+} from "centrifuge-v3/src/common/interfaces/adapters/IAxelarAdapter.sol";
 
 /// @title  Axelar Adapter
 /// @notice Routing contract that integrates with an Axelar Gateway

--- a/src/common/adapters/MultiAdapter.sol
+++ b/src/common/adapters/MultiAdapter.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {ArrayLib} from "src/misc/libraries/ArrayLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
+import {ArrayLib} from "centrifuge-v3/src/misc/libraries/ArrayLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
 
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {IMultiAdapter, MAX_ADAPTER_COUNT} from "src/common/interfaces/adapters/IMultiAdapter.sol";
+import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
+import {MessageProofLib} from "centrifuge-v3/src/common/libraries/MessageProofLib.sol";
+import {IMessageHandler} from "centrifuge-v3/src/common/interfaces/IMessageHandler.sol";
+import {IMultiAdapter, MAX_ADAPTER_COUNT} from "centrifuge-v3/src/common/interfaces/adapters/IMultiAdapter.sol";
 
 contract MultiAdapter is Auth, IMultiAdapter {
     using CastLib for *;

--- a/src/common/adapters/WormholeAdapter.sol
+++ b/src/common/adapters/WormholeAdapter.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
 
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+import {IMessageHandler} from "centrifuge-v3/src/common/interfaces/IMessageHandler.sol";
 
 import {
     IWormholeAdapter,
@@ -14,7 +14,7 @@ import {
     IWormholeReceiver,
     WormholeSource,
     WormholeDestination
-} from "src/common/interfaces/adapters/IWormholeAdapter.sol";
+} from "centrifuge-v3/src/common/interfaces/adapters/IWormholeAdapter.sol";
 
 /// @title  Wormhole Adapter
 /// @notice Routing contract that integrates with the Wormhole Relayer service

--- a/src/common/factories/PoolEscrowFactory.sol
+++ b/src/common/factories/PoolEscrowFactory.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {PoolEscrow} from "src/common/PoolEscrow.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {IPoolEscrowProvider, IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {PoolEscrow} from "centrifuge-v3/src/common/PoolEscrow.sol";
+import {IPoolEscrow} from "centrifuge-v3/src/common/interfaces/IPoolEscrow.sol";
+import {IPoolEscrowProvider, IPoolEscrowFactory} from "centrifuge-v3/src/common/factories/interfaces/IPoolEscrowFactory.sol";
 
 contract PoolEscrowFactory is Auth, IPoolEscrowFactory {
     address public immutable root;

--- a/src/common/factories/PoolEscrowFactory.sol
+++ b/src/common/factories/PoolEscrowFactory.sol
@@ -6,7 +6,10 @@ import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
 import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
 import {PoolEscrow} from "centrifuge-v3/src/common/PoolEscrow.sol";
 import {IPoolEscrow} from "centrifuge-v3/src/common/interfaces/IPoolEscrow.sol";
-import {IPoolEscrowProvider, IPoolEscrowFactory} from "centrifuge-v3/src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {
+    IPoolEscrowProvider,
+    IPoolEscrowFactory
+} from "centrifuge-v3/src/common/factories/interfaces/IPoolEscrowFactory.sol";
 
 contract PoolEscrowFactory is Auth, IPoolEscrowFactory {
     address public immutable root;

--- a/src/common/factories/interfaces/IPoolEscrowFactory.sol
+++ b/src/common/factories/interfaces/IPoolEscrowFactory.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {IPoolEscrow} from "centrifuge-v3/src/common/interfaces/IPoolEscrow.sol";
 
 interface IPoolEscrowProvider {
     /// @notice Returns the deterministic address of an escrow contract based on a given pool id wrapped into the

--- a/src/common/interfaces/IAdapter.sol
+++ b/src/common/interfaces/IAdapter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
 
 interface IAdapter is IAuth {
     error NotEntrypoint();

--- a/src/common/interfaces/IBaseValuation.sol
+++ b/src/common/interfaces/IBaseValuation.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {IValuation} from "centrifuge-v3/src/common/interfaces/IValuation.sol";
 
 /// Provides a base implementation for all ERC7726 valuation in the system
 interface IBaseValuation is IValuation {

--- a/src/common/interfaces/IGateway.sol
+++ b/src/common/interfaces/IGateway.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
+import {IRecoverable} from "centrifuge-v3/src/misc/interfaces/IRecoverable.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {IMessageSender} from "src/common/interfaces/IMessageSender.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {IMessageSender} from "centrifuge-v3/src/common/interfaces/IMessageSender.sol";
+import {IMessageHandler} from "centrifuge-v3/src/common/interfaces/IMessageHandler.sol";
 
 /// @notice Interface for dispatch-only gateway
 interface IGateway is IMessageHandler, IMessageSender, IRecoverable {

--- a/src/common/interfaces/IGatewayHandlers.sol
+++ b/src/common/interfaces/IGatewayHandlers.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {D18} from "src/misc/types/D18.sol";
+import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {VaultUpdateKind} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
 
 /// -----------------------------------------------------
 ///  Hub Handlers

--- a/src/common/interfaces/IGatewaySenders.sol
+++ b/src/common/interfaces/IGatewaySenders.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {D18} from "src/misc/types/D18.sol";
+import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {VaultUpdateKind} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
 
 interface ILocalCentrifugeId {
     function localCentrifugeId() external view returns (uint16);

--- a/src/common/interfaces/IGuardian.sol
+++ b/src/common/interfaces/IGuardian.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IAxelarAdapter} from "src/common/interfaces/adapters/IAxelarAdapter.sol";
-import {IWormholeAdapter} from "src/common/interfaces/adapters/IWormholeAdapter.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
+import {IAxelarAdapter} from "centrifuge-v3/src/common/interfaces/adapters/IAxelarAdapter.sol";
+import {IWormholeAdapter} from "centrifuge-v3/src/common/interfaces/adapters/IWormholeAdapter.sol";
 
 interface ISafe {
     function isOwner(address signer) external view returns (bool);

--- a/src/common/interfaces/IGuardianActions.sol
+++ b/src/common/interfaces/IGuardianActions.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
 
 interface IHubGuardianActions {
     /// @notice Creates a new pool.

--- a/src/common/interfaces/IMessageDispatcher.sol
+++ b/src/common/interfaces/IMessageDispatcher.sol
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {ISpokeMessageSender, IHubMessageSender, IRootMessageSender} from "centrifuge-v3/src/common/interfaces/IGatewaySenders.sol";
+import {
+    ISpokeMessageSender,
+    IHubMessageSender,
+    IRootMessageSender
+} from "centrifuge-v3/src/common/interfaces/IGatewaySenders.sol";
 
 interface IMessageDispatcher is IRootMessageSender, ISpokeMessageSender, IHubMessageSender {
     /// @notice Emitted when a call to `file()` was performed.

--- a/src/common/interfaces/IMessageDispatcher.sol
+++ b/src/common/interfaces/IMessageDispatcher.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {ISpokeMessageSender, IHubMessageSender, IRootMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
+import {ISpokeMessageSender, IHubMessageSender, IRootMessageSender} from "centrifuge-v3/src/common/interfaces/IGatewaySenders.sol";
 
 interface IMessageDispatcher is IRootMessageSender, ISpokeMessageSender, IHubMessageSender {
     /// @notice Emitted when a call to `file()` was performed.

--- a/src/common/interfaces/IMessageProcessor.sol
+++ b/src/common/interfaces/IMessageProcessor.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {IMessageProperties} from "src/common/interfaces/IMessageProperties.sol";
+import {IMessageHandler} from "centrifuge-v3/src/common/interfaces/IMessageHandler.sol";
+import {IMessageProperties} from "centrifuge-v3/src/common/interfaces/IMessageProperties.sol";
 
 interface IMessageProcessor is IMessageHandler, IMessageProperties {
     error InvalidSourceChain();

--- a/src/common/interfaces/IMessageProperties.sol
+++ b/src/common/interfaces/IMessageProperties.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {PoolId} from "src/common/types/PoolId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
 
 /// @notice Defines methods to get properties from raw messages
 interface IMessageProperties {

--- a/src/common/interfaces/IPoolEscrow.sol
+++ b/src/common/interfaces/IPoolEscrow.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IRecoverable} from "src/misc/Recoverable.sol";
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
+import {IRecoverable} from "centrifuge-v3/src/misc/Recoverable.sol";
+import {IEscrow} from "centrifuge-v3/src/misc/interfaces/IEscrow.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
 struct Holding {
     uint128 total;

--- a/src/common/interfaces/ISnapshotHook.sol
+++ b/src/common/interfaces/ISnapshotHook.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
 /// @notice Hook interface that is called whenever the accounting system of the Hub, for a given share token on
 ///         1 network, as in a (poolId, scId, centrifugeId) tuple, is in a synchronous state. This means the assets

--- a/src/common/interfaces/ITokenRecoverer.sol
+++ b/src/common/interfaces/ITokenRecoverer.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
+import {IRecoverable} from "centrifuge-v3/src/misc/interfaces/IRecoverable.sol";
 
 interface ITokenRecoverer {
     event RecoverTokens(

--- a/src/common/interfaces/ITransferHook.sol
+++ b/src/common/interfaces/ITransferHook.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {IERC165} from "src/misc/interfaces/IERC7575.sol";
+import {IERC165} from "centrifuge-v3/src/misc/interfaces/IERC7575.sol";
 
 struct HookData {
     bytes16 from;

--- a/src/common/interfaces/IValuation.sol
+++ b/src/common/interfaces/IValuation.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {AssetId} from "src/common/types/AssetId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
 
 /// Based on [ERC-7726](https://eips.ethereum.org/EIPS/eip-7726): Common Quote Oracle, but adapted for ERC6909.
 /// Interface for asset conversions.

--- a/src/common/interfaces/adapters/IAxelarAdapter.sol
+++ b/src/common/interfaces/adapters/IAxelarAdapter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
 
 // From https://github.com/axelarnetwork/axelar-cgp-solidity/blob/main/contracts/interfaces/IAxelarGateway.sol
 interface IAxelarGateway {

--- a/src/common/interfaces/adapters/IMultiAdapter.sol
+++ b/src/common/interfaces/adapters/IMultiAdapter.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
+import {IMessageHandler} from "centrifuge-v3/src/common/interfaces/IMessageHandler.sol";
 
 uint8 constant MAX_ADAPTER_COUNT = 8;
 

--- a/src/common/interfaces/adapters/IWormholeAdapter.sol
+++ b/src/common/interfaces/adapters/IWormholeAdapter.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
 
-// From https://github.com/wormhole-foundation/wormhole-solidity-sdk/blob/main/src/interfaces/IWormholeRelayer.sol#L75
+// From https://github.com/wormhole-foundation/wormhole-solidity-sdk/blob/main/centrifuge-v3/src/interfaces/IWormholeRelayer.sol#L75
 interface IWormholeRelayer {
     /**
      * @notice Publishes an instruction for the default delivery provider

--- a/src/common/interfaces/adapters/IWormholeAdapter.sol
+++ b/src/common/interfaces/adapters/IWormholeAdapter.sol
@@ -3,7 +3,8 @@ pragma solidity >=0.5.0;
 
 import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
 
-// From https://github.com/wormhole-foundation/wormhole-solidity-sdk/blob/main/centrifuge-v3/src/interfaces/IWormholeRelayer.sol#L75
+// From
+// https://github.com/wormhole-foundation/wormhole-solidity-sdk/blob/main/centrifuge-v3/src/interfaces/IWormholeRelayer.sol#L75
 interface IWormholeRelayer {
     /**
      * @notice Publishes an instruction for the default delivery provider

--- a/src/common/libraries/MessageLib.sol
+++ b/src/common/libraries/MessageLib.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
 
 // NOTE: Should never exceed 254 messages because id == 255 corresponds to message proofs
 enum MessageType {

--- a/src/common/libraries/MessageProofLib.sol
+++ b/src/common/libraries/MessageProofLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
 
 library MessageProofLib {
     using BytesLib for bytes;

--- a/src/common/libraries/PricingLib.sol
+++ b/src/common/libraries/PricingLib.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
-import {IERC6909MetadataExt} from "src/misc/interfaces/IERC6909.sol";
+import {D18, d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
+import {IERC20Metadata} from "centrifuge-v3/src/misc/interfaces/IERC20.sol";
+import {IERC6909MetadataExt} from "centrifuge-v3/src/misc/interfaces/IERC6909.sol";
 
 library PricingLib {
     using MathLib for *;

--- a/src/common/libraries/RequestCallbackMessageLib.sol
+++ b/src/common/libraries/RequestCallbackMessageLib.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
 
 enum RequestCallbackType {
     /// @dev Placeholder for null request callback type

--- a/src/common/libraries/RequestMessageLib.sol
+++ b/src/common/libraries/RequestMessageLib.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
 
 enum RequestType {
     /// @dev Placeholder for null request type

--- a/src/common/types/PoolId.sol
+++ b/src/common/types/PoolId.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
 
 using MathLib for uint256;
 

--- a/src/common/types/ShareClassId.sol
+++ b/src/common/types/ShareClassId.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
 
 type ShareClassId is bytes16;
 

--- a/src/hooks/FreelyTransferable.sol
+++ b/src/hooks/FreelyTransferable.sol
@@ -14,7 +14,10 @@ import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
 
 import {IFreezable} from "centrifuge-v3/src/hooks/interfaces/IFreezable.sol";
 import {IMemberlist} from "centrifuge-v3/src/hooks/interfaces/IMemberlist.sol";
-import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {
+    UpdateRestrictionType,
+    UpdateRestrictionMessageLib
+} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 /// @title  Freely Transferable
 /// @notice Hook implementation that:

--- a/src/hooks/FreelyTransferable.sol
+++ b/src/hooks/FreelyTransferable.sol
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {IERC165} from "src/misc/interfaces/IERC7575.sol";
-import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
+import {IERC165} from "centrifuge-v3/src/misc/interfaces/IERC7575.sol";
+import {BitmapLib} from "centrifuge-v3/src/misc/libraries/BitmapLib.sol";
 
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ITransferHook, HookData, ESCROW_HOOK_ID} from "src/common/interfaces/ITransferHook.sol";
+import {IRoot} from "centrifuge-v3/src/common/interfaces/IRoot.sol";
+import {ITransferHook, HookData, ESCROW_HOOK_ID} from "centrifuge-v3/src/common/interfaces/ITransferHook.sol";
 
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
 
-import {IFreezable} from "src/hooks/interfaces/IFreezable.sol";
-import {IMemberlist} from "src/hooks/interfaces/IMemberlist.sol";
-import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {IFreezable} from "centrifuge-v3/src/hooks/interfaces/IFreezable.sol";
+import {IMemberlist} from "centrifuge-v3/src/hooks/interfaces/IMemberlist.sol";
+import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 /// @title  Freely Transferable
 /// @notice Hook implementation that:

--- a/src/hooks/FreezeOnly.sol
+++ b/src/hooks/FreezeOnly.sol
@@ -13,7 +13,10 @@ import {ITransferHook, HookData} from "centrifuge-v3/src/common/interfaces/ITran
 import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
 
 import {IFreezable} from "centrifuge-v3/src/hooks/interfaces/IFreezable.sol";
-import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {
+    UpdateRestrictionType,
+    UpdateRestrictionMessageLib
+} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 /// @title  Freeze Only
 /// @notice Hook implementation that:

--- a/src/hooks/FreezeOnly.sol
+++ b/src/hooks/FreezeOnly.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {IERC165} from "src/misc/interfaces/IERC7575.sol";
-import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
+import {IERC165} from "centrifuge-v3/src/misc/interfaces/IERC7575.sol";
+import {BitmapLib} from "centrifuge-v3/src/misc/libraries/BitmapLib.sol";
 
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ITransferHook, HookData} from "src/common/interfaces/ITransferHook.sol";
+import {IRoot} from "centrifuge-v3/src/common/interfaces/IRoot.sol";
+import {ITransferHook, HookData} from "centrifuge-v3/src/common/interfaces/ITransferHook.sol";
 
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
 
-import {IFreezable} from "src/hooks/interfaces/IFreezable.sol";
-import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {IFreezable} from "centrifuge-v3/src/hooks/interfaces/IFreezable.sol";
+import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 /// @title  Freeze Only
 /// @notice Hook implementation that:

--- a/src/hooks/FullRestrictions.sol
+++ b/src/hooks/FullRestrictions.sol
@@ -14,7 +14,10 @@ import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
 
 import {IFreezable} from "centrifuge-v3/src/hooks/interfaces/IFreezable.sol";
 import {IMemberlist} from "centrifuge-v3/src/hooks/interfaces/IMemberlist.sol";
-import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {
+    UpdateRestrictionType,
+    UpdateRestrictionMessageLib
+} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 /// @title  Full Restrictions
 /// @notice Hook implementation that:

--- a/src/hooks/FullRestrictions.sol
+++ b/src/hooks/FullRestrictions.sol
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {IERC165} from "src/misc/interfaces/IERC7575.sol";
-import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
+import {IERC165} from "centrifuge-v3/src/misc/interfaces/IERC7575.sol";
+import {BitmapLib} from "centrifuge-v3/src/misc/libraries/BitmapLib.sol";
 
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ITransferHook, HookData, ESCROW_HOOK_ID} from "src/common/interfaces/ITransferHook.sol";
+import {IRoot} from "centrifuge-v3/src/common/interfaces/IRoot.sol";
+import {ITransferHook, HookData, ESCROW_HOOK_ID} from "centrifuge-v3/src/common/interfaces/ITransferHook.sol";
 
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
 
-import {IFreezable} from "src/hooks/interfaces/IFreezable.sol";
-import {IMemberlist} from "src/hooks/interfaces/IMemberlist.sol";
-import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {IFreezable} from "centrifuge-v3/src/hooks/interfaces/IFreezable.sol";
+import {IMemberlist} from "centrifuge-v3/src/hooks/interfaces/IMemberlist.sol";
+import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 /// @title  Full Restrictions
 /// @notice Hook implementation that:

--- a/src/hooks/RedemptionRestrictions.sol
+++ b/src/hooks/RedemptionRestrictions.sol
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {IERC165} from "src/misc/interfaces/IERC7575.sol";
-import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
+import {IERC165} from "centrifuge-v3/src/misc/interfaces/IERC7575.sol";
+import {BitmapLib} from "centrifuge-v3/src/misc/libraries/BitmapLib.sol";
 
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ITransferHook, HookData, ESCROW_HOOK_ID} from "src/common/interfaces/ITransferHook.sol";
+import {IRoot} from "centrifuge-v3/src/common/interfaces/IRoot.sol";
+import {ITransferHook, HookData, ESCROW_HOOK_ID} from "centrifuge-v3/src/common/interfaces/ITransferHook.sol";
 
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
 
-import {IFreezable} from "src/hooks/interfaces/IFreezable.sol";
-import {IMemberlist} from "src/hooks/interfaces/IMemberlist.sol";
-import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {IFreezable} from "centrifuge-v3/src/hooks/interfaces/IFreezable.sol";
+import {IMemberlist} from "centrifuge-v3/src/hooks/interfaces/IMemberlist.sol";
+import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 /// @title  Redemption Restrictions
 /// @notice Hook implementation that:

--- a/src/hooks/RedemptionRestrictions.sol
+++ b/src/hooks/RedemptionRestrictions.sol
@@ -14,7 +14,10 @@ import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
 
 import {IFreezable} from "centrifuge-v3/src/hooks/interfaces/IFreezable.sol";
 import {IMemberlist} from "centrifuge-v3/src/hooks/interfaces/IMemberlist.sol";
-import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {
+    UpdateRestrictionType,
+    UpdateRestrictionMessageLib
+} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 /// @title  Redemption Restrictions
 /// @notice Hook implementation that:

--- a/src/hooks/libraries/UpdateRestrictionMessageLib.sol
+++ b/src/hooks/libraries/UpdateRestrictionMessageLib.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
 
 enum UpdateRestrictionType {
     /// @dev Placeholder for null update restriction type

--- a/src/hub/Accounting.sol
+++ b/src/hub/Accounting.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {TransientStorageLib} from "centrifuge-v3/src/misc/libraries/TransientStorageLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AccountId} from "centrifuge-v3/src/common/types/AccountId.sol";
 
-import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
+import {IAccounting, JournalEntry} from "centrifuge-v3/src/hub/interfaces/IAccounting.sol";
 
 /// @notice In a transaction there can be multiple journal entries for different pools,
 /// which can be interleaved. We want entries for the same pool to share the same journal ID.

--- a/src/hub/Holdings.sol
+++ b/src/hub/Holdings.sol
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18} from "src/misc/types/D18.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {AccountId} from "centrifuge-v3/src/common/types/AccountId.sol";
+import {PricingLib} from "centrifuge-v3/src/common/libraries/PricingLib.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {IValuation} from "centrifuge-v3/src/common/interfaces/IValuation.sol";
+import {ISnapshotHook} from "centrifuge-v3/src/common/interfaces/ISnapshotHook.sol";
 
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IHoldings, Holding, HoldingAccount, Snapshot} from "src/hub/interfaces/IHoldings.sol";
+import {IHubRegistry} from "centrifuge-v3/src/hub/interfaces/IHubRegistry.sol";
+import {IHoldings, Holding, HoldingAccount, Snapshot} from "centrifuge-v3/src/hub/interfaces/IHoldings.sol";
 
 /// @title  Holdings
 /// @notice Bookkeeping of the holdings and its associated accounting IDs for each pool.

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -1,31 +1,31 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18} from "src/misc/types/D18.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {Multicall, IMulticall} from "src/misc/Multicall.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {Recoverable} from "centrifuge-v3/src/misc/Recoverable.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
+import {Multicall, IMulticall} from "centrifuge-v3/src/misc/Multicall.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
-import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {IHubGatewayHandler} from "src/common/interfaces/IGatewayHandlers.sol";
-import {IHubGuardianActions} from "src/common/interfaces/IGuardianActions.sol";
-import {RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
-import {IPoolEscrow, IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {AccountId} from "centrifuge-v3/src/common/types/AccountId.sol";
+import {IGateway} from "centrifuge-v3/src/common/interfaces/IGateway.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {IValuation} from "centrifuge-v3/src/common/interfaces/IValuation.sol";
+import {ISnapshotHook} from "centrifuge-v3/src/common/interfaces/ISnapshotHook.sol";
+import {IHubMessageSender} from "centrifuge-v3/src/common/interfaces/IGatewaySenders.sol";
+import {IHubGatewayHandler} from "centrifuge-v3/src/common/interfaces/IGatewayHandlers.sol";
+import {IHubGuardianActions} from "centrifuge-v3/src/common/interfaces/IGuardianActions.sol";
+import {RequestCallbackMessageLib} from "centrifuge-v3/src/common/libraries/RequestCallbackMessageLib.sol";
+import {IPoolEscrow, IPoolEscrowFactory} from "centrifuge-v3/src/common/factories/interfaces/IPoolEscrowFactory.sol";
 
-import {IHoldings} from "src/hub/interfaces/IHoldings.sol";
-import {IHubHelpers} from "src/hub/interfaces/IHubHelpers.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IHub, VaultUpdateKind} from "src/hub/interfaces/IHub.sol";
-import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+import {IHoldings} from "centrifuge-v3/src/hub/interfaces/IHoldings.sol";
+import {IHubHelpers} from "centrifuge-v3/src/hub/interfaces/IHubHelpers.sol";
+import {IHubRegistry} from "centrifuge-v3/src/hub/interfaces/IHubRegistry.sol";
+import {IHub, VaultUpdateKind} from "centrifuge-v3/src/hub/interfaces/IHub.sol";
+import {IAccounting, JournalEntry} from "centrifuge-v3/src/hub/interfaces/IAccounting.sol";
+import {IShareClassManager} from "centrifuge-v3/src/hub/interfaces/IShareClassManager.sol";
 
 /// @title  Hub
 /// @notice Central pool management contract, that brings together all functions in one place.

--- a/src/hub/HubHelpers.sol
+++ b/src/hub/HubHelpers.sol
@@ -1,25 +1,25 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {D18, d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {RequestMessageLib, RequestType} from "src/common/libraries/RequestMessageLib.sol";
-import {RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {AccountId} from "centrifuge-v3/src/common/types/AccountId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {IValuation} from "centrifuge-v3/src/common/interfaces/IValuation.sol";
+import {IHubMessageSender} from "centrifuge-v3/src/common/interfaces/IGatewaySenders.sol";
+import {RequestMessageLib, RequestType} from "centrifuge-v3/src/common/libraries/RequestMessageLib.sol";
+import {RequestCallbackMessageLib} from "centrifuge-v3/src/common/libraries/RequestCallbackMessageLib.sol";
 
-import {IHub, AccountType} from "src/hub/interfaces/IHub.sol";
-import {IAccounting} from "src/hub/interfaces/IAccounting.sol";
-import {IHubHelpers} from "src/hub/interfaces/IHubHelpers.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IHoldings, HoldingAccount} from "src/hub/interfaces/IHoldings.sol";
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+import {IHub, AccountType} from "centrifuge-v3/src/hub/interfaces/IHub.sol";
+import {IAccounting} from "centrifuge-v3/src/hub/interfaces/IAccounting.sol";
+import {IHubHelpers} from "centrifuge-v3/src/hub/interfaces/IHubHelpers.sol";
+import {IHubRegistry} from "centrifuge-v3/src/hub/interfaces/IHubRegistry.sol";
+import {IHoldings, HoldingAccount} from "centrifuge-v3/src/hub/interfaces/IHoldings.sol";
+import {IShareClassManager} from "centrifuge-v3/src/hub/interfaces/IShareClassManager.sol";
 
 contract HubHelpers is Auth, IHubHelpers {
     using MathLib for uint256;

--- a/src/hub/HubRegistry.sol
+++ b/src/hub/HubRegistry.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
+import {IERC6909Decimals} from "centrifuge-v3/src/misc/interfaces/IERC6909.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {PoolId, newPoolId} from "src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {PoolId, newPoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
 
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
+import {IHubRegistry} from "centrifuge-v3/src/hub/interfaces/IHubRegistry.sol";
 
 /// @title  Hub Registry
 /// @notice Registry of all known pools, currencies, and assets.

--- a/src/hub/ShareClassManager.sol
+++ b/src/hub/ShareClassManager.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {D18, d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {ShareClassId, newShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {PricingLib} from "centrifuge-v3/src/common/libraries/PricingLib.sol";
+import {ShareClassId, newShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
+import {IHubRegistry} from "centrifuge-v3/src/hub/interfaces/IHubRegistry.sol";
 
 import {
     IShareClassManager,
@@ -24,7 +24,7 @@ import {
     QueuedOrder,
     RequestType,
     EpochId
-} from "src/hub/interfaces/IShareClassManager.sol";
+} from "centrifuge-v3/src/hub/interfaces/IShareClassManager.sol";
 
 /// @title  Share Class Manager
 /// @notice Manager for the share classes of a pool, and the core logic for tracking, approving, and fulfilling

--- a/src/hub/interfaces/IAccounting.sol
+++ b/src/hub/interfaces/IAccounting.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AccountId} from "centrifuge-v3/src/common/types/AccountId.sol";
 
 struct JournalEntry {
     uint128 value;

--- a/src/hub/interfaces/IHoldings.sol
+++ b/src/hub/interfaces/IHoldings.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {D18} from "src/misc/types/D18.sol";
+import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {AccountId} from "centrifuge-v3/src/common/types/AccountId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {IValuation} from "centrifuge-v3/src/common/interfaces/IValuation.sol";
+import {ISnapshotHook} from "centrifuge-v3/src/common/interfaces/ISnapshotHook.sol";
 
 struct Holding {
     uint128 assetAmount;

--- a/src/hub/interfaces/IHub.sol
+++ b/src/hub/interfaces/IHub.sol
@@ -1,22 +1,22 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {D18} from "src/misc/types/D18.sol";
+import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
-import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
-import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {AccountId} from "centrifuge-v3/src/common/types/AccountId.sol";
+import {IGateway} from "centrifuge-v3/src/common/interfaces/IGateway.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {IValuation} from "centrifuge-v3/src/common/interfaces/IValuation.sol";
+import {VaultUpdateKind} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
+import {ISnapshotHook} from "centrifuge-v3/src/common/interfaces/ISnapshotHook.sol";
+import {IHubMessageSender} from "centrifuge-v3/src/common/interfaces/IGatewaySenders.sol";
 
-import {IHoldings} from "src/hub/interfaces/IHoldings.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+import {IHoldings} from "centrifuge-v3/src/hub/interfaces/IHoldings.sol";
+import {IHubRegistry} from "centrifuge-v3/src/hub/interfaces/IHubRegistry.sol";
+import {IAccounting, JournalEntry} from "centrifuge-v3/src/hub/interfaces/IAccounting.sol";
+import {IShareClassManager} from "centrifuge-v3/src/hub/interfaces/IShareClassManager.sol";
 
 /// @notice Account types used by Hub
 enum AccountType {

--- a/src/hub/interfaces/IHubHelpers.sol
+++ b/src/hub/interfaces/IHubHelpers.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {D18} from "src/misc/types/D18.sol";
+import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {AccountId} from "centrifuge-v3/src/common/types/AccountId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {HoldingAccount} from "src/hub/interfaces/IHoldings.sol";
+import {HoldingAccount} from "centrifuge-v3/src/hub/interfaces/IHoldings.sol";
 
 interface IHubHelpers {
     /// @notice Emitted when a call to `file()` was performed.

--- a/src/hub/interfaces/IHubRegistry.sol
+++ b/src/hub/interfaces/IHubRegistry.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
+import {IERC6909Decimals} from "centrifuge-v3/src/misc/interfaces/IERC6909.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
 
 interface IHubRegistry is IERC6909Decimals {
     event NewAsset(AssetId indexed assetId, uint8 decimals);

--- a/src/hub/interfaces/IShareClassManager.sol
+++ b/src/hub/interfaces/IShareClassManager.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {D18} from "src/misc/types/D18.sol";
+import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
 struct EpochRedeemAmounts {
     /// @dev Amount of shares pending to be redeemed at time of epoch

--- a/src/managers/MerkleProofManager.sol
+++ b/src/managers/MerkleProofManager.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MerkleProofLib} from "src/misc/libraries/MerkleProofLib.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {MerkleProofLib} from "centrifuge-v3/src/misc/libraries/MerkleProofLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
-import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
-import {UpdateContractMessageLib, UpdateContractType} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import {IBalanceSheet} from "centrifuge-v3/src/spoke/interfaces/IBalanceSheet.sol";
+import {IUpdateContract} from "centrifuge-v3/src/spoke/interfaces/IUpdateContract.sol";
+import {UpdateContractMessageLib, UpdateContractType} from "centrifuge-v3/src/spoke/libraries/UpdateContractMessageLib.sol";
 
-import {IMerkleProofManagerFactory} from "src/managers/interfaces/IMerkleProofManagerFactory.sol";
-import {IMerkleProofManager, Call, PolicyLeaf} from "src/managers/interfaces/IMerkleProofManager.sol";
+import {IMerkleProofManagerFactory} from "centrifuge-v3/src/managers/interfaces/IMerkleProofManagerFactory.sol";
+import {IMerkleProofManager, Call, PolicyLeaf} from "centrifuge-v3/src/managers/interfaces/IMerkleProofManager.sol";
 
 /// @title  Merkle Proof Manager
 /// @author Inspired by Boring Vaults from Se7en-Seas

--- a/src/managers/MerkleProofManager.sol
+++ b/src/managers/MerkleProofManager.sol
@@ -9,7 +9,10 @@ import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
 import {IBalanceSheet} from "centrifuge-v3/src/spoke/interfaces/IBalanceSheet.sol";
 import {IUpdateContract} from "centrifuge-v3/src/spoke/interfaces/IUpdateContract.sol";
-import {UpdateContractMessageLib, UpdateContractType} from "centrifuge-v3/src/spoke/libraries/UpdateContractMessageLib.sol";
+import {
+    UpdateContractMessageLib,
+    UpdateContractType
+} from "centrifuge-v3/src/spoke/libraries/UpdateContractMessageLib.sol";
 
 import {IMerkleProofManagerFactory} from "centrifuge-v3/src/managers/interfaces/IMerkleProofManagerFactory.sol";
 import {IMerkleProofManager, Call, PolicyLeaf} from "centrifuge-v3/src/managers/interfaces/IMerkleProofManager.sol";

--- a/src/managers/OnOfframpManager.sol
+++ b/src/managers/OnOfframpManager.sol
@@ -11,7 +11,10 @@ import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
 import {IBalanceSheet} from "centrifuge-v3/src/spoke/interfaces/IBalanceSheet.sol";
 import {IUpdateContract} from "centrifuge-v3/src/spoke/interfaces/IUpdateContract.sol";
-import {UpdateContractType, UpdateContractMessageLib} from "centrifuge-v3/src/spoke/libraries/UpdateContractMessageLib.sol";
+import {
+    UpdateContractType,
+    UpdateContractMessageLib
+} from "centrifuge-v3/src/spoke/libraries/UpdateContractMessageLib.sol";
 
 import {IOnOfframpManager} from "centrifuge-v3/src/managers/interfaces/IOnOfframpManager.sol";
 import {IOnOfframpManagerFactory} from "centrifuge-v3/src/managers/interfaces/IOnOfframpManagerFactory.sol";

--- a/src/managers/OnOfframpManager.sol
+++ b/src/managers/OnOfframpManager.sol
@@ -1,21 +1,21 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {IERC165} from "src/misc/interfaces/IERC165.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {IERC165} from "centrifuge-v3/src/misc/interfaces/IERC165.sol";
+import {SafeTransferLib} from "centrifuge-v3/src/misc/libraries/SafeTransferLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
-import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
-import {UpdateContractType, UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import {IBalanceSheet} from "centrifuge-v3/src/spoke/interfaces/IBalanceSheet.sol";
+import {IUpdateContract} from "centrifuge-v3/src/spoke/interfaces/IUpdateContract.sol";
+import {UpdateContractType, UpdateContractMessageLib} from "centrifuge-v3/src/spoke/libraries/UpdateContractMessageLib.sol";
 
-import {IOnOfframpManager} from "src/managers/interfaces/IOnOfframpManager.sol";
-import {IOnOfframpManagerFactory} from "src/managers/interfaces/IOnOfframpManagerFactory.sol";
-import {IDepositManager, IWithdrawManager} from "src/managers/interfaces/IBalanceSheetManager.sol";
+import {IOnOfframpManager} from "centrifuge-v3/src/managers/interfaces/IOnOfframpManager.sol";
+import {IOnOfframpManagerFactory} from "centrifuge-v3/src/managers/interfaces/IOnOfframpManagerFactory.sol";
+import {IDepositManager, IWithdrawManager} from "centrifuge-v3/src/managers/interfaces/IBalanceSheetManager.sol";
 
 /// @title  OnOfframpManager
 /// @notice Balance sheet manager for depositing and withdrawing ERC20 assets.

--- a/src/managers/decoders/BaseDecoder.sol
+++ b/src/managers/decoders/BaseDecoder.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
 contract BaseDecoder {
     error FunctionNotImplemented(bytes _calldata);

--- a/src/managers/decoders/CircleDecoder.sol
+++ b/src/managers/decoders/CircleDecoder.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {BaseDecoder} from "src/managers/decoders/BaseDecoder.sol";
+import {BaseDecoder} from "centrifuge-v3/src/managers/decoders/BaseDecoder.sol";
 
 contract CircleDecoder is BaseDecoder {
     /// @notice Deposit assets into Circle to burn, in order to bridge to another chain

--- a/src/managers/decoders/VaultDecoder.sol
+++ b/src/managers/decoders/VaultDecoder.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {BaseDecoder} from "src/managers/decoders/BaseDecoder.sol";
+import {BaseDecoder} from "centrifuge-v3/src/managers/decoders/BaseDecoder.sol";
 
 contract VaultDecoder is BaseDecoder {
     /// @notice Deposit into the ERC4626 vault

--- a/src/managers/interfaces/IBalanceSheetManager.sol
+++ b/src/managers/interfaces/IBalanceSheetManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IERC165} from "src/misc/interfaces/IERC165.sol";
+import {IERC165} from "centrifuge-v3/src/misc/interfaces/IERC165.sol";
 
 interface IDepositManager is IERC165 {
     function deposit(address asset, uint256 tokenId, uint128 amount, address owner) external;

--- a/src/managers/interfaces/IMerkleProofManagerFactory.sol
+++ b/src/managers/interfaces/IMerkleProofManagerFactory.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
 
-import {IMerkleProofManager} from "src/managers/interfaces/IMerkleProofManager.sol";
+import {IMerkleProofManager} from "centrifuge-v3/src/managers/interfaces/IMerkleProofManager.sol";
 
 interface IMerkleProofManagerFactory {
     event DeployMerkleProofManager(PoolId indexed poolId, address indexed manager);

--- a/src/managers/interfaces/IOnOfframpManager.sol
+++ b/src/managers/interfaces/IOnOfframpManager.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
+import {IUpdateContract} from "centrifuge-v3/src/spoke/interfaces/IUpdateContract.sol";
 
-import {IDepositManager, IWithdrawManager} from "src/managers/interfaces/IBalanceSheetManager.sol";
+import {IDepositManager, IWithdrawManager} from "centrifuge-v3/src/managers/interfaces/IBalanceSheetManager.sol";
 
 interface IOnOfframpManager is IDepositManager, IWithdrawManager, IUpdateContract {
     event UpdateOnramp(address indexed asset, bool isEnabled);

--- a/src/managers/interfaces/IOnOfframpManagerFactory.sol
+++ b/src/managers/interfaces/IOnOfframpManagerFactory.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {IOnOfframpManager} from "src/managers/interfaces/IOnOfframpManager.sol";
+import {IOnOfframpManager} from "centrifuge-v3/src/managers/interfaces/IOnOfframpManager.sol";
 
 interface IOnOfframpManagerFactory {
     event DeployOnOfframpManager(PoolId indexed poolId, ShareClassId scId, address indexed manager);

--- a/src/misc/Auth.sol
+++ b/src/misc/Auth.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
 
 /// @title  Auth
 /// @notice Simple authentication pattern

--- a/src/misc/ERC20.sol
+++ b/src/misc/ERC20.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {EIP712Lib} from "src/misc/libraries/EIP712Lib.sol";
-import {SignatureLib} from "src/misc/libraries/SignatureLib.sol";
-import {IERC20, IERC20Metadata, IERC20Permit} from "src/misc/interfaces/IERC20.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {EIP712Lib} from "centrifuge-v3/src/misc/libraries/EIP712Lib.sol";
+import {SignatureLib} from "centrifuge-v3/src/misc/libraries/SignatureLib.sol";
+import {IERC20, IERC20Metadata, IERC20Permit} from "centrifuge-v3/src/misc/interfaces/IERC20.sol";
 
 /// @title  ERC20
 /// @notice Standard ERC-20 implementation, with mint/burn functionality and permit logic.
-/// @author Modified from https://github.com/makerdao/xdomain-dss/blob/master/src/Dai.sol
+/// @author Modified from https://github.com/makerdao/xdomain-dss/blob/master/centrifuge-v3/src/Dai.sol
 contract ERC20 is Auth, IERC20Metadata, IERC20Permit {
     event File(bytes32 indexed what, string data);
 

--- a/src/misc/Escrow.sol
+++ b/src/misc/Escrow.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
-import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {IERC20} from "centrifuge-v3/src/misc/interfaces/IERC20.sol";
+import {IEscrow} from "centrifuge-v3/src/misc/interfaces/IEscrow.sol";
+import {IERC6909} from "centrifuge-v3/src/misc/interfaces/IERC6909.sol";
+import {SafeTransferLib} from "centrifuge-v3/src/misc/libraries/SafeTransferLib.sol";
 
 contract Escrow is Auth, IEscrow {
     constructor(address deployer) Auth(deployer) {}

--- a/src/misc/IdentityValuation.sol
+++ b/src/misc/IdentityValuation.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {d18} from "src/misc/types/D18.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
-import {IIdentityValuation} from "src/misc/interfaces/IIdentityValuation.sol";
+import {d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
+import {IERC6909Decimals} from "centrifuge-v3/src/misc/interfaces/IERC6909.sol";
+import {IIdentityValuation} from "centrifuge-v3/src/misc/interfaces/IIdentityValuation.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {BaseValuation} from "src/common/BaseValuation.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {BaseValuation} from "centrifuge-v3/src/common/BaseValuation.sol";
+import {PricingLib} from "centrifuge-v3/src/common/libraries/PricingLib.sol";
+import {IValuation} from "centrifuge-v3/src/common/interfaces/IValuation.sol";
 
 contract IdentityValuation is BaseValuation, IIdentityValuation {
     using MathLib for *;

--- a/src/misc/Multicall.sol
+++ b/src/misc/Multicall.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.28;
 // NOTE: This file has warning disabled due https://github.com/ethereum/solidity/issues/14359
 // If perform any change on it, please ensure no other warnings appears
 
-import {IMulticall} from "src/misc/interfaces/IMulticall.sol";
-import {ReentrancyProtection} from "src/misc/ReentrancyProtection.sol";
+import {IMulticall} from "centrifuge-v3/src/misc/interfaces/IMulticall.sol";
+import {ReentrancyProtection} from "centrifuge-v3/src/misc/ReentrancyProtection.sol";
 
 abstract contract Multicall is ReentrancyProtection, IMulticall {
     function multicall(bytes[] calldata data) public payable virtual protected {

--- a/src/misc/Recoverable.sol
+++ b/src/misc/Recoverable.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
-import {IRecoverable, ETH_ADDRESS} from "src/misc/interfaces/IRecoverable.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {IERC6909} from "centrifuge-v3/src/misc/interfaces/IERC6909.sol";
+import {SafeTransferLib} from "centrifuge-v3/src/misc/libraries/SafeTransferLib.sol";
+import {IRecoverable, ETH_ADDRESS} from "centrifuge-v3/src/misc/interfaces/IRecoverable.sol";
 
 abstract contract Recoverable is Auth, IRecoverable {
     /// @inheritdoc IRecoverable

--- a/src/misc/interfaces/IERC7575.sol
+++ b/src/misc/interfaces/IERC7575.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IERC165} from "src/misc/interfaces/IERC165.sol";
+import {IERC165} from "centrifuge-v3/src/misc/interfaces/IERC165.sol";
 
 interface IERC7575 is IERC165 {
     event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares);

--- a/src/misc/interfaces/IIdentityValuation.sol
+++ b/src/misc/interfaces/IIdentityValuation.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {IValuation} from "centrifuge-v3/src/common/interfaces/IValuation.sol";
 
 /// @notice An IERC7726 valuation that always values 1:1.
 interface IIdentityValuation is IValuation {}

--- a/src/misc/libraries/MathLib.sol
+++ b/src/misc/libraries/MathLib.sol
@@ -20,7 +20,8 @@ library MathLib {
 
     /// @notice Returns x^n with rounding precision of base
     ///
-    /// @dev Source: https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/centrifuge-v3/src/jug.sol#L62
+    /// @dev Source:
+    /// https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/centrifuge-v3/src/jug.sol#L62
     ///
     /// @param x The base value which should be exponentiated
     /// @param n The exponent

--- a/src/misc/libraries/MathLib.sol
+++ b/src/misc/libraries/MathLib.sol
@@ -20,7 +20,7 @@ library MathLib {
 
     /// @notice Returns x^n with rounding precision of base
     ///
-    /// @dev Source: https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/src/jug.sol#L62
+    /// @dev Source: https://github.com/makerdao/dss/blob/fa4f6630afb0624d04a003e920b0d71a00331d98/centrifuge-v3/src/jug.sol#L62
     ///
     /// @param x The base value which should be exponentiated
     /// @param n The exponent

--- a/src/misc/libraries/MerkleProofLib.sol
+++ b/src/misc/libraries/MerkleProofLib.sol
@@ -3,7 +3,8 @@ pragma solidity 0.8.28;
 
 /// @notice Gas optimized merkle proof verification library.
 /// @author Solmate (https://github.com/transmissions11/solmate/blob/main/centrifuge-v3/src/utils/MerkleProofLib.sol)
-/// @author Modified from Solady (https://github.com/Vectorized/solady/blob/main/centrifuge-v3/src/utils/MerkleProofLib.sol)
+/// @author Modified from Solady
+/// (https://github.com/Vectorized/solady/blob/main/centrifuge-v3/src/utils/MerkleProofLib.sol)
 library MerkleProofLib {
     function verify(bytes32[] calldata proof, bytes32 root, bytes32 leaf) internal pure returns (bool isValid) {
         /// @solidity memory-safe-assembly

--- a/src/misc/libraries/MerkleProofLib.sol
+++ b/src/misc/libraries/MerkleProofLib.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.28;
 
 /// @notice Gas optimized merkle proof verification library.
-/// @author Solmate (https://github.com/transmissions11/solmate/blob/main/src/utils/MerkleProofLib.sol)
-/// @author Modified from Solady (https://github.com/Vectorized/solady/blob/main/src/utils/MerkleProofLib.sol)
+/// @author Solmate (https://github.com/transmissions11/solmate/blob/main/centrifuge-v3/src/utils/MerkleProofLib.sol)
+/// @author Modified from Solady (https://github.com/Vectorized/solady/blob/main/centrifuge-v3/src/utils/MerkleProofLib.sol)
 library MerkleProofLib {
     function verify(bytes32[] calldata proof, bytes32 root, bytes32 leaf) internal pure returns (bool isValid) {
         /// @solidity memory-safe-assembly

--- a/src/misc/libraries/SafeTransferLib.sol
+++ b/src/misc/libraries/SafeTransferLib.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
-import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
+import {IERC20} from "centrifuge-v3/src/misc/interfaces/IERC20.sol";
+import {IERC7751} from "centrifuge-v3/src/misc/interfaces/IERC7751.sol";
 
 /// @title  Safe Transfer Lib
 /// @author Modified from Uniswap v3 Periphery (libraries/TransferHelper.sol)

--- a/src/misc/libraries/TransientArrayLib.sol
+++ b/src/misc/libraries/TransientArrayLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
+import {TransientStorageLib} from "centrifuge-v3/src/misc/libraries/TransientStorageLib.sol";
 
 /// @title  TransientArrayLib
 library TransientArrayLib {

--- a/src/misc/libraries/TransientBytesLib.sol
+++ b/src/misc/libraries/TransientBytesLib.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
+import {TransientStorageLib} from "centrifuge-v3/src/misc/libraries/TransientStorageLib.sol";
 
 /// @title  TransientBytesLib
 library TransientBytesLib {

--- a/src/misc/types/D18.sol
+++ b/src/misc/types/D18.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.28;
 
 // Small library to handle fixed point number operations with 18 decimals with static typing support.
 
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
 
 type D18 is uint128;
 

--- a/src/spoke/BalanceSheet.sol
+++ b/src/spoke/BalanceSheet.sol
@@ -1,30 +1,30 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
-import {Multicall, IMulticall} from "src/misc/Multicall.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
-import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {D18, d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
+import {Recoverable} from "centrifuge-v3/src/misc/Recoverable.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
+import {IERC6909} from "centrifuge-v3/src/misc/interfaces/IERC6909.sol";
+import {Multicall, IMulticall} from "centrifuge-v3/src/misc/Multicall.sol";
+import {SafeTransferLib} from "centrifuge-v3/src/misc/libraries/SafeTransferLib.sol";
+import {TransientStorageLib} from "centrifuge-v3/src/misc/libraries/TransientStorageLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {IBalanceSheetGatewayHandler} from "src/common/interfaces/IGatewayHandlers.sol";
-import {IPoolEscrowProvider} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {IRoot} from "centrifuge-v3/src/common/interfaces/IRoot.sol";
+import {IGateway} from "centrifuge-v3/src/common/interfaces/IGateway.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {IPoolEscrow} from "centrifuge-v3/src/common/interfaces/IPoolEscrow.sol";
+import {ISpokeMessageSender} from "centrifuge-v3/src/common/interfaces/IGatewaySenders.sol";
+import {IBalanceSheetGatewayHandler} from "centrifuge-v3/src/common/interfaces/IGatewayHandlers.sol";
+import {IPoolEscrowProvider} from "centrifuge-v3/src/common/factories/interfaces/IPoolEscrowFactory.sol";
 
-import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IBalanceSheet, ShareQueueAmount, AssetQueueAmount} from "src/spoke/interfaces/IBalanceSheet.sol";
+import {ISpoke} from "centrifuge-v3/src/spoke/interfaces/ISpoke.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
+import {IBalanceSheet, ShareQueueAmount, AssetQueueAmount} from "centrifuge-v3/src/spoke/interfaces/IBalanceSheet.sol";
 
 /// @title  Balance Sheet
 /// @notice Management contract that integrates all balance sheet functions of a pool:

--- a/src/spoke/ContractUpdater.sol
+++ b/src/spoke/ContractUpdater.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IUpdateContractGatewayHandler} from "src/common/interfaces/IGatewayHandlers.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {IUpdateContractGatewayHandler} from "centrifuge-v3/src/common/interfaces/IGatewayHandlers.sol";
 
-import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
+import {IUpdateContract} from "centrifuge-v3/src/spoke/interfaces/IUpdateContract.sol";
 
 contract ContractUpdater is Auth, IUpdateContractGatewayHandler {
     event UpdateContract(PoolId indexed poolId, ShareClassId indexed scId, address target, bytes payload);

--- a/src/spoke/ShareToken.sol
+++ b/src/spoke/ShareToken.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ERC20} from "src/misc/ERC20.sol";
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC7575Share, IERC165} from "src/misc/interfaces/IERC7575.sol";
+import {ERC20} from "centrifuge-v3/src/misc/ERC20.sol";
+import {IERC20} from "centrifuge-v3/src/misc/interfaces/IERC20.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
+import {IERC7575Share, IERC165} from "centrifuge-v3/src/misc/interfaces/IERC7575.sol";
 
-import {IShareToken, IERC1404} from "src/spoke/interfaces/IShareToken.sol";
+import {IShareToken, IERC1404} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
 
 import {
     ITransferHook,
@@ -15,7 +15,7 @@ import {
     SUCCESS_MESSAGE,
     ERROR_CODE_ID,
     ERROR_MESSAGE
-} from "src/common/interfaces/ITransferHook.sol";
+} from "centrifuge-v3/src/common/interfaces/ITransferHook.sol";
 
 /// @title  Share Token
 /// @notice Extension of ERC20 + ERC1404,

--- a/src/spoke/Spoke.sol
+++ b/src/spoke/Spoke.sol
@@ -1,36 +1,36 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18} from "src/misc/types/D18.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {IERC165} from "src/misc/interfaces/IERC7575.sol";
-import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
-import {IERC6909MetadataExt} from "src/misc/interfaces/IERC6909.sol";
-import {ReentrancyProtection} from "src/misc/ReentrancyProtection.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {Recoverable} from "centrifuge-v3/src/misc/Recoverable.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
+import {IERC165} from "centrifuge-v3/src/misc/interfaces/IERC7575.sol";
+import {IERC20Metadata} from "centrifuge-v3/src/misc/interfaces/IERC20.sol";
+import {IERC6909MetadataExt} from "centrifuge-v3/src/misc/interfaces/IERC6909.sol";
+import {ReentrancyProtection} from "centrifuge-v3/src/misc/ReentrancyProtection.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {newAssetId, AssetId} from "src/common/types/AssetId.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
-import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {ISpokeGatewayHandler} from "src/common/interfaces/IGatewayHandlers.sol";
-import {VaultUpdateKind, MessageLib} from "src/common/libraries/MessageLib.sol";
-import {IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {IGateway} from "centrifuge-v3/src/common/interfaces/IGateway.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {newAssetId, AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {IPoolEscrow} from "centrifuge-v3/src/common/interfaces/IPoolEscrow.sol";
+import {ITransferHook} from "centrifuge-v3/src/common/interfaces/ITransferHook.sol";
+import {ISpokeMessageSender} from "centrifuge-v3/src/common/interfaces/IGatewaySenders.sol";
+import {ISpokeGatewayHandler} from "centrifuge-v3/src/common/interfaces/IGatewayHandlers.sol";
+import {VaultUpdateKind, MessageLib} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
+import {IPoolEscrowFactory} from "centrifuge-v3/src/common/factories/interfaces/IPoolEscrowFactory.sol";
 
-import {Price} from "src/spoke/types/Price.sol";
-import {IVault} from "src/spoke/interfaces/IVault.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
-import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
-import {ITokenFactory} from "src/spoke/factories/interfaces/ITokenFactory.sol";
-import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
-import {AssetIdKey, Pool, ShareClassDetails, VaultDetails, ISpoke} from "src/spoke/interfaces/ISpoke.sol";
+import {Price} from "centrifuge-v3/src/spoke/types/Price.sol";
+import {IVault} from "centrifuge-v3/src/spoke/interfaces/IVault.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
+import {IVaultManager} from "centrifuge-v3/src/spoke/interfaces/IVaultManager.sol";
+import {IRequestManager} from "centrifuge-v3/src/spoke/interfaces/IRequestManager.sol";
+import {ITokenFactory} from "centrifuge-v3/src/spoke/factories/interfaces/ITokenFactory.sol";
+import {IVaultFactory} from "centrifuge-v3/src/spoke/factories/interfaces/IVaultFactory.sol";
+import {AssetIdKey, Pool, ShareClassDetails, VaultDetails, ISpoke} from "centrifuge-v3/src/spoke/interfaces/ISpoke.sol";
 
 /// @title  Spoke
 /// @notice This contract manages which pools & share classes exist, controlling allowed pool currencies,

--- a/src/spoke/Spoke.sol
+++ b/src/spoke/Spoke.sol
@@ -30,7 +30,9 @@ import {IVaultManager} from "centrifuge-v3/src/spoke/interfaces/IVaultManager.so
 import {IRequestManager} from "centrifuge-v3/src/spoke/interfaces/IRequestManager.sol";
 import {ITokenFactory} from "centrifuge-v3/src/spoke/factories/interfaces/ITokenFactory.sol";
 import {IVaultFactory} from "centrifuge-v3/src/spoke/factories/interfaces/IVaultFactory.sol";
-import {AssetIdKey, Pool, ShareClassDetails, VaultDetails, ISpoke} from "centrifuge-v3/src/spoke/interfaces/ISpoke.sol";
+import {
+    AssetIdKey, Pool, ShareClassDetails, VaultDetails, ISpoke
+} from "centrifuge-v3/src/spoke/interfaces/ISpoke.sol";
 
 /// @title  Spoke
 /// @notice This contract manages which pools & share classes exist, controlling allowed pool currencies,

--- a/src/spoke/factories/TokenFactory.sol
+++ b/src/spoke/factories/TokenFactory.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
 
-import {ShareToken} from "src/spoke/ShareToken.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {ITokenFactory} from "src/spoke/factories/interfaces/ITokenFactory.sol";
+import {ShareToken} from "centrifuge-v3/src/spoke/ShareToken.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
+import {ITokenFactory} from "centrifuge-v3/src/spoke/factories/interfaces/ITokenFactory.sol";
 
 /// @title  Share Token Factory
 /// @dev    Utility for deploying new share class token contracts

--- a/src/spoke/factories/interfaces/ITokenFactory.sol
+++ b/src/spoke/factories/interfaces/ITokenFactory.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
 
 interface ITokenFactory {
     event File(bytes32 what, address[] addr);

--- a/src/spoke/factories/interfaces/IVaultFactory.sol
+++ b/src/spoke/factories/interfaces/IVaultFactory.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {IVault} from "src/spoke/interfaces/IVault.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {IVault} from "centrifuge-v3/src/spoke/interfaces/IVault.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
 
 interface IVaultFactory {
     error UnsupportedTokenId();

--- a/src/spoke/interfaces/IBalanceSheet.sol
+++ b/src/spoke/interfaces/IBalanceSheet.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {D18} from "src/misc/types/D18.sol";
+import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {IPoolEscrowProvider} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {IRoot} from "centrifuge-v3/src/common/interfaces/IRoot.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {IPoolEscrow} from "centrifuge-v3/src/common/interfaces/IPoolEscrow.sol";
+import {ISpokeMessageSender} from "centrifuge-v3/src/common/interfaces/IGatewaySenders.sol";
+import {IPoolEscrowProvider} from "centrifuge-v3/src/common/factories/interfaces/IPoolEscrowFactory.sol";
 
-import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
+import {ISpoke} from "centrifuge-v3/src/spoke/interfaces/ISpoke.sol";
 
 struct ShareQueueAmount {
     // Net queued shares

--- a/src/spoke/interfaces/IRequestManager.sol
+++ b/src/spoke/interfaces/IRequestManager.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
 interface IRequestManager {
     error UnknownRequestCallbackType();

--- a/src/spoke/interfaces/IShareToken.sol
+++ b/src/spoke/interfaces/IShareToken.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
-import {IERC7575Share} from "src/misc/interfaces/IERC7575.sol";
+import {IERC20Metadata} from "centrifuge-v3/src/misc/interfaces/IERC20.sol";
+import {IERC7575Share} from "centrifuge-v3/src/misc/interfaces/IERC7575.sol";
 
 interface IERC1404 {
     /// @notice Detects if a transfer will be reverted and if so returns an appropriate reference code

--- a/src/spoke/interfaces/ISpoke.sol
+++ b/src/spoke/interfaces/ISpoke.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {D18} from "src/misc/types/D18.sol";
+import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {Price} from "src/spoke/types/Price.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IVault, VaultKind} from "src/spoke/interfaces/IVault.sol";
-import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
-import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
+import {Price} from "centrifuge-v3/src/spoke/types/Price.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
+import {IVault, VaultKind} from "centrifuge-v3/src/spoke/interfaces/IVault.sol";
+import {IRequestManager} from "centrifuge-v3/src/spoke/interfaces/IRequestManager.sol";
+import {IVaultFactory} from "centrifuge-v3/src/spoke/factories/interfaces/IVaultFactory.sol";
 
 /// @dev Centrifuge pools
 struct Pool {

--- a/src/spoke/interfaces/IUpdateContract.sol
+++ b/src/spoke/interfaces/IUpdateContract.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
 interface IUpdateContract {
     error UnknownUpdateContractType();

--- a/src/spoke/interfaces/IVault.sol
+++ b/src/spoke/interfaces/IVault.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
+import {IVaultManager} from "centrifuge-v3/src/spoke/interfaces/IVaultManager.sol";
 
 enum VaultKind {
     /// @dev Refers to AsyncVault

--- a/src/spoke/interfaces/IVaultManager.sol
+++ b/src/spoke/interfaces/IVaultManager.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {IVault} from "src/spoke/interfaces/IVault.sol";
+import {IVault} from "centrifuge-v3/src/spoke/interfaces/IVault.sol";
 
 interface IVaultManager {
     error VaultAlreadyExists();

--- a/src/spoke/libraries/UpdateContractMessageLib.sol
+++ b/src/spoke/libraries/UpdateContractMessageLib.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
 
 enum UpdateContractType {
     /// @dev Placeholder for null update restriction type

--- a/src/spoke/types/Price.sol
+++ b/src/spoke/types/Price.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
+import {D18, d18} from "centrifuge-v3/src/misc/types/D18.sol";
 
 /// @dev Price struct that contains a price, the timestamp at which it was computed and the max age of the price.
 struct Price {

--- a/src/vaults/AsyncRequestManager.sol
+++ b/src/vaults/AsyncRequestManager.sol
@@ -16,7 +16,10 @@ import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 import {IPoolEscrow} from "centrifuge-v3/src/common/interfaces/IPoolEscrow.sol";
 import {ESCROW_HOOK_ID} from "centrifuge-v3/src/common/interfaces/ITransferHook.sol";
 import {RequestMessageLib} from "centrifuge-v3/src/common/libraries/RequestMessageLib.sol";
-import {RequestCallbackType, RequestCallbackMessageLib} from "centrifuge-v3/src/common/libraries/RequestCallbackMessageLib.sol";
+import {
+    RequestCallbackType,
+    RequestCallbackMessageLib
+} from "centrifuge-v3/src/common/libraries/RequestCallbackMessageLib.sol";
 
 import {IVault} from "centrifuge-v3/src/spoke/interfaces/IVault.sol";
 import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";

--- a/src/vaults/AsyncRequestManager.sol
+++ b/src/vaults/AsyncRequestManager.sol
@@ -1,38 +1,38 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {D18, d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {Recoverable} from "centrifuge-v3/src/misc/Recoverable.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
+import {IEscrow} from "centrifuge-v3/src/misc/interfaces/IEscrow.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {ESCROW_HOOK_ID} from "src/common/interfaces/ITransferHook.sol";
-import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
-import {RequestCallbackType, RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {PricingLib} from "centrifuge-v3/src/common/libraries/PricingLib.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {IPoolEscrow} from "centrifuge-v3/src/common/interfaces/IPoolEscrow.sol";
+import {ESCROW_HOOK_ID} from "centrifuge-v3/src/common/interfaces/ITransferHook.sol";
+import {RequestMessageLib} from "centrifuge-v3/src/common/libraries/RequestMessageLib.sol";
+import {RequestCallbackType, RequestCallbackMessageLib} from "centrifuge-v3/src/common/libraries/RequestCallbackMessageLib.sol";
 
-import {IVault} from "src/spoke/interfaces/IVault.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
-import {ISpoke, VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
-import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
-import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
+import {IVault} from "centrifuge-v3/src/spoke/interfaces/IVault.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
+import {IBalanceSheet} from "centrifuge-v3/src/spoke/interfaces/IBalanceSheet.sol";
+import {ISpoke, VaultDetails} from "centrifuge-v3/src/spoke/interfaces/ISpoke.sol";
+import {IVaultManager} from "centrifuge-v3/src/spoke/interfaces/IVaultManager.sol";
+import {IRequestManager} from "centrifuge-v3/src/spoke/interfaces/IRequestManager.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IAsyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
-import {IAsyncVault, IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IAsyncRequestManager, AsyncInvestmentState} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
+import {IRedeemManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
+import {IDepositManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
+import {IAsyncRedeemManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
+import {IAsyncDepositManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseRequestManager} from "centrifuge-v3/src/vaults/interfaces/IBaseRequestManager.sol";
+import {IAsyncVault, IAsyncRedeemVault} from "centrifuge-v3/src/vaults/interfaces/IAsyncVault.sol";
+import {IAsyncRequestManager, AsyncInvestmentState} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 
 /// @title  Async Request Manager
 /// @notice This is the main contract vaults interact with for

--- a/src/vaults/AsyncVault.sol
+++ b/src/vaults/AsyncVault.sol
@@ -1,21 +1,21 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "src/misc/interfaces/IERC7540.sol";
-import "src/misc/interfaces/IERC7575.sol";
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
+import "centrifuge-v3/src/misc/interfaces/IERC7540.sol";
+import "centrifuge-v3/src/misc/interfaces/IERC7575.sol";
+import {IERC20} from "centrifuge-v3/src/misc/interfaces/IERC20.sol";
+import {SafeTransferLib} from "centrifuge-v3/src/misc/libraries/SafeTransferLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {VaultKind} from "src/spoke/interfaces/IVault.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {VaultKind} from "centrifuge-v3/src/spoke/interfaces/IVault.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
 
-import {BaseVault} from "src/vaults/BaseVaults.sol";
-import {BaseAsyncRedeemVault} from "src/vaults/BaseVaults.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {BaseVault} from "centrifuge-v3/src/vaults/BaseVaults.sol";
+import {BaseAsyncRedeemVault} from "centrifuge-v3/src/vaults/BaseVaults.sol";
+import {IAsyncVault} from "centrifuge-v3/src/vaults/interfaces/IAsyncVault.sol";
+import {IAsyncRequestManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 
 /// @title  AsyncVault
 /// @notice Asynchronous Tokenized Vault standard implementation for Centrifuge pools

--- a/src/vaults/BaseVaults.sol
+++ b/src/vaults/BaseVaults.sol
@@ -1,29 +1,29 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import "src/misc/interfaces/IERC7540.sol";
-import "src/misc/interfaces/IERC7575.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
-import {IERC7575} from "src/misc/interfaces/IERC7575.sol";
-import {EIP712Lib} from "src/misc/libraries/EIP712Lib.sol";
-import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
-import {SignatureLib} from "src/misc/libraries/SignatureLib.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import "centrifuge-v3/src/misc/interfaces/IERC7540.sol";
+import "centrifuge-v3/src/misc/interfaces/IERC7575.sol";
+import {Recoverable} from "centrifuge-v3/src/misc/Recoverable.sol";
+import {IERC7575} from "centrifuge-v3/src/misc/interfaces/IERC7575.sol";
+import {EIP712Lib} from "centrifuge-v3/src/misc/libraries/EIP712Lib.sol";
+import {IERC20Metadata} from "centrifuge-v3/src/misc/interfaces/IERC20.sol";
+import {SignatureLib} from "centrifuge-v3/src/misc/libraries/SignatureLib.sol";
+import {SafeTransferLib} from "centrifuge-v3/src/misc/libraries/SafeTransferLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {IRoot} from "centrifuge-v3/src/common/interfaces/IRoot.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {IVault} from "src/spoke/interfaces/IVaultManager.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
+import {IVault} from "centrifuge-v3/src/spoke/interfaces/IVaultManager.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
+import {IVaultManager} from "centrifuge-v3/src/spoke/interfaces/IVaultManager.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {ISyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
+import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncRedeemVault} from "centrifuge-v3/src/vaults/interfaces/IAsyncVault.sol";
+import {IAsyncRedeemManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
+import {ISyncDepositManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseRequestManager} from "centrifuge-v3/src/vaults/interfaces/IBaseRequestManager.sol";
 
 abstract contract BaseVault is Auth, Recoverable, IBaseVault {
     /// @dev Requests for Centrifuge pool are non-fungible and all have ID = 0

--- a/src/vaults/SyncDepositVault.sol
+++ b/src/vaults/SyncDepositVault.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IERC165} from "src/misc/interfaces/IERC7575.sol";
+import {IERC165} from "centrifuge-v3/src/misc/interfaces/IERC7575.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {VaultKind} from "src/spoke/interfaces/IVault.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {VaultKind} from "centrifuge-v3/src/spoke/interfaces/IVault.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
 
-import {BaseVault} from "src/vaults/BaseVaults.sol";
-import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {ISyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
-import {BaseAsyncRedeemVault, BaseSyncDepositVault} from "src/vaults/BaseVaults.sol";
+import {BaseVault} from "centrifuge-v3/src/vaults/BaseVaults.sol";
+import {IAsyncRedeemManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
+import {ISyncDepositManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseRequestManager} from "centrifuge-v3/src/vaults/interfaces/IBaseRequestManager.sol";
+import {BaseAsyncRedeemVault, BaseSyncDepositVault} from "centrifuge-v3/src/vaults/BaseVaults.sol";
 
 /// @title  SyncDepositVault
 /// @notice Partially (a)synchronous Tokenized Vault implementation with synchronous deposits

--- a/src/vaults/SyncManager.sol
+++ b/src/vaults/SyncManager.sol
@@ -1,27 +1,27 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18} from "src/misc/types/D18.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {Recoverable} from "centrifuge-v3/src/misc/Recoverable.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {PricingLib} from "centrifuge-v3/src/common/libraries/PricingLib.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
-import {ISpoke, VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
-import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
-import {UpdateContractMessageLib, UpdateContractType} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import {IBalanceSheet} from "centrifuge-v3/src/spoke/interfaces/IBalanceSheet.sol";
+import {ISpoke, VaultDetails} from "centrifuge-v3/src/spoke/interfaces/ISpoke.sol";
+import {IUpdateContract} from "centrifuge-v3/src/spoke/interfaces/IUpdateContract.sol";
+import {UpdateContractMessageLib, UpdateContractType} from "centrifuge-v3/src/spoke/libraries/UpdateContractMessageLib.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {ISyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {ISyncManager, ISyncDepositValuation} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
+import {IDepositManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
+import {ISyncDepositManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
+import {ISyncManager, ISyncDepositValuation} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 
 /// @title  Sync Manager
 /// @notice This is the main contract for synchronous ERC-4626 deposits.

--- a/src/vaults/SyncManager.sol
+++ b/src/vaults/SyncManager.sol
@@ -16,7 +16,10 @@ import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 import {IBalanceSheet} from "centrifuge-v3/src/spoke/interfaces/IBalanceSheet.sol";
 import {ISpoke, VaultDetails} from "centrifuge-v3/src/spoke/interfaces/ISpoke.sol";
 import {IUpdateContract} from "centrifuge-v3/src/spoke/interfaces/IUpdateContract.sol";
-import {UpdateContractMessageLib, UpdateContractType} from "centrifuge-v3/src/spoke/libraries/UpdateContractMessageLib.sol";
+import {
+    UpdateContractMessageLib,
+    UpdateContractType
+} from "centrifuge-v3/src/spoke/libraries/UpdateContractMessageLib.sol";
 
 import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
 import {IDepositManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";

--- a/src/vaults/VaultRouter.sol
+++ b/src/vaults/VaultRouter.sol
@@ -1,25 +1,25 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
-import {Multicall, IMulticall} from "src/misc/Multicall.sol";
-import {IERC7540Deposit} from "src/misc/interfaces/IERC7540.sol";
-import {IERC20, IERC20Permit} from "src/misc/interfaces/IERC20.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {Recoverable} from "centrifuge-v3/src/misc/Recoverable.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {IEscrow} from "centrifuge-v3/src/misc/interfaces/IEscrow.sol";
+import {Multicall, IMulticall} from "centrifuge-v3/src/misc/Multicall.sol";
+import {IERC7540Deposit} from "centrifuge-v3/src/misc/interfaces/IERC7540.sol";
+import {IERC20, IERC20Permit} from "centrifuge-v3/src/misc/interfaces/IERC20.sol";
+import {SafeTransferLib} from "centrifuge-v3/src/misc/libraries/SafeTransferLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {IGateway} from "centrifuge-v3/src/common/interfaces/IGateway.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {ISpoke, VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
+import {ISpoke, VaultDetails} from "centrifuge-v3/src/spoke/interfaces/ISpoke.sol";
 
-import {BaseSyncDepositVault} from "src/vaults/BaseVaults.sol";
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IVaultRouter} from "src/vaults/interfaces/IVaultRouter.sol";
+import {BaseSyncDepositVault} from "centrifuge-v3/src/vaults/BaseVaults.sol";
+import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncVault} from "centrifuge-v3/src/vaults/interfaces/IAsyncVault.sol";
+import {IVaultRouter} from "centrifuge-v3/src/vaults/interfaces/IVaultRouter.sol";
 
 /// @title  VaultRouter
 /// @notice This is a helper contract, designed to be the entrypoint for EOAs.

--- a/src/vaults/factories/AsyncVaultFactory.sol
+++ b/src/vaults/factories/AsyncVaultFactory.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {IVault} from "src/spoke/interfaces/IVault.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
+import {IVault} from "centrifuge-v3/src/spoke/interfaces/IVault.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
+import {IVaultFactory} from "centrifuge-v3/src/spoke/factories/interfaces/IVaultFactory.sol";
 
-import {AsyncVault} from "src/vaults/AsyncVault.sol";
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {AsyncVault} from "centrifuge-v3/src/vaults/AsyncVault.sol";
+import {IAsyncRequestManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 
 /// @title  ERC7540 Vault Factory
 /// @dev    Utility for deploying new vault contracts

--- a/src/vaults/factories/SyncDepositVaultFactory.sol
+++ b/src/vaults/factories/SyncDepositVaultFactory.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {IVault} from "src/spoke/interfaces/IVault.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
+import {IVault} from "centrifuge-v3/src/spoke/interfaces/IVault.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
+import {IVaultFactory} from "centrifuge-v3/src/spoke/factories/interfaces/IVaultFactory.sol";
 
-import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
-import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {ISyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {SyncDepositVault} from "centrifuge-v3/src/vaults/SyncDepositVault.sol";
+import {IAsyncRedeemManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
+import {ISyncDepositManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 
 /// @title  Sync Vault Factory
 /// @dev    Utility for deploying new vault contracts

--- a/src/vaults/interfaces/IAsyncVault.sol
+++ b/src/vaults/interfaces/IAsyncVault.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IERC7540Redeem, IERC7887Redeem, IERC7887Deposit, IERC7540Deposit} from "src/misc/interfaces/IERC7540.sol";
+import {IERC7540Redeem, IERC7887Redeem, IERC7887Deposit, IERC7540Deposit} from "centrifuge-v3/src/misc/interfaces/IERC7540.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncRedeemManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 
 /**
  * @title  IAsyncRedeemVault

--- a/src/vaults/interfaces/IAsyncVault.sol
+++ b/src/vaults/interfaces/IAsyncVault.sol
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IERC7540Redeem, IERC7887Redeem, IERC7887Deposit, IERC7540Deposit} from "centrifuge-v3/src/misc/interfaces/IERC7540.sol";
+import {
+    IERC7540Redeem,
+    IERC7887Redeem,
+    IERC7887Deposit,
+    IERC7540Deposit
+} from "centrifuge-v3/src/misc/interfaces/IERC7540.sol";
 
 import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
 import {IAsyncRedeemManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";

--- a/src/vaults/interfaces/IBaseRequestManager.sol
+++ b/src/vaults/interfaces/IBaseRequestManager.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
+import {IEscrow} from "centrifuge-v3/src/misc/interfaces/IEscrow.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {IPoolEscrow} from "centrifuge-v3/src/common/interfaces/IPoolEscrow.sol";
 
-import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
-import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
-import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
+import {ISpoke} from "centrifuge-v3/src/spoke/interfaces/ISpoke.sol";
+import {IVaultManager} from "centrifuge-v3/src/spoke/interfaces/IVaultManager.sol";
+import {IRequestManager} from "centrifuge-v3/src/spoke/interfaces/IRequestManager.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
 
 interface IBaseRequestManager is IVaultManager, IRequestManager {
     event File(bytes32 indexed what, address data);

--- a/src/vaults/interfaces/IBaseVault.sol
+++ b/src/vaults/interfaces/IBaseVault.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IERC7575} from "src/misc/interfaces/IERC7575.sol";
-import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
-import {IERC7540Operator, IERC7714, IERC7741} from "src/misc/interfaces/IERC7540.sol";
+import {IERC7575} from "centrifuge-v3/src/misc/interfaces/IERC7575.sol";
+import {IRecoverable} from "centrifuge-v3/src/misc/interfaces/IRecoverable.sol";
+import {IERC7540Operator, IERC7714, IERC7741} from "centrifuge-v3/src/misc/interfaces/IERC7540.sol";
 
-import {IVault} from "src/spoke/interfaces/IVault.sol";
+import {IVault} from "centrifuge-v3/src/spoke/interfaces/IVault.sol";
 
 /// @notice Interface for the all vault contracts
 /// @dev Must be implemented by all vaults

--- a/src/vaults/interfaces/IVaultManagers.sol
+++ b/src/vaults/interfaces/IVaultManagers.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {D18} from "src/misc/types/D18.sol";
+import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
+import {IUpdateContract} from "centrifuge-v3/src/spoke/interfaces/IUpdateContract.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
+import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
+import {IBaseRequestManager} from "centrifuge-v3/src/vaults/interfaces/IBaseRequestManager.sol";
 
 interface IDepositManager {
     /// @notice Processes owner's asset deposit after the epoch has been executed on the corresponding CP instance and

--- a/src/vaults/interfaces/IVaultRouter.sol
+++ b/src/vaults/interfaces/IVaultRouter.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IMulticall} from "src/misc/interfaces/IMulticall.sol";
+import {IMulticall} from "centrifuge-v3/src/misc/interfaces/IMulticall.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {BaseSyncDepositVault} from "src/vaults/BaseVaults.sol";
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {BaseSyncDepositVault} from "centrifuge-v3/src/vaults/BaseVaults.sol";
+import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncVault} from "centrifuge-v3/src/vaults/interfaces/IAsyncVault.sol";
 
 interface IVaultRouter is IMulticall {
     // --- Events ---

--- a/test/adapters/Deployment.t.sol
+++ b/test/adapters/Deployment.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.28;
 
 import {IWormholeRelayer, IWormholeDeliveryProvider} from "centrifuge-v3/src/common/interfaces/adapters/IWormholeAdapter.sol";
 
-import {CommonDeploymentInputTest} from "test/common/Deployment.t.sol";
+import {CommonDeploymentInputTest} from "centrifuge-v3/test/common/Deployment.t.sol";
 
 import "forge-std/Test.sol";
 
@@ -13,7 +13,7 @@ import {
     AdaptersInput,
     WormholeInput,
     AxelarInput
-} from "script/AdaptersDeployer.s.sol";
+} from "centrifuge-v3/script/AdaptersDeployer.s.sol";
 
 contract AdaptersDeploymentInputTest is Test {
     address immutable WORMHOLE_RELAYER = makeAddr("WormholeRelayer");

--- a/test/adapters/Deployment.t.sol
+++ b/test/adapters/Deployment.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IWormholeRelayer, IWormholeDeliveryProvider} from "src/common/interfaces/adapters/IWormholeAdapter.sol";
+import {IWormholeRelayer, IWormholeDeliveryProvider} from "centrifuge-v3/src/common/interfaces/adapters/IWormholeAdapter.sol";
 
 import {CommonDeploymentInputTest} from "test/common/Deployment.t.sol";
 

--- a/test/adapters/Deployment.t.sol
+++ b/test/adapters/Deployment.t.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IWormholeRelayer, IWormholeDeliveryProvider} from "centrifuge-v3/src/common/interfaces/adapters/IWormholeAdapter.sol";
+import {
+    IWormholeRelayer,
+    IWormholeDeliveryProvider
+} from "centrifuge-v3/src/common/interfaces/adapters/IWormholeAdapter.sol";
 
 import {CommonDeploymentInputTest} from "centrifuge-v3/test/common/Deployment.t.sol";
 

--- a/test/common/Deployment.t.sol
+++ b/test/common/Deployment.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.28;
 
 import {ISafe} from "centrifuge-v3/src/common/interfaces/IGuardian.sol";
 
-import {CommonDeployer, CommonInput, CommonActionBatcher} from "script/CommonDeployer.s.sol";
+import {CommonDeployer, CommonInput, CommonActionBatcher} from "centrifuge-v3/script/CommonDeployer.s.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/Deployment.t.sol
+++ b/test/common/Deployment.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ISafe} from "src/common/interfaces/IGuardian.sol";
+import {ISafe} from "centrifuge-v3/src/common/interfaces/IGuardian.sol";
 
 import {CommonDeployer, CommonInput, CommonActionBatcher} from "script/CommonDeployer.s.sol";
 

--- a/test/common/mocks/MockAdapter.sol
+++ b/test/common/mocks/MockAdapter.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
 
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
+import {IMessageHandler} from "centrifuge-v3/src/common/interfaces/IMessageHandler.sol";
 
 import "test/common/mocks/Mock.sol";
 

--- a/test/common/mocks/MockAdapter.sol
+++ b/test/common/mocks/MockAdapter.sol
@@ -6,7 +6,7 @@ import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
 import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
 import {IMessageHandler} from "centrifuge-v3/src/common/interfaces/IMessageHandler.sol";
 
-import "test/common/mocks/Mock.sol";
+import "centrifuge-v3/test/common/mocks/Mock.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/mocks/MockRoot.sol
+++ b/test/common/mocks/MockRoot.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "test/common/mocks/Mock.sol";
+import "centrifuge-v3/test/common/mocks/Mock.sol";
 
 contract MockRoot is Mock {
     function endorsed(address) public view returns (bool) {

--- a/test/common/mocks/MockValuation.sol
+++ b/test/common/mocks/MockValuation.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
+import {D18, d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
+import {IERC6909Decimals} from "centrifuge-v3/src/misc/interfaces/IERC6909.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {BaseValuation} from "src/common/BaseValuation.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {BaseValuation} from "centrifuge-v3/src/common/BaseValuation.sol";
+import {PricingLib} from "centrifuge-v3/src/common/libraries/PricingLib.sol";
+import {IValuation} from "centrifuge-v3/src/common/interfaces/IValuation.sol";
 
 struct Price {
     D18 value;

--- a/test/common/types/AccountId.t.sol
+++ b/test/common/types/AccountId.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {AccountId} from "src/common/types/AccountId.sol";
+import {AccountId} from "centrifuge-v3/src/common/types/AccountId.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/types/AssetId.t.sol
+++ b/test/common/types/AssetId.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
+import {AssetId, newAssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/types/PoolId.t.sol
+++ b/test/common/types/PoolId.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {PoolId, newPoolId} from "src/common/types/PoolId.sol";
+import {PoolId, newPoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/types/ShareClassId.t.sol
+++ b/test/common/types/ShareClassId.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId, newShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId, newShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/AxelarAdapter.t.sol
+++ b/test/common/unit/AxelarAdapter.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
 
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {AxelarAdapter, IAdapter, IAxelarExecutable} from "src/common/adapters/AxelarAdapter.sol";
+import {IMessageHandler} from "centrifuge-v3/src/common/interfaces/IMessageHandler.sol";
+import {AxelarAdapter, IAdapter, IAxelarExecutable} from "centrifuge-v3/src/common/adapters/AxelarAdapter.sol";
 
 import {Mock} from "test/common/mocks/Mock.sol";
 

--- a/test/common/unit/AxelarAdapter.t.sol
+++ b/test/common/unit/AxelarAdapter.t.sol
@@ -6,7 +6,7 @@ import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
 import {IMessageHandler} from "centrifuge-v3/src/common/interfaces/IMessageHandler.sol";
 import {AxelarAdapter, IAdapter, IAxelarExecutable} from "centrifuge-v3/src/common/adapters/AxelarAdapter.sol";
 
-import {Mock} from "test/common/mocks/Mock.sol";
+import {Mock} from "centrifuge-v3/test/common/mocks/Mock.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/GasService.t.sol
+++ b/test/common/unit/GasService.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
 
-import {GasService} from "src/common/GasService.sol";
-import {MAX_MESSAGE_COST} from "src/common/interfaces/IGasService.sol";
-import {MessageLib, MessageType, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {GasService} from "centrifuge-v3/src/common/GasService.sol";
+import {MAX_MESSAGE_COST} from "centrifuge-v3/src/common/interfaces/IGasService.sol";
+import {MessageLib, MessageType, VaultUpdateKind} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/Gateway.t.sol
+++ b/test/common/unit/Gateway.t.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth, IAuth} from "src/misc/Auth.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {Recoverable, IRecoverable} from "src/misc/Recoverable.sol";
-import {TransientArrayLib} from "src/misc/libraries/TransientArrayLib.sol";
-import {TransientBytesLib} from "src/misc/libraries/TransientBytesLib.sol";
-import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
+import {Auth, IAuth} from "centrifuge-v3/src/misc/Auth.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
+import {Recoverable, IRecoverable} from "centrifuge-v3/src/misc/Recoverable.sol";
+import {TransientArrayLib} from "centrifuge-v3/src/misc/libraries/TransientArrayLib.sol";
+import {TransientBytesLib} from "centrifuge-v3/src/misc/libraries/TransientBytesLib.sol";
+import {TransientStorageLib} from "centrifuge-v3/src/misc/libraries/TransientStorageLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {Gateway, IRoot, IGasService, IGateway} from "src/common/Gateway.sol";
-import {IMessageProperties} from "src/common/interfaces/IMessageProperties.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
+import {Gateway, IRoot, IGasService, IGateway} from "centrifuge-v3/src/common/Gateway.sol";
+import {IMessageProperties} from "centrifuge-v3/src/common/interfaces/IMessageProperties.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/Guardian.t.sol
+++ b/test/common/unit/Guardian.t.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IGuardian} from "src/common/interfaces/IGuardian.sol";
-import {IHubGuardianActions} from "src/common/interfaces/IGuardianActions.sol";
-import {IAxelarAdapter} from "src/common/interfaces/adapters/IAxelarAdapter.sol";
-import {IWormholeAdapter} from "src/common/interfaces/adapters/IWormholeAdapter.sol";
-import {Guardian, ISafe, IMultiAdapter, IRoot, IRootMessageSender} from "src/common/Guardian.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
+import {IGuardian} from "centrifuge-v3/src/common/interfaces/IGuardian.sol";
+import {IHubGuardianActions} from "centrifuge-v3/src/common/interfaces/IGuardianActions.sol";
+import {IAxelarAdapter} from "centrifuge-v3/src/common/interfaces/adapters/IAxelarAdapter.sol";
+import {IWormholeAdapter} from "centrifuge-v3/src/common/interfaces/adapters/IWormholeAdapter.sol";
+import {Guardian, ISafe, IMultiAdapter, IRoot, IRootMessageSender} from "centrifuge-v3/src/common/Guardian.sol";
 
 import {AxelarAddressToString} from "test/common/unit/AxelarAdapter.t.sol";
 

--- a/test/common/unit/Guardian.t.sol
+++ b/test/common/unit/Guardian.t.sol
@@ -12,7 +12,7 @@ import {IAxelarAdapter} from "centrifuge-v3/src/common/interfaces/adapters/IAxel
 import {IWormholeAdapter} from "centrifuge-v3/src/common/interfaces/adapters/IWormholeAdapter.sol";
 import {Guardian, ISafe, IMultiAdapter, IRoot, IRootMessageSender} from "centrifuge-v3/src/common/Guardian.sol";
 
-import {AxelarAddressToString} from "test/common/unit/AxelarAdapter.t.sol";
+import {AxelarAddressToString} from "centrifuge-v3/test/common/unit/AxelarAdapter.t.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/MultiAdapter.t.sol
+++ b/test/common/unit/MultiAdapter.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/Auth.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {IAuth} from "centrifuge-v3/src/misc/Auth.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
 
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {MultiAdapter} from "src/common/adapters/MultiAdapter.sol";
-import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {IMultiAdapter, MAX_ADAPTER_COUNT} from "src/common/interfaces/adapters/IMultiAdapter.sol";
+import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
+import {MultiAdapter} from "centrifuge-v3/src/common/adapters/MultiAdapter.sol";
+import {MessageProofLib} from "centrifuge-v3/src/common/libraries/MessageProofLib.sol";
+import {IMessageHandler} from "centrifuge-v3/src/common/interfaces/IMessageHandler.sol";
+import {IMultiAdapter, MAX_ADAPTER_COUNT} from "centrifuge-v3/src/common/interfaces/adapters/IMultiAdapter.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/PoolEscrow.t.sol
+++ b/test/common/unit/PoolEscrow.t.sol
@@ -9,7 +9,7 @@ import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
 import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 import {PoolEscrow, IPoolEscrow} from "centrifuge-v3/src/common/PoolEscrow.sol";
 
-import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
+import {MockERC6909} from "centrifuge-v3/test/misc/mocks/MockERC6909.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/PoolEscrow.t.sol
+++ b/test/common/unit/PoolEscrow.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ERC20} from "src/misc/ERC20.sol";
-import {Escrow, IEscrow} from "src/misc/Escrow.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {ERC20} from "centrifuge-v3/src/misc/ERC20.sol";
+import {Escrow, IEscrow} from "centrifuge-v3/src/misc/Escrow.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {PoolEscrow, IPoolEscrow} from "src/common/PoolEscrow.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {PoolEscrow, IPoolEscrow} from "centrifuge-v3/src/common/PoolEscrow.sol";
 
 import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
 

--- a/test/common/unit/Root.t.sol
+++ b/test/common/unit/Root.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
 
-import {Root, IRoot} from "src/common/Root.sol";
+import {Root, IRoot} from "centrifuge-v3/src/common/Root.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/TokenRecoverer.t.sol
+++ b/test/common/unit/TokenRecoverer.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {IAuth} from "src/misc/Auth.sol";
-import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
+import {IAuth} from "centrifuge-v3/src/misc/Auth.sol";
+import {IRecoverable} from "centrifuge-v3/src/misc/interfaces/IRecoverable.sol";
 
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {TokenRecoverer, ITokenRecoverer} from "src/common/TokenRecoverer.sol";
+import {IRoot} from "centrifuge-v3/src/common/interfaces/IRoot.sol";
+import {TokenRecoverer, ITokenRecoverer} from "centrifuge-v3/src/common/TokenRecoverer.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/WormholeAdapter.t.sol
+++ b/test/common/unit/WormholeAdapter.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
 
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {WormholeAdapter} from "src/common/adapters/WormholeAdapter.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {IWormholeAdapter} from "src/common/interfaces/adapters/IWormholeAdapter.sol";
+import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
+import {WormholeAdapter} from "centrifuge-v3/src/common/adapters/WormholeAdapter.sol";
+import {IMessageHandler} from "centrifuge-v3/src/common/interfaces/IMessageHandler.sol";
+import {IWormholeAdapter} from "centrifuge-v3/src/common/interfaces/adapters/IWormholeAdapter.sol";
 
 import {Mock} from "test/common/mocks/Mock.sol";
 

--- a/test/common/unit/WormholeAdapter.t.sol
+++ b/test/common/unit/WormholeAdapter.t.sol
@@ -9,7 +9,7 @@ import {WormholeAdapter} from "centrifuge-v3/src/common/adapters/WormholeAdapter
 import {IMessageHandler} from "centrifuge-v3/src/common/interfaces/IMessageHandler.sol";
 import {IWormholeAdapter} from "centrifuge-v3/src/common/interfaces/adapters/IWormholeAdapter.sol";
 
-import {Mock} from "test/common/mocks/Mock.sol";
+import {Mock} from "centrifuge-v3/test/common/mocks/Mock.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/factories/PoolEscrowFactory.t.sol
+++ b/test/common/unit/factories/PoolEscrowFactory.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {PoolEscrow} from "src/common/PoolEscrow.sol";
-import {PoolEscrowFactory} from "src/common/factories/PoolEscrowFactory.sol";
-import {IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {PoolEscrow} from "centrifuge-v3/src/common/PoolEscrow.sol";
+import {PoolEscrowFactory} from "centrifuge-v3/src/common/factories/PoolEscrowFactory.sol";
+import {IPoolEscrowFactory} from "centrifuge-v3/src/common/factories/interfaces/IPoolEscrowFactory.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/libraries/MessageLib.t.sol
+++ b/test/common/unit/libraries/MessageLib.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
-import {MessageType, MessageLib} from "src/common/libraries/MessageLib.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {MessageProofLib} from "centrifuge-v3/src/common/libraries/MessageProofLib.sol";
+import {MessageType, MessageLib} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/libraries/MessageProofLib.t.sol
+++ b/test/common/unit/libraries/MessageProofLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
+import {MessageProofLib} from "centrifuge-v3/src/common/libraries/MessageProofLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/libraries/RequestCallbackMessageLib.t.sol
+++ b/test/common/unit/libraries/RequestCallbackMessageLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {RequestCallbackType, RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
+import {RequestCallbackType, RequestCallbackMessageLib} from "centrifuge-v3/src/common/libraries/RequestCallbackMessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/libraries/RequestCallbackMessageLib.t.sol
+++ b/test/common/unit/libraries/RequestCallbackMessageLib.t.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {RequestCallbackType, RequestCallbackMessageLib} from "centrifuge-v3/src/common/libraries/RequestCallbackMessageLib.sol";
+import {
+    RequestCallbackType,
+    RequestCallbackMessageLib
+} from "centrifuge-v3/src/common/libraries/RequestCallbackMessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hooks/Deployment.t.sol
+++ b/test/hooks/Deployment.t.sol
@@ -3,9 +3,9 @@ pragma solidity 0.8.28;
 
 import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
 
-import {HooksDeployer, HooksActionBatcher} from "script/HooksDeployer.s.sol";
+import {HooksDeployer, HooksActionBatcher} from "centrifuge-v3/script/HooksDeployer.s.sol";
 
-import {CommonDeploymentInputTest} from "test/common/Deployment.t.sol";
+import {CommonDeploymentInputTest} from "centrifuge-v3/test/common/Deployment.t.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hooks/Deployment.t.sol
+++ b/test/hooks/Deployment.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
 
 import {HooksDeployer, HooksActionBatcher} from "script/HooksDeployer.s.sol";
 

--- a/test/hooks/integration/FreelyTransferable.t.sol
+++ b/test/hooks/integration/FreelyTransferable.t.sol
@@ -7,7 +7,7 @@ import {IAsyncRequestManager} from "centrifuge-v3/src/vaults/interfaces/IVaultMa
 
 import {FreelyTransferable} from "centrifuge-v3/src/hooks/FreelyTransferable.sol";
 
-import "test/spoke/BaseTest.sol";
+import "centrifuge-v3/test/spoke/BaseTest.sol";
 
 contract FreelyTransferableTest is BaseTest {
     using CastLib for *;

--- a/test/hooks/integration/FreelyTransferable.t.sol
+++ b/test/hooks/integration/FreelyTransferable.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
 
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IAsyncRequestManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 
-import {FreelyTransferable} from "src/hooks/FreelyTransferable.sol";
+import {FreelyTransferable} from "centrifuge-v3/src/hooks/FreelyTransferable.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/hooks/integration/FreezeOnly.t.sol
+++ b/test/hooks/integration/FreezeOnly.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
 
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
+import {ITransferHook} from "centrifuge-v3/src/common/interfaces/ITransferHook.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/hooks/integration/FreezeOnly.t.sol
+++ b/test/hooks/integration/FreezeOnly.t.sol
@@ -5,7 +5,7 @@ import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
 
 import {ITransferHook} from "centrifuge-v3/src/common/interfaces/ITransferHook.sol";
 
-import "test/spoke/BaseTest.sol";
+import "centrifuge-v3/test/spoke/BaseTest.sol";
 
 contract FreezeOnlyTest is BaseTest {
     using CastLib for *;

--- a/test/hooks/integration/RedemptionRestrictions.t.sol
+++ b/test/hooks/integration/RedemptionRestrictions.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
 
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IAsyncRequestManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 
-import {RedemptionRestrictions} from "src/hooks/RedemptionRestrictions.sol";
+import {RedemptionRestrictions} from "centrifuge-v3/src/hooks/RedemptionRestrictions.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/hooks/integration/RedemptionRestrictions.t.sol
+++ b/test/hooks/integration/RedemptionRestrictions.t.sol
@@ -7,7 +7,7 @@ import {IAsyncRequestManager} from "centrifuge-v3/src/vaults/interfaces/IVaultMa
 
 import {RedemptionRestrictions} from "centrifuge-v3/src/hooks/RedemptionRestrictions.sol";
 
-import "test/spoke/BaseTest.sol";
+import "centrifuge-v3/test/spoke/BaseTest.sol";
 
 contract RedemptionRestrictionsTest is BaseTest {
     using CastLib for *;

--- a/test/hooks/mocks/MockSnapshotHook.sol
+++ b/test/hooks/mocks/MockSnapshotHook.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {ISnapshotHook} from "centrifuge-v3/src/common/interfaces/ISnapshotHook.sol";
 
 contract MockSnapshotHook is ISnapshotHook {
     mapping(PoolId => mapping(ShareClassId => mapping(uint16 centrifugeId => uint256 counter))) public synced;

--- a/test/hooks/unit/libraries/UpdateRestrictionManagerLib.t.sol
+++ b/test/hooks/unit/libraries/UpdateRestrictionManagerLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {UpdateRestrictionMessageLib} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/Deployment.t.sol
+++ b/test/hub/Deployment.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {HubDeployer, HubActionBatcher} from "script/HubDeployer.s.sol";
+import {HubDeployer, HubActionBatcher} from "centrifuge-v3/script/HubDeployer.s.sol";
 
-import {CommonDeploymentInputTest} from "test/common/Deployment.t.sol";
+import {CommonDeploymentInputTest} from "centrifuge-v3/test/common/Deployment.t.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/integration/BaseTest.sol
+++ b/test/hub/integration/BaseTest.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {D18, d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
-import {MAX_MESSAGE_COST} from "src/common/interfaces/IGasService.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AccountId} from "centrifuge-v3/src/common/types/AccountId.sol";
+import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
+import {AssetId, newAssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {MAX_MESSAGE_COST} from "centrifuge-v3/src/common/interfaces/IGasService.sol";
 
 import {HubDeployer, HubActionBatcher, CommonInput} from "script/HubDeployer.s.sol";
 

--- a/test/hub/integration/BaseTest.sol
+++ b/test/hub/integration/BaseTest.sol
@@ -10,10 +10,10 @@ import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
 import {AssetId, newAssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
 import {MAX_MESSAGE_COST} from "centrifuge-v3/src/common/interfaces/IGasService.sol";
 
-import {HubDeployer, HubActionBatcher, CommonInput} from "script/HubDeployer.s.sol";
+import {HubDeployer, HubActionBatcher, CommonInput} from "centrifuge-v3/script/HubDeployer.s.sol";
 
-import {MockVaults} from "test/hub/mocks/MockVaults.sol";
-import {MockValuation} from "test/common/mocks/MockValuation.sol";
+import {MockVaults} from "centrifuge-v3/test/hub/mocks/MockVaults.sol";
+import {MockValuation} from "centrifuge-v3/test/common/mocks/MockValuation.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/integration/BatchingAndPayment.t.sol
+++ b/test/hub/integration/BatchingAndPayment.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import "test/hub/integration/BaseTest.sol";
+import "centrifuge-v3/test/hub/integration/BaseTest.sol";
 
 contract TestBatchingAndPayment is BaseTest {
     /// Test the following:

--- a/test/hub/integration/Cases.t.sol
+++ b/test/hub/integration/Cases.t.sol
@@ -13,7 +13,7 @@ import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 import {VaultUpdateKind} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
 import {RequestCallbackMessageLib} from "centrifuge-v3/src/common/libraries/RequestCallbackMessageLib.sol";
 
-import "test/hub/integration/BaseTest.sol";
+import "centrifuge-v3/test/hub/integration/BaseTest.sol";
 
 contract TestCases is BaseTest {
     using MathLib for *;

--- a/test/hub/integration/Cases.t.sol
+++ b/test/hub/integration/Cases.t.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {D18, d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
-import {RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {MessageLib} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
+import {PricingLib} from "centrifuge-v3/src/common/libraries/PricingLib.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {VaultUpdateKind} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
+import {RequestCallbackMessageLib} from "centrifuge-v3/src/common/libraries/RequestCallbackMessageLib.sol";
 
 import "test/hub/integration/BaseTest.sol";
 

--- a/test/hub/mocks/MockVaults.sol
+++ b/test/hub/mocks/MockVaults.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18} from "src/misc/types/D18.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
+import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
+import {MessageLib} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {IMessageHandler} from "centrifuge-v3/src/common/interfaces/IMessageHandler.sol";
+import {RequestMessageLib} from "centrifuge-v3/src/common/libraries/RequestMessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/unit/Accounting.t.sol
+++ b/test/hub/unit/Accounting.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AccountId} from "centrifuge-v3/src/common/types/AccountId.sol";
 
-import {Accounting} from "src/hub/Accounting.sol";
-import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
+import {Accounting} from "centrifuge-v3/src/hub/Accounting.sol";
+import {IAccounting, JournalEntry} from "centrifuge-v3/src/hub/interfaces/IAccounting.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/unit/Holdings.t.sol
+++ b/test/hub/unit/Holdings.t.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {d18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {AccountId} from "centrifuge-v3/src/common/types/AccountId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {IValuation} from "centrifuge-v3/src/common/interfaces/IValuation.sol";
 
-import {Holdings} from "src/hub/Holdings.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IHoldings, HoldingAccount} from "src/hub/interfaces/IHoldings.sol";
+import {Holdings} from "centrifuge-v3/src/hub/Holdings.sol";
+import {IHubRegistry} from "centrifuge-v3/src/hub/interfaces/IHubRegistry.sol";
+import {IHoldings, HoldingAccount} from "centrifuge-v3/src/hub/interfaces/IHoldings.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/unit/Hub.t.sol
+++ b/test/hub/unit/Hub.t.sol
@@ -1,24 +1,24 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {D18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {AccountId} from "centrifuge-v3/src/common/types/AccountId.sol";
+import {IGateway} from "centrifuge-v3/src/common/interfaces/IGateway.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {IValuation} from "centrifuge-v3/src/common/interfaces/IValuation.sol";
+import {ISnapshotHook} from "centrifuge-v3/src/common/interfaces/ISnapshotHook.sol";
 
-import {Hub} from "src/hub/Hub.sol";
-import {IHoldings} from "src/hub/interfaces/IHoldings.sol";
-import {IHubHelpers} from "src/hub/interfaces/IHubHelpers.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IHub, VaultUpdateKind} from "src/hub/interfaces/IHub.sol";
-import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+import {Hub} from "centrifuge-v3/src/hub/Hub.sol";
+import {IHoldings} from "centrifuge-v3/src/hub/interfaces/IHoldings.sol";
+import {IHubHelpers} from "centrifuge-v3/src/hub/interfaces/IHubHelpers.sol";
+import {IHubRegistry} from "centrifuge-v3/src/hub/interfaces/IHubRegistry.sol";
+import {IHub, VaultUpdateKind} from "centrifuge-v3/src/hub/interfaces/IHub.sol";
+import {IAccounting, JournalEntry} from "centrifuge-v3/src/hub/interfaces/IAccounting.sol";
+import {IShareClassManager} from "centrifuge-v3/src/hub/interfaces/IShareClassManager.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/unit/HubHelpers.t.sol
+++ b/test/hub/unit/HubHelpers.t.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {d18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {IHubMessageSender} from "centrifuge-v3/src/common/interfaces/IGatewaySenders.sol";
 
-import {HubHelpers} from "src/hub/HubHelpers.sol";
-import {IHoldings} from "src/hub/interfaces/IHoldings.sol";
-import {IAccounting} from "src/hub/interfaces/IAccounting.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+import {HubHelpers} from "centrifuge-v3/src/hub/HubHelpers.sol";
+import {IHoldings} from "centrifuge-v3/src/hub/interfaces/IHoldings.sol";
+import {IAccounting} from "centrifuge-v3/src/hub/interfaces/IAccounting.sol";
+import {IHubRegistry} from "centrifuge-v3/src/hub/interfaces/IHubRegistry.sol";
+import {IShareClassManager} from "centrifuge-v3/src/hub/interfaces/IShareClassManager.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/unit/HubRegistry.t.sol
+++ b/test/hub/unit/HubRegistry.t.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {PoolId, newPoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {PoolId, newPoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {HubRegistry} from "src/hub/HubRegistry.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+import {HubRegistry} from "centrifuge-v3/src/hub/HubRegistry.sol";
+import {IHubRegistry} from "centrifuge-v3/src/hub/interfaces/IHubRegistry.sol";
+import {IShareClassManager} from "centrifuge-v3/src/hub/interfaces/IShareClassManager.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/unit/ShareClassManager.t.sol
+++ b/test/hub/unit/ShareClassManager.t.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {D18, d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {PricingLib} from "centrifuge-v3/src/common/libraries/PricingLib.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {ShareClassManager} from "src/hub/ShareClassManager.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+import {ShareClassManager} from "centrifuge-v3/src/hub/ShareClassManager.sol";
+import {IHubRegistry} from "centrifuge-v3/src/hub/interfaces/IHubRegistry.sol";
+import {IShareClassManager} from "centrifuge-v3/src/hub/interfaces/IShareClassManager.sol";
 
 import "forge-std/Test.sol";
 
@@ -26,7 +26,7 @@ import {
     ShareClassMetrics,
     QueuedOrder,
     RequestType
-} from "src/hub/interfaces/IShareClassManager.sol";
+} from "centrifuge-v3/src/hub/interfaces/IShareClassManager.sol";
 
 uint16 constant CHAIN_ID = 1;
 uint64 constant POOL_ID = 42;

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -46,11 +46,11 @@ import {FullRestrictions} from "centrifuge-v3/src/hooks/FullRestrictions.sol";
 import {RedemptionRestrictions} from "centrifuge-v3/src/hooks/RedemptionRestrictions.sol";
 import {UpdateRestrictionMessageLib} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
-import {FullDeployer, FullActionBatcher, CommonInput} from "script/FullDeployer.s.sol";
+import {FullDeployer, FullActionBatcher, CommonInput} from "centrifuge-v3/script/FullDeployer.s.sol";
 
-import {MockValuation} from "test/common/mocks/MockValuation.sol";
-import {MockSnapshotHook} from "test/hooks/mocks/MockSnapshotHook.sol";
-import {LocalAdapter} from "test/integration/adapters/LocalAdapter.sol";
+import {MockValuation} from "centrifuge-v3/test/common/mocks/MockValuation.sol";
+import {MockSnapshotHook} from "centrifuge-v3/test/hooks/mocks/MockSnapshotHook.sol";
+import {LocalAdapter} from "centrifuge-v3/test/integration/adapters/LocalAdapter.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -1,50 +1,50 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {ERC20} from "src/misc/ERC20.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {ETH_ADDRESS} from "src/misc/interfaces/IRecoverable.sol";
-import {IdentityValuation} from "src/misc/IdentityValuation.sol";
+import {ERC20} from "centrifuge-v3/src/misc/ERC20.sol";
+import {D18, d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
+import {ETH_ADDRESS} from "centrifuge-v3/src/misc/interfaces/IRecoverable.sol";
+import {IdentityValuation} from "centrifuge-v3/src/misc/IdentityValuation.sol";
 
-import {Root} from "src/common/Root.sol";
-import {Gateway} from "src/common/Gateway.sol";
-import {Guardian} from "src/common/Guardian.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
-import {GasService} from "src/common/GasService.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {ISafe} from "src/common/interfaces/IGuardian.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
-import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
-import {MAX_MESSAGE_COST} from "src/common/interfaces/IGasService.sol";
+import {Root} from "centrifuge-v3/src/common/Root.sol";
+import {Gateway} from "centrifuge-v3/src/common/Gateway.sol";
+import {Guardian} from "centrifuge-v3/src/common/Guardian.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {GasService} from "centrifuge-v3/src/common/GasService.sol";
+import {AccountId} from "centrifuge-v3/src/common/types/AccountId.sol";
+import {ISafe} from "centrifuge-v3/src/common/interfaces/IGuardian.sol";
+import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
+import {PricingLib} from "centrifuge-v3/src/common/libraries/PricingLib.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {AssetId, newAssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {VaultUpdateKind} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
+import {MAX_MESSAGE_COST} from "centrifuge-v3/src/common/interfaces/IGasService.sol";
 
-import {Hub} from "src/hub/Hub.sol";
-import {Holdings} from "src/hub/Holdings.sol";
-import {Accounting} from "src/hub/Accounting.sol";
-import {HubRegistry} from "src/hub/HubRegistry.sol";
-import {ShareClassManager} from "src/hub/ShareClassManager.sol";
+import {Hub} from "centrifuge-v3/src/hub/Hub.sol";
+import {Holdings} from "centrifuge-v3/src/hub/Holdings.sol";
+import {Accounting} from "centrifuge-v3/src/hub/Accounting.sol";
+import {HubRegistry} from "centrifuge-v3/src/hub/HubRegistry.sol";
+import {ShareClassManager} from "centrifuge-v3/src/hub/ShareClassManager.sol";
 
-import {Spoke} from "src/spoke/Spoke.sol";
-import {IVault} from "src/spoke/interfaces/IVault.sol";
-import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
-import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import {Spoke} from "centrifuge-v3/src/spoke/Spoke.sol";
+import {IVault} from "centrifuge-v3/src/spoke/interfaces/IVault.sol";
+import {BalanceSheet} from "centrifuge-v3/src/spoke/BalanceSheet.sol";
+import {UpdateContractMessageLib} from "centrifuge-v3/src/spoke/libraries/UpdateContractMessageLib.sol";
 
-import {SyncManager} from "src/vaults/SyncManager.sol";
-import {VaultRouter} from "src/vaults/VaultRouter.sol";
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {AsyncRequestManager} from "src/vaults/AsyncRequestManager.sol";
-import {IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {SyncManager} from "centrifuge-v3/src/vaults/SyncManager.sol";
+import {VaultRouter} from "centrifuge-v3/src/vaults/VaultRouter.sol";
+import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncVault} from "centrifuge-v3/src/vaults/interfaces/IAsyncVault.sol";
+import {AsyncRequestManager} from "centrifuge-v3/src/vaults/AsyncRequestManager.sol";
+import {IAsyncRedeemVault} from "centrifuge-v3/src/vaults/interfaces/IAsyncVault.sol";
 
-import {FreezeOnly} from "src/hooks/FreezeOnly.sol";
-import {FullRestrictions} from "src/hooks/FullRestrictions.sol";
-import {RedemptionRestrictions} from "src/hooks/RedemptionRestrictions.sol";
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {FreezeOnly} from "centrifuge-v3/src/hooks/FreezeOnly.sol";
+import {FullRestrictions} from "centrifuge-v3/src/hooks/FullRestrictions.sol";
+import {RedemptionRestrictions} from "centrifuge-v3/src/hooks/RedemptionRestrictions.sol";
+import {UpdateRestrictionMessageLib} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import {FullDeployer, FullActionBatcher, CommonInput} from "script/FullDeployer.s.sol";
 

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -7,9 +7,9 @@ import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
 import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 import {MAX_MESSAGE_COST as GAS} from "centrifuge-v3/src/common/interfaces/IGasService.sol";
 
-import {FullDeployer, FullActionBatcher, CommonInput} from "script/FullDeployer.s.sol";
+import {FullDeployer, FullActionBatcher, CommonInput} from "centrifuge-v3/script/FullDeployer.s.sol";
 
-import {MockValuation} from "test/common/mocks/MockValuation.sol";
+import {MockValuation} from "centrifuge-v3/test/common/mocks/MockValuation.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -63,7 +63,7 @@ contract CentrifugeIntegrationTestWithUtils is CentrifugeIntegrationTest {
     ERC20 usdc;
     AssetId usdcId;
 
-    function setUp() public override {
+    function setUp() public virtual override {
         super.setUp();
 
         POOL_A = hubRegistry.poolId(LOCAL_CENTRIFUGE_ID, 1);

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.28;
 
 import {ERC20} from "centrifuge-v3/src/misc/ERC20.sol";
 
-import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
 import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
 import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 import {MAX_MESSAGE_COST as GAS} from "centrifuge-v3/src/common/interfaces/IGasService.sol";
 
@@ -109,7 +109,6 @@ contract CentrifugeIntegrationTestWithUtils is CentrifugeIntegrationTest {
             maxReserve: maxReserve
         }).serialize();
     }
-
 }
 
 contract _CentrifugeIntegrationTestWithUtilsTest is CentrifugeIntegrationTestWithUtils {

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -83,6 +83,11 @@ contract CentrifugeIntegrationTestWithUtils is CentrifugeIntegrationTest {
         usdcId = spoke.registerAsset{value: GAS}(LOCAL_CENTRIFUGE_ID, address(usdc), 0);
     }
 
+    function _mintUSDC(address receiver, uint256 amount) internal {
+        vm.prank(ADMIN);
+        usdc.mint(receiver, amount);
+    }
+
     function _createPool() internal {
         vm.prank(ADMIN);
         guardian.createPool(POOL_A, FM, USD_ID);

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {ERC20} from "src/misc/ERC20.sol";
+import {ERC20} from "centrifuge-v3/src/misc/ERC20.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {MAX_MESSAGE_COST as GAS} from "src/common/interfaces/IGasService.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {MAX_MESSAGE_COST as GAS} from "centrifuge-v3/src/common/interfaces/IGasService.sol";
 
 import {FullDeployer, FullActionBatcher, CommonInput} from "script/FullDeployer.s.sol";
 

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -75,21 +75,22 @@ contract CentrifugeIntegrationTestWithUtils is CentrifugeIntegrationTest {
         usdc.file("name", "USD Coin");
         usdc.file("symbol", "USDC");
         vm.label(address(usdc), "usdc");
+        vm.stopPrank();
     }
 
     function _registerUSDC() internal {
-        vm.startPrank(FUNDED);
+        vm.prank(FUNDED);
         usdcId = spoke.registerAsset{value: GAS}(LOCAL_CENTRIFUGE_ID, address(usdc), 0);
     }
 
     function _createPool() internal {
-        vm.startPrank(ADMIN);
+        vm.prank(ADMIN);
         guardian.createPool(POOL_A, FM, USD_ID);
 
-        vm.startPrank(FM);
+        vm.prank(FM);
         hub.addShareClass(POOL_A, "ShareClass1", "sc1", bytes32("salt"));
 
-        vm.startPrank(FUNDED);
+        vm.prank(FUNDED);
         gateway.subsidizePool{value: DEFAULT_SUBSIDY}(POOL_A);
     }
 

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -3,9 +3,12 @@ pragma solidity ^0.8.28;
 
 import {ERC20} from "centrifuge-v3/src/misc/ERC20.sol";
 
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
 import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
 import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 import {MAX_MESSAGE_COST as GAS} from "centrifuge-v3/src/common/interfaces/IGasService.sol";
+
+import {UpdateContractMessageLib} from "centrifuge-v3/src/spoke/libraries/UpdateContractMessageLib.sol";
 
 import {FullDeployer, FullActionBatcher, CommonInput} from "centrifuge-v3/script/FullDeployer.s.sol";
 
@@ -50,12 +53,15 @@ contract CentrifugeIntegrationTest is FullDeployer, Test {
 
 /// @notice Similar to CentrifugeIntegrationTest but with some customized general utilities
 contract CentrifugeIntegrationTestWithUtils is CentrifugeIntegrationTest {
+    using UpdateContractMessageLib for *;
+
     address immutable FM = makeAddr("fundManager");
     PoolId POOL_A;
     ShareClassId SC_1;
 
     // Extra deployment
     ERC20 usdc;
+    AssetId usdcId;
 
     function setUp() public override {
         super.setUp();
@@ -71,12 +77,12 @@ contract CentrifugeIntegrationTestWithUtils is CentrifugeIntegrationTest {
         vm.label(address(usdc), "usdc");
     }
 
-    function registerUSDC() public {
+    function _registerUSDC() internal {
         vm.startPrank(FUNDED);
-        spoke.registerAsset{value: GAS}(LOCAL_CENTRIFUGE_ID, address(usdc), 0);
+        usdcId = spoke.registerAsset{value: GAS}(LOCAL_CENTRIFUGE_ID, address(usdc), 0);
     }
 
-    function createPool() public {
+    function _createPool() internal {
         vm.startPrank(ADMIN);
         guardian.createPool(POOL_A, FM, USD_ID);
 
@@ -86,14 +92,26 @@ contract CentrifugeIntegrationTestWithUtils is CentrifugeIntegrationTest {
         vm.startPrank(FUNDED);
         gateway.subsidizePool{value: DEFAULT_SUBSIDY}(POOL_A);
     }
+
+    function _updateContractSyncDepositMaxReserveMsg(AssetId assetId, uint128 maxReserve)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return UpdateContractMessageLib.UpdateContractSyncDepositMaxReserve({
+            assetId: assetId.raw(),
+            maxReserve: maxReserve
+        }).serialize();
+    }
+
 }
 
 contract _CentrifugeIntegrationTestWithUtilsTest is CentrifugeIntegrationTestWithUtils {
     function testCreatePool() public {
-        createPool();
+        _createPool();
     }
 
     function testRegisterUSDC() public {
-        registerUSDC();
+        _registerUSDC();
     }
 }

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -15,10 +15,10 @@ import {IHub} from "centrifuge-v3/src/hub/interfaces/IHub.sol";
 import {ISpoke} from "centrifuge-v3/src/spoke/interfaces/ISpoke.sol";
 import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
 
-import {FullDeployer} from "script/FullDeployer.s.sol";
+import {FullDeployer} from "centrifuge-v3/script/FullDeployer.s.sol";
 
-import "test/integration/EndToEnd.t.sol";
-import {LocalAdapter} from "test/integration/adapters/LocalAdapter.sol";
+import "centrifuge-v3/test/integration/EndToEnd.t.sol";
+import {LocalAdapter} from "centrifuge-v3/test/integration/adapters/LocalAdapter.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ISafe} from "src/common/interfaces/IGuardian.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IMultiAdapter} from "src/common/interfaces/adapters/IMultiAdapter.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ISafe} from "centrifuge-v3/src/common/interfaces/IGuardian.sol";
+import {IGateway} from "centrifuge-v3/src/common/interfaces/IGateway.sol";
+import {MessageLib} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {IMultiAdapter} from "centrifuge-v3/src/common/interfaces/adapters/IMultiAdapter.sol";
 
-import {IHub} from "src/hub/interfaces/IHub.sol";
+import {IHub} from "centrifuge-v3/src/hub/interfaces/IHub.sol";
 
-import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {ISpoke} from "centrifuge-v3/src/spoke/interfaces/ISpoke.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
 
 import {FullDeployer} from "script/FullDeployer.s.sol";
 

--- a/test/integration/adapters/LocalAdapter.sol
+++ b/test/integration/adapters/LocalAdapter.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
+import {Auth} from "centrifuge-v3/src/misc/Auth.sol";
 
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
+import {IMessageHandler} from "centrifuge-v3/src/common/interfaces/IMessageHandler.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/managers/Deployment.t.sol
+++ b/test/managers/Deployment.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ManagersDeployer, ManagersActionBatcher} from "script/ManagersDeployer.s.sol";
+import {ManagersDeployer, ManagersActionBatcher} from "centrifuge-v3/script/ManagersDeployer.s.sol";
 
-import {CommonDeploymentInputTest} from "test/common/Deployment.t.sol";
+import {CommonDeploymentInputTest} from "centrifuge-v3/test/common/Deployment.t.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/managers/integration/MerkleProofManager.t.sol
+++ b/test/managers/integration/MerkleProofManager.t.sol
@@ -17,8 +17,8 @@ import {VaultDecoder} from "centrifuge-v3/src/managers/decoders/VaultDecoder.sol
 import {MerkleProofManager, PolicyLeaf, Call} from "centrifuge-v3/src/managers/MerkleProofManager.sol";
 import {IMerkleProofManager, IERC7751} from "centrifuge-v3/src/managers/interfaces/IMerkleProofManager.sol";
 
-import "test/spoke/BaseTest.sol";
-import {MerkleTreeLib} from "test/managers/libraries/MerkleTreeLib.sol";
+import "centrifuge-v3/test/spoke/BaseTest.sol";
+import {MerkleTreeLib} from "centrifuge-v3/test/managers/libraries/MerkleTreeLib.sol";
 
 abstract contract MerkleProofManagerBaseTest is BaseTest {
     using CastLib for *;

--- a/test/managers/integration/MerkleProofManager.t.sol
+++ b/test/managers/integration/MerkleProofManager.t.sol
@@ -1,21 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/Auth.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {IAuth} from "centrifuge-v3/src/misc/Auth.sol";
+import {D18, d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
-import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import {BalanceSheet} from "centrifuge-v3/src/spoke/BalanceSheet.sol";
+import {UpdateContractMessageLib} from "centrifuge-v3/src/spoke/libraries/UpdateContractMessageLib.sol";
 
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {UpdateRestrictionMessageLib} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
-import {VaultDecoder} from "src/managers/decoders/VaultDecoder.sol";
-import {MerkleProofManager, PolicyLeaf, Call} from "src/managers/MerkleProofManager.sol";
-import {IMerkleProofManager, IERC7751} from "src/managers/interfaces/IMerkleProofManager.sol";
+import {VaultDecoder} from "centrifuge-v3/src/managers/decoders/VaultDecoder.sol";
+import {MerkleProofManager, PolicyLeaf, Call} from "centrifuge-v3/src/managers/MerkleProofManager.sol";
+import {IMerkleProofManager, IERC7751} from "centrifuge-v3/src/managers/interfaces/IMerkleProofManager.sol";
 
 import "test/spoke/BaseTest.sol";
 import {MerkleTreeLib} from "test/managers/libraries/MerkleTreeLib.sol";

--- a/test/managers/integration/OnOfframpManager.t.sol
+++ b/test/managers/integration/OnOfframpManager.t.sol
@@ -1,23 +1,23 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {IERC165} from "src/misc/interfaces/IERC165.sol";
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
-import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
+import {D18, d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {IERC165} from "centrifuge-v3/src/misc/interfaces/IERC165.sol";
+import {IEscrow} from "centrifuge-v3/src/misc/interfaces/IEscrow.sol";
+import {IERC7751} from "centrifuge-v3/src/misc/interfaces/IERC7751.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
 
-import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import {UpdateContractMessageLib} from "centrifuge-v3/src/spoke/libraries/UpdateContractMessageLib.sol";
 
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {UpdateRestrictionMessageLib} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
-import {OnOfframpManagerFactory} from "src/managers/OnOfframpManager.sol";
-import {IOnOfframpManager} from "src/managers/interfaces/IOnOfframpManager.sol";
-import {IDepositManager, IWithdrawManager} from "src/managers/interfaces/IBalanceSheetManager.sol";
+import {OnOfframpManagerFactory} from "centrifuge-v3/src/managers/OnOfframpManager.sol";
+import {IOnOfframpManager} from "centrifuge-v3/src/managers/interfaces/IOnOfframpManager.sol";
+import {IDepositManager, IWithdrawManager} from "centrifuge-v3/src/managers/interfaces/IBalanceSheetManager.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/managers/integration/OnOfframpManager.t.sol
+++ b/test/managers/integration/OnOfframpManager.t.sol
@@ -19,7 +19,7 @@ import {OnOfframpManagerFactory} from "centrifuge-v3/src/managers/OnOfframpManag
 import {IOnOfframpManager} from "centrifuge-v3/src/managers/interfaces/IOnOfframpManager.sol";
 import {IDepositManager, IWithdrawManager} from "centrifuge-v3/src/managers/interfaces/IBalanceSheetManager.sol";
 
-import "test/spoke/BaseTest.sol";
+import "centrifuge-v3/test/spoke/BaseTest.sol";
 
 abstract contract OnOfframpManagerBaseTest is BaseTest {
     using CastLib for *;

--- a/test/misc/mocks/MockERC6909.sol
+++ b/test/misc/mocks/MockERC6909.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IERC6909MetadataExt, IERC6909Fungible, IERC6909} from "src/misc/interfaces/IERC6909.sol";
+import {IERC6909MetadataExt, IERC6909Fungible, IERC6909} from "centrifuge-v3/src/misc/interfaces/IERC6909.sol";
 
 contract MockERC6909 is IERC6909MetadataExt, IERC6909Fungible {
     mapping(address owner => mapping(uint256 tokenId => uint256)) public balanceOf;

--- a/test/misc/unit/BaseValuation.t.sol
+++ b/test/misc/unit/BaseValuation.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
+import {IERC6909Decimals} from "centrifuge-v3/src/misc/interfaces/IERC6909.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {BaseValuation} from "src/common/BaseValuation.sol";
-import {IBaseValuation} from "src/common/interfaces/IBaseValuation.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {BaseValuation} from "centrifuge-v3/src/common/BaseValuation.sol";
+import {IBaseValuation} from "centrifuge-v3/src/common/interfaces/IBaseValuation.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/EIP712Lib.t.sol
+++ b/test/misc/unit/EIP712Lib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "src/misc/libraries/EIP712Lib.sol";
+import "centrifuge-v3/src/misc/libraries/EIP712Lib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/ERC20.t.sol
+++ b/test/misc/unit/ERC20.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ERC20} from "src/misc/ERC20.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {IERC1271} from "src/misc/libraries/SignatureLib.sol";
-import {IERC20, IERC20Permit} from "src/misc/interfaces/IERC20.sol";
+import {ERC20} from "centrifuge-v3/src/misc/ERC20.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
+import {IERC1271} from "centrifuge-v3/src/misc/libraries/SignatureLib.sol";
+import {IERC20, IERC20Permit} from "centrifuge-v3/src/misc/interfaces/IERC20.sol";
 
 import "forge-std/Test.sol";
 
@@ -42,7 +42,7 @@ contract MockMultisig is IERC1271 {
     function test() public {}
 }
 
-/// @author Modified from https://github.com/makerdao/xdomain-dss/blob/master/src/test/Dai.t.sol
+/// @author Modified from https://github.com/makerdao/xdomain-dss/blob/master/centrifuge-v3/src/test/Dai.t.sol
 contract ERC20Test is Test {
     ERC20 token;
 

--- a/test/misc/unit/ERC20.t.sol
+++ b/test/misc/unit/ERC20.t.sol
@@ -42,7 +42,8 @@ contract MockMultisig is IERC1271 {
     function test() public {}
 }
 
-/// @author Modified from https://github.com/makerdao/xdomain-dss/blob/master/centrifuge-v3/src/centrifuge-v3/test/Dai.t.sol
+/// @author Modified from
+/// https://github.com/makerdao/xdomain-dss/blob/master/centrifuge-v3/src/centrifuge-v3/test/Dai.t.sol
 contract ERC20Test is Test {
     ERC20 token;
 

--- a/test/misc/unit/ERC20.t.sol
+++ b/test/misc/unit/ERC20.t.sol
@@ -42,7 +42,7 @@ contract MockMultisig is IERC1271 {
     function test() public {}
 }
 
-/// @author Modified from https://github.com/makerdao/xdomain-dss/blob/master/centrifuge-v3/src/test/Dai.t.sol
+/// @author Modified from https://github.com/makerdao/xdomain-dss/blob/master/centrifuge-v3/src/centrifuge-v3/test/Dai.t.sol
 contract ERC20Test is Test {
     ERC20 token;
 

--- a/test/misc/unit/IdentityValuation.t.sol
+++ b/test/misc/unit/IdentityValuation.t.sol
@@ -5,7 +5,7 @@ import {IdentityValuation} from "centrifuge-v3/src/misc/IdentityValuation.sol";
 
 import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
 
-import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
+import {MockERC6909} from "centrifuge-v3/test/misc/mocks/MockERC6909.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/IdentityValuation.t.sol
+++ b/test/misc/unit/IdentityValuation.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import {IdentityValuation} from "src/misc/IdentityValuation.sol";
+import {IdentityValuation} from "centrifuge-v3/src/misc/IdentityValuation.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
 
 import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
 

--- a/test/misc/unit/Multicall.t.sol
+++ b/test/misc/unit/Multicall.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import {Multicall} from "src/misc/Multicall.sol";
-import {IMulticall} from "src/misc/interfaces/IMulticall.sol";
-import {ReentrancyProtection} from "src/misc/ReentrancyProtection.sol";
+import {Multicall} from "centrifuge-v3/src/misc/Multicall.sol";
+import {IMulticall} from "centrifuge-v3/src/misc/interfaces/IMulticall.sol";
+import {ReentrancyProtection} from "centrifuge-v3/src/misc/ReentrancyProtection.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/Recoverable.t.sol
+++ b/test/misc/unit/Recoverable.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {ERC20} from "src/misc/ERC20.sol";
-import {Auth, IAuth} from "src/misc/Auth.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
+import {ERC20} from "centrifuge-v3/src/misc/ERC20.sol";
+import {Auth, IAuth} from "centrifuge-v3/src/misc/Auth.sol";
+import {Recoverable} from "centrifuge-v3/src/misc/Recoverable.sol";
 
 import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
 

--- a/test/misc/unit/Recoverable.t.sol
+++ b/test/misc/unit/Recoverable.t.sol
@@ -5,7 +5,7 @@ import {ERC20} from "centrifuge-v3/src/misc/ERC20.sol";
 import {Auth, IAuth} from "centrifuge-v3/src/misc/Auth.sol";
 import {Recoverable} from "centrifuge-v3/src/misc/Recoverable.sol";
 
-import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
+import {MockERC6909} from "centrifuge-v3/test/misc/mocks/MockERC6909.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/SignatureLib.t.sol
+++ b/test/misc/unit/SignatureLib.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "src/misc/libraries/EIP712Lib.sol";
-import "src/misc/libraries/SignatureLib.sol";
+import "centrifuge-v3/src/misc/libraries/EIP712Lib.sol";
+import "centrifuge-v3/src/misc/libraries/SignatureLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/ArrayLib.t.sol
+++ b/test/misc/unit/libraries/ArrayLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ArrayLib} from "src/misc/libraries/ArrayLib.sol";
+import {ArrayLib} from "centrifuge-v3/src/misc/libraries/ArrayLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/BytesLib.t.sol
+++ b/test/misc/unit/libraries/BytesLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/CastLib.t.sol
+++ b/test/misc/unit/libraries/CastLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/D18.t.sol
+++ b/test/misc/unit/libraries/D18.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import "src/misc/types/D18.sol";
-import "src/misc/libraries/MathLib.sol";
+import "centrifuge-v3/src/misc/types/D18.sol";
+import "centrifuge-v3/src/misc/libraries/MathLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/MathLib.t.sol
+++ b/test/misc/unit/libraries/MathLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import "src/misc/libraries/MathLib.sol";
+import "centrifuge-v3/src/misc/libraries/MathLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/MerkleProofLib.t.sol
+++ b/test/misc/unit/libraries/MerkleProofLib.t.sol
@@ -5,7 +5,8 @@ import {MerkleProofLib} from "centrifuge-v3/src/misc/libraries/MerkleProofLib.so
 
 import "forge-std/Test.sol";
 
-/// @author Modified from https://github.com/transmissions11/solmate/blob/main/centrifuge-v3/src/centrifuge-v3/test/MerkleProofLib.t.sol
+/// @author Modified from
+/// https://github.com/transmissions11/solmate/blob/main/centrifuge-v3/src/centrifuge-v3/test/MerkleProofLib.t.sol
 contract MerkleProofLibTest is Test {
     function testVerifyEmptyMerkleProofSuppliedLeafAndRootSame() public view {
         bytes32[] memory proof;

--- a/test/misc/unit/libraries/MerkleProofLib.t.sol
+++ b/test/misc/unit/libraries/MerkleProofLib.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {MerkleProofLib} from "src/misc/libraries/MerkleProofLib.sol";
+import {MerkleProofLib} from "centrifuge-v3/src/misc/libraries/MerkleProofLib.sol";
 
 import "forge-std/Test.sol";
 
-/// @author Modified from https://github.com/transmissions11/solmate/blob/main/src/test/MerkleProofLib.t.sol
+/// @author Modified from https://github.com/transmissions11/solmate/blob/main/centrifuge-v3/src/test/MerkleProofLib.t.sol
 contract MerkleProofLibTest is Test {
     function testVerifyEmptyMerkleProofSuppliedLeafAndRootSame() public view {
         bytes32[] memory proof;

--- a/test/misc/unit/libraries/MerkleProofLib.t.sol
+++ b/test/misc/unit/libraries/MerkleProofLib.t.sol
@@ -5,7 +5,7 @@ import {MerkleProofLib} from "centrifuge-v3/src/misc/libraries/MerkleProofLib.so
 
 import "forge-std/Test.sol";
 
-/// @author Modified from https://github.com/transmissions11/solmate/blob/main/centrifuge-v3/src/test/MerkleProofLib.t.sol
+/// @author Modified from https://github.com/transmissions11/solmate/blob/main/centrifuge-v3/src/centrifuge-v3/test/MerkleProofLib.t.sol
 contract MerkleProofLibTest is Test {
     function testVerifyEmptyMerkleProofSuppliedLeafAndRootSame() public view {
         bytes32[] memory proof;

--- a/test/misc/unit/libraries/PricingLib.t.sol
+++ b/test/misc/unit/libraries/PricingLib.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
+import {D18, d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
+import {IERC20Metadata} from "centrifuge-v3/src/misc/interfaces/IERC20.sol";
 
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
+import {PricingLib} from "centrifuge-v3/src/common/libraries/PricingLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/SafeTransferLib.t.sol
+++ b/test/misc/unit/libraries/SafeTransferLib.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
+import {IERC7751} from "centrifuge-v3/src/misc/interfaces/IERC7751.sol";
+import {SafeTransferLib} from "centrifuge-v3/src/misc/libraries/SafeTransferLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/SafeTransferLib.t.sol
+++ b/test/misc/unit/libraries/SafeTransferLib.t.sol
@@ -60,7 +60,7 @@ contract ERC20WithBooleanAlwaysFalse {
 }
 
 /// @author Modified from
-/// https://github.com/morpho-org/morpho-blue/blob/main/test/forge/libraries/SafeTransferLibTest.sol
+/// https://github.com/morpho-org/morpho-blue/blob/main/centrifuge-v3/test/forge/libraries/SafeTransferLibTest.sol
 contract SafeTransferLibTest is Test {
     ERC20WithoutBoolean public tokenWithoutBoolean;
     ERC20WithBooleanAlwaysFalse public tokenWithBooleanAlwaysFalse;

--- a/test/misc/unit/libraries/StringLib.t.sol
+++ b/test/misc/unit/libraries/StringLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "src/misc/libraries/StringLib.sol";
+import "centrifuge-v3/src/misc/libraries/StringLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/TransientArrayLib.t.sol
+++ b/test/misc/unit/libraries/TransientArrayLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {TransientArrayLib} from "src/misc/libraries/TransientArrayLib.sol";
+import {TransientArrayLib} from "centrifuge-v3/src/misc/libraries/TransientArrayLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/TransientBytesLib.t.sol
+++ b/test/misc/unit/libraries/TransientBytesLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {TransientBytesLib} from "src/misc/libraries/TransientBytesLib.sol";
+import {TransientBytesLib} from "centrifuge-v3/src/misc/libraries/TransientBytesLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/TransientStorageLib.t.sol
+++ b/test/misc/unit/libraries/TransientStorageLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
+import {TransientStorageLib} from "centrifuge-v3/src/misc/libraries/TransientStorageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/spoke/BaseTest.sol
+++ b/test/spoke/BaseTest.sol
@@ -21,12 +21,12 @@ import {IVaultFactory} from "centrifuge-v3/src/spoke/factories/interfaces/IVault
 
 import {AsyncVault} from "centrifuge-v3/src/vaults/AsyncVault.sol";
 
-import {ExtendedSpokeDeployer, ExtendedSpokeActionBatcher, CommonInput} from "script/ExtendedSpokeDeployer.s.sol";
+import {ExtendedSpokeDeployer, ExtendedSpokeActionBatcher, CommonInput} from "centrifuge-v3/script/ExtendedSpokeDeployer.s.sol";
 
-import {MockSafe} from "test/spoke/mocks/MockSafe.sol";
-import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
-import {MockAdapter} from "test/common/mocks/MockAdapter.sol";
-import {MockCentrifugeChain} from "test/spoke/mocks/MockCentrifugeChain.sol";
+import {MockSafe} from "centrifuge-v3/test/spoke/mocks/MockSafe.sol";
+import {MockERC6909} from "centrifuge-v3/test/misc/mocks/MockERC6909.sol";
+import {MockAdapter} from "centrifuge-v3/test/common/mocks/MockAdapter.sol";
+import {MockCentrifugeChain} from "centrifuge-v3/test/spoke/mocks/MockCentrifugeChain.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/spoke/BaseTest.sol
+++ b/test/spoke/BaseTest.sol
@@ -2,24 +2,24 @@
 pragma solidity 0.8.28;
 pragma abicoder v2;
 
-import "src/misc/interfaces/IERC20.sol";
-import {ERC20} from "src/misc/ERC20.sol";
-import {IERC6909Fungible} from "src/misc/interfaces/IERC6909.sol";
+import "centrifuge-v3/src/misc/interfaces/IERC20.sol";
+import {ERC20} from "centrifuge-v3/src/misc/ERC20.sol";
+import {IERC6909Fungible} from "centrifuge-v3/src/misc/interfaces/IERC6909.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {newAssetId} from "src/common/types/AssetId.sol";
-import {ISafe} from "src/common/interfaces/IGuardian.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {PoolId, newPoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {MAX_MESSAGE_COST} from "src/common/interfaces/IGasService.sol";
-import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {newAssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {ISafe} from "centrifuge-v3/src/common/interfaces/IGuardian.sol";
+import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
+import {PoolId, newPoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {MAX_MESSAGE_COST} from "centrifuge-v3/src/common/interfaces/IGasService.sol";
+import {MessageLib, VaultUpdateKind} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
 
-import {VaultKind} from "src/spoke/interfaces/IVault.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
+import {VaultKind} from "centrifuge-v3/src/spoke/interfaces/IVault.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
+import {IVaultFactory} from "centrifuge-v3/src/spoke/factories/interfaces/IVaultFactory.sol";
 
-import {AsyncVault} from "src/vaults/AsyncVault.sol";
+import {AsyncVault} from "centrifuge-v3/src/vaults/AsyncVault.sol";
 
 import {ExtendedSpokeDeployer, ExtendedSpokeActionBatcher, CommonInput} from "script/ExtendedSpokeDeployer.s.sol";
 

--- a/test/spoke/BaseTest.sol
+++ b/test/spoke/BaseTest.sol
@@ -21,7 +21,11 @@ import {IVaultFactory} from "centrifuge-v3/src/spoke/factories/interfaces/IVault
 
 import {AsyncVault} from "centrifuge-v3/src/vaults/AsyncVault.sol";
 
-import {ExtendedSpokeDeployer, ExtendedSpokeActionBatcher, CommonInput} from "centrifuge-v3/script/ExtendedSpokeDeployer.s.sol";
+import {
+    ExtendedSpokeDeployer,
+    ExtendedSpokeActionBatcher,
+    CommonInput
+} from "centrifuge-v3/script/ExtendedSpokeDeployer.s.sol";
 
 import {MockSafe} from "centrifuge-v3/test/spoke/mocks/MockSafe.sol";
 import {MockERC6909} from "centrifuge-v3/test/misc/mocks/MockERC6909.sol";

--- a/test/spoke/Deployment.t.sol
+++ b/test/spoke/Deployment.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {SpokeDeployer, SpokeActionBatcher} from "script/SpokeDeployer.s.sol";
+import {SpokeDeployer, SpokeActionBatcher} from "centrifuge-v3/script/SpokeDeployer.s.sol";
 
-import {CommonDeploymentInputTest} from "test/common/Deployment.t.sol";
+import {CommonDeploymentInputTest} from "centrifuge-v3/test/common/Deployment.t.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/spoke/integration/AssetShareConversion.t.sol
+++ b/test/spoke/integration/AssetShareConversion.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "test/spoke/BaseTest.sol";
+import "centrifuge-v3/test/spoke/BaseTest.sol";
 
 contract AssetShareConversionTest is BaseTest {
     function testAssetShareConversion(bytes16 scId) public {

--- a/test/spoke/integration/AsyncRequestManager.t.sol
+++ b/test/spoke/integration/AsyncRequestManager.t.sol
@@ -2,20 +2,20 @@
 pragma solidity 0.8.28;
 pragma abicoder v2;
 
-import {d18, D18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
+import {d18, D18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
+import {IEscrow} from "centrifuge-v3/src/misc/interfaces/IEscrow.sol";
 
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
+import {PricingLib} from "centrifuge-v3/src/common/libraries/PricingLib.sol";
 
-import {VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
+import {VaultDetails} from "centrifuge-v3/src/spoke/interfaces/ISpoke.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {AsyncRequestManager} from "src/vaults/AsyncRequestManager.sol";
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
+import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncVault} from "centrifuge-v3/src/vaults/interfaces/IAsyncVault.sol";
+import {AsyncRequestManager} from "centrifuge-v3/src/vaults/AsyncRequestManager.sol";
+import {IAsyncRequestManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseRequestManager} from "centrifuge-v3/src/vaults/interfaces/IBaseRequestManager.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/integration/AsyncRequestManager.t.sol
+++ b/test/spoke/integration/AsyncRequestManager.t.sol
@@ -17,7 +17,7 @@ import {AsyncRequestManager} from "centrifuge-v3/src/vaults/AsyncRequestManager.
 import {IAsyncRequestManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 import {IBaseRequestManager} from "centrifuge-v3/src/vaults/interfaces/IBaseRequestManager.sol";
 
-import "test/spoke/BaseTest.sol";
+import "centrifuge-v3/test/spoke/BaseTest.sol";
 
 interface VaultLike {
     function priceComputedAt() external view returns (uint64);

--- a/test/spoke/integration/Burn.t.sol
+++ b/test/spoke/integration/Burn.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
+import {IERC20} from "centrifuge-v3/src/misc/interfaces/IERC20.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/integration/Burn.t.sol
+++ b/test/spoke/integration/Burn.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
 import {IERC20} from "centrifuge-v3/src/misc/interfaces/IERC20.sol";
 
-import "test/spoke/BaseTest.sol";
+import "centrifuge-v3/test/spoke/BaseTest.sol";
 
 contract BurnTest is BaseTest {
     function testBurn(uint256 amount) public {

--- a/test/spoke/integration/Deposit.t.sol
+++ b/test/spoke/integration/Deposit.t.sol
@@ -15,7 +15,7 @@ import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
 import {IAsyncVault} from "centrifuge-v3/src/vaults/interfaces/IAsyncVault.sol";
 import {IAsyncRequestManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 
-import "test/spoke/BaseTest.sol";
+import "centrifuge-v3/test/spoke/BaseTest.sol";
 
 contract DepositTest is BaseTest {
     using MessageLib for *;

--- a/test/spoke/integration/Deposit.t.sol
+++ b/test/spoke/integration/Deposit.t.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18} from "src/misc/types/D18.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
+import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
+import {IERC7751} from "centrifuge-v3/src/misc/interfaces/IERC7751.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {RequestMessageLib} from "centrifuge-v3/src/common/libraries/RequestMessageLib.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncVault} from "centrifuge-v3/src/vaults/interfaces/IAsyncVault.sol";
+import {IAsyncRequestManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/integration/DepositRedeem.t.sol
+++ b/test/spoke/integration/DepositRedeem.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18} from "src/misc/types/D18.sol";
+import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/integration/DepositRedeem.t.sol
+++ b/test/spoke/integration/DepositRedeem.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.28;
 
 import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
 
-import "test/spoke/BaseTest.sol";
+import "centrifuge-v3/test/spoke/BaseTest.sol";
 
 contract DepositRedeem is BaseTest {
     function testPartialDepositAndRedeemExecutions(bytes16 scId) public {

--- a/test/spoke/integration/Mint.t.sol
+++ b/test/spoke/integration/Mint.t.sol
@@ -5,7 +5,7 @@ import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
 
 import {ITransferHook} from "centrifuge-v3/src/common/interfaces/ITransferHook.sol";
 
-import "test/spoke/BaseTest.sol";
+import "centrifuge-v3/test/spoke/BaseTest.sol";
 
 contract MintTest is BaseTest {
     function testMint(uint256 amount) public {

--- a/test/spoke/integration/Mint.t.sol
+++ b/test/spoke/integration/Mint.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
 
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
+import {ITransferHook} from "centrifuge-v3/src/common/interfaces/ITransferHook.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/integration/Operator.t.sol
+++ b/test/spoke/integration/Operator.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
+import {IERC20} from "centrifuge-v3/src/misc/interfaces/IERC20.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncVault} from "centrifuge-v3/src/vaults/interfaces/IAsyncVault.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/integration/Operator.t.sol
+++ b/test/spoke/integration/Operator.t.sol
@@ -6,7 +6,7 @@ import {IERC20} from "centrifuge-v3/src/misc/interfaces/IERC20.sol";
 import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
 import {IAsyncVault} from "centrifuge-v3/src/vaults/interfaces/IAsyncVault.sol";
 
-import "test/spoke/BaseTest.sol";
+import "centrifuge-v3/test/spoke/BaseTest.sol";
 
 contract OperatorTest is BaseTest {
     function testDepositAsOperator(uint256 amount) public {

--- a/test/spoke/integration/Redeem.t.sol
+++ b/test/spoke/integration/Redeem.t.sol
@@ -14,7 +14,7 @@ import {RequestMessageLib} from "centrifuge-v3/src/common/libraries/RequestMessa
 import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
 import {IAsyncRequestManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 
-import "test/spoke/BaseTest.sol";
+import "centrifuge-v3/test/spoke/BaseTest.sol";
 
 contract RedeemTest is BaseTest {
     using MessageLib for *;

--- a/test/spoke/integration/Redeem.t.sol
+++ b/test/spoke/integration/Redeem.t.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {D18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
+import {IERC20} from "centrifuge-v3/src/misc/interfaces/IERC20.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {RequestMessageLib} from "centrifuge-v3/src/common/libraries/RequestMessageLib.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncRequestManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/integration/Spoke.t.sol
+++ b/test/spoke/integration/Spoke.t.sol
@@ -1,27 +1,27 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {BytesLib} from "centrifuge-v3/src/misc/libraries/BytesLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {IGateway} from "centrifuge-v3/src/common/interfaces/IGateway.sol";
+import {MessageLib} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {ITransferHook} from "centrifuge-v3/src/common/interfaces/ITransferHook.sol";
 
-import {ShareToken} from "src/spoke/ShareToken.sol";
-import {IVault} from "src/spoke/interfaces/IVaultManager.sol";
-import {ISpoke, VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
-import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
+import {ShareToken} from "centrifuge-v3/src/spoke/ShareToken.sol";
+import {IVault} from "centrifuge-v3/src/spoke/interfaces/IVaultManager.sol";
+import {ISpoke, VaultDetails} from "centrifuge-v3/src/spoke/interfaces/ISpoke.sol";
+import {IUpdateContract} from "centrifuge-v3/src/spoke/interfaces/IUpdateContract.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {AsyncVaultFactory} from "src/vaults/factories/AsyncVaultFactory.sol";
+import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
+import {AsyncVaultFactory} from "centrifuge-v3/src/vaults/factories/AsyncVaultFactory.sol";
 
-import {IMemberlist} from "src/hooks/interfaces/IMemberlist.sol";
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {IMemberlist} from "centrifuge-v3/src/hooks/interfaces/IMemberlist.sol";
+import {UpdateRestrictionMessageLib} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import "test/spoke/BaseTest.sol";
 import {MockHook} from "test/spoke/mocks/MockHook.sol";

--- a/test/spoke/integration/Spoke.t.sol
+++ b/test/spoke/integration/Spoke.t.sol
@@ -23,9 +23,9 @@ import {AsyncVaultFactory} from "centrifuge-v3/src/vaults/factories/AsyncVaultFa
 import {IMemberlist} from "centrifuge-v3/src/hooks/interfaces/IMemberlist.sol";
 import {UpdateRestrictionMessageLib} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
-import "test/spoke/BaseTest.sol";
-import {MockHook} from "test/spoke/mocks/MockHook.sol";
-import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
+import "centrifuge-v3/test/spoke/BaseTest.sol";
+import {MockHook} from "centrifuge-v3/test/spoke/mocks/MockHook.sol";
+import {MockERC6909} from "centrifuge-v3/test/misc/mocks/MockERC6909.sol";
 
 contract SpokeTestHelper is BaseTest {
     PoolId poolId;

--- a/test/spoke/integration/SyncDeposit.t.sol
+++ b/test/spoke/integration/SyncDeposit.t.sol
@@ -1,26 +1,26 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
+import {D18, d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
+import {IERC7751} from "centrifuge-v3/src/misc/interfaces/IERC7751.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {MessageLib} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {ITransferHook} from "centrifuge-v3/src/common/interfaces/ITransferHook.sol";
 
-import {VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
-import {IVault} from "src/spoke/interfaces/IVaultManager.sol";
-import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
+import {VaultDetails} from "centrifuge-v3/src/spoke/interfaces/ISpoke.sol";
+import {IVault} from "centrifuge-v3/src/spoke/interfaces/IVaultManager.sol";
+import {IBalanceSheet} from "centrifuge-v3/src/spoke/interfaces/IBalanceSheet.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
-import {ISyncManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
+import {SyncDepositVault} from "centrifuge-v3/src/vaults/SyncDepositVault.sol";
+import {ISyncManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
+import {IAsyncRedeemVault} from "centrifuge-v3/src/vaults/interfaces/IAsyncVault.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/integration/SyncDeposit.t.sol
+++ b/test/spoke/integration/SyncDeposit.t.sol
@@ -22,7 +22,7 @@ import {SyncDepositVault} from "centrifuge-v3/src/vaults/SyncDepositVault.sol";
 import {ISyncManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 import {IAsyncRedeemVault} from "centrifuge-v3/src/vaults/interfaces/IAsyncVault.sol";
 
-import "test/spoke/BaseTest.sol";
+import "centrifuge-v3/test/spoke/BaseTest.sol";
 
 contract SyncDepositTestHelper is BaseTest {
     using CastLib for *;

--- a/test/spoke/integration/SyncManager.t.sol
+++ b/test/spoke/integration/SyncManager.t.sol
@@ -13,7 +13,7 @@ import {ISyncManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.s
 import {IBaseRequestManager} from "centrifuge-v3/src/vaults/interfaces/IBaseRequestManager.sol";
 import {ISyncManager, ISyncDepositValuation} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 
-import "test/spoke/BaseTest.sol";
+import "centrifuge-v3/test/spoke/BaseTest.sol";
 
 contract SyncManagerBaseTest is BaseTest {
     function _deploySyncDepositVault(D18 pricePoolPerShare, D18 pricePoolPerAsset)

--- a/test/spoke/integration/SyncManager.t.sol
+++ b/test/spoke/integration/SyncManager.t.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {D18, d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
 
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
+import {MessageLib} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
-import {ISyncManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
-import {ISyncManager, ISyncDepositValuation} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
+import {SyncDepositVault} from "centrifuge-v3/src/vaults/SyncDepositVault.sol";
+import {ISyncManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseRequestManager} from "centrifuge-v3/src/vaults/interfaces/IBaseRequestManager.sol";
+import {ISyncManager, ISyncDepositValuation} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/integration/VaultRouter.t.sol
+++ b/test/spoke/integration/VaultRouter.t.sol
@@ -1,21 +1,21 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "src/misc/interfaces/IERC20.sol";
-import "src/misc/interfaces/IERC7540.sol";
-import "src/misc/interfaces/IERC7575.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
+import "centrifuge-v3/src/misc/interfaces/IERC20.sol";
+import "centrifuge-v3/src/misc/interfaces/IERC7540.sol";
+import "centrifuge-v3/src/misc/interfaces/IERC7575.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
+import {IERC7751} from "centrifuge-v3/src/misc/interfaces/IERC7751.sol";
 
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
+import {MessageLib} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
 
-import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
+import {ISpoke} from "centrifuge-v3/src/spoke/interfaces/ISpoke.sol";
 
-import {VaultRouter} from "src/vaults/VaultRouter.sol";
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IVaultRouter} from "src/vaults/interfaces/IVaultRouter.sol";
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {VaultRouter} from "centrifuge-v3/src/vaults/VaultRouter.sol";
+import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncVault} from "centrifuge-v3/src/vaults/interfaces/IAsyncVault.sol";
+import {IVaultRouter} from "centrifuge-v3/src/vaults/interfaces/IVaultRouter.sol";
+import {IAsyncRequestManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/integration/VaultRouter.t.sol
+++ b/test/spoke/integration/VaultRouter.t.sol
@@ -17,7 +17,7 @@ import {IAsyncVault} from "centrifuge-v3/src/vaults/interfaces/IAsyncVault.sol";
 import {IVaultRouter} from "centrifuge-v3/src/vaults/interfaces/IVaultRouter.sol";
 import {IAsyncRequestManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 
-import "test/spoke/BaseTest.sol";
+import "centrifuge-v3/test/spoke/BaseTest.sol";
 
 contract VaultRouterTest is BaseTest {
     using MessageLib for *;

--- a/test/spoke/mocks/MockCentrifugeChain.sol
+++ b/test/spoke/mocks/MockCentrifugeChain.sol
@@ -1,23 +1,23 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {D18, d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
-import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
-import {RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {IAdapter} from "centrifuge-v3/src/common/interfaces/IAdapter.sol";
+import {MessageProofLib} from "centrifuge-v3/src/common/libraries/MessageProofLib.sol";
+import {MessageLib, VaultUpdateKind} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
+import {RequestCallbackMessageLib} from "centrifuge-v3/src/common/libraries/RequestCallbackMessageLib.sol";
 
-import {Spoke} from "src/spoke/Spoke.sol";
-import {VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
-import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import {Spoke} from "centrifuge-v3/src/spoke/Spoke.sol";
+import {VaultDetails} from "centrifuge-v3/src/spoke/interfaces/ISpoke.sol";
+import {UpdateContractMessageLib} from "centrifuge-v3/src/spoke/libraries/UpdateContractMessageLib.sol";
 
-import {SyncManager} from "src/vaults/SyncManager.sol";
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {SyncManager} from "centrifuge-v3/src/vaults/SyncManager.sol";
+import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
 
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {UpdateRestrictionMessageLib} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/spoke/mocks/MockFullRestrictions.sol
+++ b/test/spoke/mocks/MockFullRestrictions.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.28;
 
 import "centrifuge-v3/src/hooks/FullRestrictions.sol";
 
-import "test/common/mocks/Mock.sol";
+import "centrifuge-v3/test/common/mocks/Mock.sol";
 
 contract MockFullRestrictions is FullRestrictions, Mock {
     constructor(address root_, address deployer) FullRestrictions(root_, deployer) {}

--- a/test/spoke/mocks/MockFullRestrictions.sol
+++ b/test/spoke/mocks/MockFullRestrictions.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "src/hooks/FullRestrictions.sol";
+import "centrifuge-v3/src/hooks/FullRestrictions.sol";
 
 import "test/common/mocks/Mock.sol";
 

--- a/test/spoke/mocks/MockHook.sol
+++ b/test/spoke/mocks/MockHook.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IERC165} from "src/misc/interfaces/IERC7575.sol";
+import {IERC165} from "centrifuge-v3/src/misc/interfaces/IERC7575.sol";
 
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
+import {ITransferHook} from "centrifuge-v3/src/common/interfaces/ITransferHook.sol";
 
 import "test/common/mocks/Mock.sol";
 

--- a/test/spoke/mocks/MockHook.sol
+++ b/test/spoke/mocks/MockHook.sol
@@ -5,7 +5,7 @@ import {IERC165} from "centrifuge-v3/src/misc/interfaces/IERC7575.sol";
 
 import {ITransferHook} from "centrifuge-v3/src/common/interfaces/ITransferHook.sol";
 
-import "test/common/mocks/Mock.sol";
+import "centrifuge-v3/test/common/mocks/Mock.sol";
 
 contract MockHook is Mock {
     function supportsInterface(bytes4 interfaceId) external pure returns (bool) {

--- a/test/spoke/mocks/MockSafe.sol
+++ b/test/spoke/mocks/MockSafe.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ISafe} from "src/common/Guardian.sol";
+import {ISafe} from "centrifuge-v3/src/common/Guardian.sol";
 
 import {Mock} from "test/common/mocks/Mock.sol";
 

--- a/test/spoke/mocks/MockSafe.sol
+++ b/test/spoke/mocks/MockSafe.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.28;
 
 import {ISafe} from "centrifuge-v3/src/common/Guardian.sol";
 
-import {Mock} from "test/common/mocks/Mock.sol";
+import {Mock} from "centrifuge-v3/test/common/mocks/Mock.sol";
 
 contract MockSafe is Mock, ISafe {
     constructor(address[] memory owners, uint256 threshold) {

--- a/test/spoke/unit/AsyncVault.t.sol
+++ b/test/spoke/unit/AsyncVault.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "src/misc/interfaces/IERC7540.sol";
-import "src/misc/interfaces/IERC7575.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import "centrifuge-v3/src/misc/interfaces/IERC7540.sol";
+import "centrifuge-v3/src/misc/interfaces/IERC7575.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncRequestManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/unit/AsyncVault.t.sol
+++ b/test/spoke/unit/AsyncVault.t.sol
@@ -9,7 +9,7 @@ import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
 import {IBaseVault} from "centrifuge-v3/src/vaults/interfaces/IBaseVault.sol";
 import {IAsyncRequestManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 
-import "test/spoke/BaseTest.sol";
+import "centrifuge-v3/test/spoke/BaseTest.sol";
 
 contract AsyncVaultTest is BaseTest {
     // Deployment

--- a/test/spoke/unit/BalanceSheet.t.sol
+++ b/test/spoke/unit/BalanceSheet.t.sol
@@ -1,27 +1,27 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
-import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
+import {D18, d18} from "centrifuge-v3/src/misc/types/D18.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
+import {IERC20} from "centrifuge-v3/src/misc/interfaces/IERC20.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {IEscrow} from "centrifuge-v3/src/misc/interfaces/IEscrow.sol";
+import {IERC6909} from "centrifuge-v3/src/misc/interfaces/IERC6909.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {IPoolEscrowProvider} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {PoolId} from "centrifuge-v3/src/common/types/PoolId.sol";
+import {AssetId} from "centrifuge-v3/src/common/types/AssetId.sol";
+import {IRoot} from "centrifuge-v3/src/common/interfaces/IRoot.sol";
+import {IGateway} from "centrifuge-v3/src/common/interfaces/IGateway.sol";
+import {ShareClassId} from "centrifuge-v3/src/common/types/ShareClassId.sol";
+import {IPoolEscrow} from "centrifuge-v3/src/common/interfaces/IPoolEscrow.sol";
+import {ISpokeMessageSender} from "centrifuge-v3/src/common/interfaces/IGatewaySenders.sol";
+import {IPoolEscrowProvider} from "centrifuge-v3/src/common/factories/interfaces/IPoolEscrowFactory.sol";
 
-import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {BalanceSheet, IBalanceSheet} from "src/spoke/BalanceSheet.sol";
+import {ISpoke} from "centrifuge-v3/src/spoke/interfaces/ISpoke.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
+import {BalanceSheet, IBalanceSheet} from "centrifuge-v3/src/spoke/BalanceSheet.sol";
 
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {UpdateRestrictionMessageLib} from "centrifuge-v3/src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/spoke/unit/RestrictedTransfers.t.sol
+++ b/test/spoke/unit/RestrictedTransfers.t.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IERC165} from "src/misc/interfaces/IERC7575.sol";
+import {IERC165} from "centrifuge-v3/src/misc/interfaces/IERC7575.sol";
 
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
+import {ITransferHook} from "centrifuge-v3/src/common/interfaces/ITransferHook.sol";
 
-import {ShareToken} from "src/spoke/ShareToken.sol";
+import {ShareToken} from "centrifuge-v3/src/spoke/ShareToken.sol";
 
-import {IFreezable} from "src/hooks/interfaces/IFreezable.sol";
-import {FullRestrictions} from "src/hooks/FullRestrictions.sol";
-import {IMemberlist} from "src/hooks/interfaces/IMemberlist.sol";
+import {IFreezable} from "centrifuge-v3/src/hooks/interfaces/IFreezable.sol";
+import {FullRestrictions} from "centrifuge-v3/src/hooks/FullRestrictions.sol";
+import {IMemberlist} from "centrifuge-v3/src/hooks/interfaces/IMemberlist.sol";
 
 import {MockRoot} from "test/common/mocks/MockRoot.sol";
 

--- a/test/spoke/unit/RestrictedTransfers.t.sol
+++ b/test/spoke/unit/RestrictedTransfers.t.sol
@@ -11,7 +11,7 @@ import {IFreezable} from "centrifuge-v3/src/hooks/interfaces/IFreezable.sol";
 import {FullRestrictions} from "centrifuge-v3/src/hooks/FullRestrictions.sol";
 import {IMemberlist} from "centrifuge-v3/src/hooks/interfaces/IMemberlist.sol";
 
-import {MockRoot} from "test/common/mocks/MockRoot.sol";
+import {MockRoot} from "centrifuge-v3/test/common/mocks/MockRoot.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/spoke/unit/ShareToken.t.sol
+++ b/test/spoke/unit/ShareToken.t.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ERC20} from "src/misc/ERC20.sol";
-import "src/misc/interfaces/IERC7540.sol";
-import "src/misc/interfaces/IERC7575.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
+import {ERC20} from "centrifuge-v3/src/misc/ERC20.sol";
+import "centrifuge-v3/src/misc/interfaces/IERC7540.sol";
+import "centrifuge-v3/src/misc/interfaces/IERC7575.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
+import {IERC20} from "centrifuge-v3/src/misc/interfaces/IERC20.sol";
 
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
+import {ITransferHook} from "centrifuge-v3/src/common/interfaces/ITransferHook.sol";
 
-import {ShareToken} from "src/spoke/ShareToken.sol";
+import {ShareToken} from "centrifuge-v3/src/spoke/ShareToken.sol";
 
 import {MockRoot} from "test/common/mocks/MockRoot.sol";
 import {MockFullRestrictions} from "test/spoke/mocks/MockFullRestrictions.sol";

--- a/test/spoke/unit/ShareToken.t.sol
+++ b/test/spoke/unit/ShareToken.t.sol
@@ -11,8 +11,8 @@ import {ITransferHook} from "centrifuge-v3/src/common/interfaces/ITransferHook.s
 
 import {ShareToken} from "centrifuge-v3/src/spoke/ShareToken.sol";
 
-import {MockRoot} from "test/common/mocks/MockRoot.sol";
-import {MockFullRestrictions} from "test/spoke/mocks/MockFullRestrictions.sol";
+import {MockRoot} from "centrifuge-v3/test/common/mocks/MockRoot.sol";
+import {MockFullRestrictions} from "centrifuge-v3/test/spoke/mocks/MockFullRestrictions.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/spoke/unit/VaultRouter.t.sol
+++ b/test/spoke/unit/VaultRouter.t.sol
@@ -1,23 +1,23 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "src/misc/interfaces/IERC20.sol";
-import "src/misc/interfaces/IERC7540.sol";
-import "src/misc/interfaces/IERC7575.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
+import "centrifuge-v3/src/misc/interfaces/IERC20.sol";
+import "centrifuge-v3/src/misc/interfaces/IERC7540.sol";
+import "centrifuge-v3/src/misc/interfaces/IERC7575.sol";
+import {CastLib} from "centrifuge-v3/src/misc/libraries/CastLib.sol";
+import {MathLib} from "centrifuge-v3/src/misc/libraries/MathLib.sol";
+import {IERC7751} from "centrifuge-v3/src/misc/interfaces/IERC7751.sol";
 
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
+import {IGateway} from "centrifuge-v3/src/common/interfaces/IGateway.sol";
+import {MessageLib} from "centrifuge-v3/src/common/libraries/MessageLib.sol";
 
-import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
+import {ISpoke} from "centrifuge-v3/src/spoke/interfaces/ISpoke.sol";
 
-import {VaultRouter} from "src/vaults/VaultRouter.sol";
-import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IVaultRouter} from "src/vaults/interfaces/IVaultRouter.sol";
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {VaultRouter} from "centrifuge-v3/src/vaults/VaultRouter.sol";
+import {SyncDepositVault} from "centrifuge-v3/src/vaults/SyncDepositVault.sol";
+import {IAsyncVault} from "centrifuge-v3/src/vaults/interfaces/IAsyncVault.sol";
+import {IVaultRouter} from "centrifuge-v3/src/vaults/interfaces/IVaultRouter.sol";
+import {IAsyncRequestManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 
 import "test/spoke/BaseTest.sol";
 

--- a/test/spoke/unit/VaultRouter.t.sol
+++ b/test/spoke/unit/VaultRouter.t.sol
@@ -19,7 +19,7 @@ import {IAsyncVault} from "centrifuge-v3/src/vaults/interfaces/IAsyncVault.sol";
 import {IVaultRouter} from "centrifuge-v3/src/vaults/interfaces/IVaultRouter.sol";
 import {IAsyncRequestManager} from "centrifuge-v3/src/vaults/interfaces/IVaultManagers.sol";
 
-import "test/spoke/BaseTest.sol";
+import "centrifuge-v3/test/spoke/BaseTest.sol";
 
 interface Authlike {
     function rely(address) external;

--- a/test/spoke/unit/factories/TokenFactory.t.sol
+++ b/test/spoke/unit/factories/TokenFactory.t.sol
@@ -10,7 +10,7 @@ import {VaultKind} from "centrifuge-v3/src/spoke/interfaces/IVault.sol";
 import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
 import {TokenFactory} from "centrifuge-v3/src/spoke/factories/TokenFactory.sol";
 
-import {BaseTest} from "test/spoke/BaseTest.sol";
+import {BaseTest} from "centrifuge-v3/test/spoke/BaseTest.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/spoke/unit/factories/TokenFactory.t.sol
+++ b/test/spoke/unit/factories/TokenFactory.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {IAuth} from "centrifuge-v3/src/misc/interfaces/IAuth.sol";
 
-import {Root} from "src/common/Root.sol";
+import {Root} from "centrifuge-v3/src/common/Root.sol";
 
-import {ShareToken} from "src/spoke/ShareToken.sol";
-import {VaultKind} from "src/spoke/interfaces/IVault.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {TokenFactory} from "src/spoke/factories/TokenFactory.sol";
+import {ShareToken} from "centrifuge-v3/src/spoke/ShareToken.sol";
+import {VaultKind} from "centrifuge-v3/src/spoke/interfaces/IVault.sol";
+import {IShareToken} from "centrifuge-v3/src/spoke/interfaces/IShareToken.sol";
+import {TokenFactory} from "centrifuge-v3/src/spoke/factories/TokenFactory.sol";
 
 import {BaseTest} from "test/spoke/BaseTest.sol";
 

--- a/test/spoke/unit/libraries/UpdateContractMessageLib.t.sol
+++ b/test/spoke/unit/libraries/UpdateContractMessageLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import {UpdateContractMessageLib} from "centrifuge-v3/src/spoke/libraries/UpdateContractMessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/vaults/Deployment.t.sol
+++ b/test/vaults/Deployment.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {VaultsDeployer, VaultsActionBatcher} from "script/VaultsDeployer.s.sol";
+import {VaultsDeployer, VaultsActionBatcher} from "centrifuge-v3/script/VaultsDeployer.s.sol";
 
-import {CommonDeploymentInputTest} from "test/common/Deployment.t.sol";
+import {CommonDeploymentInputTest} from "centrifuge-v3/test/common/Deployment.t.sol";
 
 import "forge-std/Test.sol";
 


### PR DESCRIPTION
### The problem:

Right now, we can not be used as a dependency. To determine where a struct/enum is, solidity uses the path from the import, so different paths to the same file are actually different things.

A dependency can import i.e. `PoolId` as: `"centrifuge-v3/src/common/types/PoolId.sol"`, but later our own repo, internally also import `PoolId` as `"src/common/types/PoolId.sol"`. It means different paths, and consequently different types.

### Solution:
1. Use relative paths, like `"./types/PoolId.sol"`, nevertheless, this means, AFAICT, a manual refactor over 200 files. Unless we create or find a script to do that. Also, future refactors could be a pain if using relative paths. Uniswap uses this BTW

2. Use absolute paths prefixed with a name that our customer can use in the remapping. Our customer needs to do: `centrifuge-v3/=lib/protocol-v3/src`, that way, both paths are the same, not matter from where you import the file.

I've chosen 2, because it is the fastest way to do this, and both ways are supposed to be ok. (chatgtp recommends option 2 as more stable, BTW, but not sure how reliable it is). I'm not against 1, if we found a way to do it and maintain the repo structure