### PR TITLE
ref: relative paths with priority list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,19 @@ jobs:
       - name: Check import order
         run: python3 script/utils/fix_imports.py --check-relative
 
+  roundtrip-relative-absolute-imports:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Check import order
+        run: python3 script/utils/fix_imports.py --test-roundtrip
+
   unused-imports:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,19 @@ jobs:
       - name: Check import order
         run: python3 script/utils/fix_imports.py --check-order
 
+  relative-imports:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Check import order
+        run: python3 script/utils/fix_imports.py --check-relative
+
   unused-imports:
     runs-on: ubuntu-latest
     steps:
@@ -107,39 +120,39 @@ jobs:
   anvil-deploy:
     runs-on: ubuntu-latest
     permissions:
-      contents: 'read'
-      id-token: 'write'        
+      contents: "read"
+      id-token: "write"
     steps:
-    - uses: actions/checkout@v3
-    - id: 'auth'
-      uses: 'google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f' # v2.1.7
-      with:
-        workload_identity_provider: ${{ secrets.GCP_WIP }}
-        service_account: ${{ secrets.GCP_SA }}
-        create_credentials_file: true
-        cleanup_credentials: true
+      - uses: actions/checkout@v3
+      - id: "auth"
+        uses: "google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f" # v2.1.7
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIP }}
+          service_account: ${{ secrets.GCP_SA }}
+          create_credentials_file: true
+          cleanup_credentials: true
 
-    - name: 'Set up Cloud SDK'
-      uses: 'google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a' # v2.1.2
-      with:
-        version: '>= 363.0.0'
-    - name: Install Foundry
-      uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # 1.4.0
-      with:
-        version: v1.2.3          
-    #Make sure all tools are installed and with proper versions
-    - name: Setup deployer tools
-      env:
-        CI_MODE: true
-      run: |
-        script/deploy/setup.sh
-    - name: Install dependencies (forge)
-      run: |
-        forge install -j 0 --shallow --color auto
-    - name: Deploy Anvil
-      run: |
-        python3 script/deploy/deploy.py --network anvil 
-          
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a" # v2.1.2
+        with:
+          version: ">= 363.0.0"
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@82dee4ba654bd2146511f85f0d013af94670c4de # 1.4.0
+        with:
+          version: v1.2.3
+      #Make sure all tools are installed and with proper versions
+      - name: Setup deployer tools
+        env:
+          CI_MODE: true
+        run: |
+          script/deploy/setup.sh
+      - name: Install dependencies (forge)
+        run: |
+          forge install -j 0 --shallow --color auto
+      - name: Deploy Anvil
+        run: |
+          python3 script/deploy/deploy.py --network anvil
+
   coverage:
     runs-on: ubuntu-latest
     permissions:

--- a/script/AdaptersDeployer.s.sol
+++ b/script/AdaptersDeployer.s.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {AxelarAdapter} from "src/common/adapters/AxelarAdapter.sol";
-import {WormholeAdapter} from "src/common/adapters/WormholeAdapter.sol";
+import {CommonDeployer, CommonInput, CommonReport, CommonActionBatcher} from "./CommonDeployer.s.sol";
 
-import {CommonDeployer, CommonInput, CommonReport, CommonActionBatcher} from "script/CommonDeployer.s.sol";
+import {AxelarAdapter} from "../src/common/adapters/AxelarAdapter.sol";
+import {WormholeAdapter} from "../src/common/adapters/WormholeAdapter.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/CommonDeployer.s.sol
+++ b/script/CommonDeployer.s.sol
@@ -1,20 +1,21 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Root} from "src/common/Root.sol";
-import {Gateway} from "src/common/Gateway.sol";
-import {GasService} from "src/common/GasService.sol";
-import {Guardian, ISafe} from "src/common/Guardian.sol";
-import {TokenRecoverer} from "src/common/TokenRecoverer.sol";
-import {MessageProcessor} from "src/common/MessageProcessor.sol";
-import {MultiAdapter} from "src/common/adapters/MultiAdapter.sol";
-import {MessageDispatcher} from "src/common/MessageDispatcher.sol";
-import {PoolEscrowFactory} from "src/common/factories/PoolEscrowFactory.sol";
+import {Root} from "../src/common/Root.sol";
+import {Gateway} from "../src/common/Gateway.sol";
+import {GasService} from "../src/common/GasService.sol";
+import {Guardian, ISafe} from "../src/common/Guardian.sol";
+import {TokenRecoverer} from "../src/common/TokenRecoverer.sol";
+import {MessageProcessor} from "../src/common/MessageProcessor.sol";
+import {MultiAdapter} from "../src/common/adapters/MultiAdapter.sol";
+import {MessageDispatcher} from "../src/common/MessageDispatcher.sol";
+import {PoolEscrowFactory} from "../src/common/factories/PoolEscrowFactory.sol";
 
-import {JsonRegistry} from "script/utils/JsonRegistry.s.sol";
+import {CreateXScript} from "createx-forge/script/CreateXScript.sol";
 
 import "forge-std/Script.sol";
-import {CreateXScript} from "createx-forge/script/CreateXScript.sol";
+
+import {JsonRegistry} from "./utils/JsonRegistry.s.sol";
 
 struct CommonInput {
     uint16 centrifugeId;

--- a/script/CommonDeployer.s.sol
+++ b/script/CommonDeployer.s.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
+import {JsonRegistry} from "./utils/JsonRegistry.s.sol";
+
 import {Root} from "../src/common/Root.sol";
 import {Gateway} from "../src/common/Gateway.sol";
 import {GasService} from "../src/common/GasService.sol";
@@ -14,8 +16,6 @@ import {PoolEscrowFactory} from "../src/common/factories/PoolEscrowFactory.sol";
 import {CreateXScript} from "createx-forge/script/CreateXScript.sol";
 
 import "forge-std/Script.sol";
-
-import {JsonRegistry} from "./utils/JsonRegistry.s.sol";
 
 struct CommonInput {
     uint16 centrifugeId;

--- a/script/ExtendedSpokeDeployer.s.sol
+++ b/script/ExtendedSpokeDeployer.s.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CommonInput} from "script/CommonDeployer.s.sol";
-import {HooksDeployer, HooksActionBatcher} from "script/HooksDeployer.s.sol";
-import {VaultsDeployer, VaultsActionBatcher} from "script/VaultsDeployer.s.sol";
-import {ManagersDeployer, ManagersActionBatcher} from "script/ManagersDeployer.s.sol";
+import {CommonInput} from "./CommonDeployer.s.sol";
+import {HooksDeployer, HooksActionBatcher} from "./HooksDeployer.s.sol";
+import {VaultsDeployer, VaultsActionBatcher} from "./VaultsDeployer.s.sol";
+import {ManagersDeployer, ManagersActionBatcher} from "./ManagersDeployer.s.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/FullDeployer.s.sol
+++ b/script/FullDeployer.s.sol
@@ -4,7 +4,13 @@ pragma solidity 0.8.28;
 import {CommonInput} from "./CommonDeployer.s.sol";
 import {HubDeployer, HubActionBatcher} from "./HubDeployer.s.sol";
 import {ExtendedSpokeDeployer, ExtendedSpokeActionBatcher} from "./ExtendedSpokeDeployer.s.sol";
-import { WormholeInput, AxelarInput, AdaptersInput, AdaptersDeployer, AdaptersActionBatcher } from "./AdaptersDeployer.s.sol";
+import {
+    WormholeInput,
+    AxelarInput,
+    AdaptersInput,
+    AdaptersDeployer,
+    AdaptersActionBatcher
+} from "./AdaptersDeployer.s.sol";
 
 import {ISafe} from "../src/common/interfaces/IGuardian.sol";
 

--- a/script/FullDeployer.s.sol
+++ b/script/FullDeployer.s.sol
@@ -1,21 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ISafe} from "src/common/interfaces/IGuardian.sol";
+import {CommonInput} from "./CommonDeployer.s.sol";
+import {HubDeployer, HubActionBatcher} from "./HubDeployer.s.sol";
+import {ExtendedSpokeDeployer, ExtendedSpokeActionBatcher} from "./ExtendedSpokeDeployer.s.sol";
+import { WormholeInput, AxelarInput, AdaptersInput, AdaptersDeployer, AdaptersActionBatcher } from "./AdaptersDeployer.s.sol";
 
-import {CommonInput} from "script/CommonDeployer.s.sol";
-import {HubDeployer, HubActionBatcher} from "script/HubDeployer.s.sol";
-import {ExtendedSpokeDeployer, ExtendedSpokeActionBatcher} from "script/ExtendedSpokeDeployer.s.sol";
+import {ISafe} from "../src/common/interfaces/IGuardian.sol";
 
 import "forge-std/Script.sol";
-
-import {
-    WormholeInput,
-    AxelarInput,
-    AdaptersInput,
-    AdaptersDeployer,
-    AdaptersActionBatcher
-} from "script/AdaptersDeployer.s.sol";
 
 contract FullActionBatcher is HubActionBatcher, ExtendedSpokeActionBatcher, AdaptersActionBatcher {}
 

--- a/script/HooksDeployer.s.sol
+++ b/script/HooksDeployer.s.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Spoke} from "src/spoke/Spoke.sol";
+import {CommonInput} from "./CommonDeployer.s.sol";
+import {SpokeDeployer, SpokeReport, SpokeActionBatcher} from "./SpokeDeployer.s.sol";
 
-import {FreezeOnly} from "src/hooks/FreezeOnly.sol";
-import {FullRestrictions} from "src/hooks/FullRestrictions.sol";
-import {FreelyTransferable} from "src/hooks/FreelyTransferable.sol";
-import {RedemptionRestrictions} from "src/hooks/RedemptionRestrictions.sol";
+import {Spoke} from "../src/spoke/Spoke.sol";
 
-import {CommonInput} from "script/CommonDeployer.s.sol";
-import {SpokeDeployer, SpokeReport, SpokeActionBatcher} from "script/SpokeDeployer.s.sol";
+import {FreezeOnly} from "../src/hooks/FreezeOnly.sol";
+import {FullRestrictions} from "../src/hooks/FullRestrictions.sol";
+import {FreelyTransferable} from "../src/hooks/FreelyTransferable.sol";
+import {RedemptionRestrictions} from "../src/hooks/RedemptionRestrictions.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/HubDeployer.s.sol
+++ b/script/HubDeployer.s.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IdentityValuation} from "src/misc/IdentityValuation.sol";
+import {CommonDeployer, CommonInput, CommonReport, CommonActionBatcher} from "./CommonDeployer.s.sol";
 
-import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
+import {IdentityValuation} from "../src/misc/IdentityValuation.sol";
 
-import {Hub} from "src/hub/Hub.sol";
-import {Holdings} from "src/hub/Holdings.sol";
-import {Accounting} from "src/hub/Accounting.sol";
-import {HubHelpers} from "src/hub/HubHelpers.sol";
-import {HubRegistry} from "src/hub/HubRegistry.sol";
-import {ShareClassManager} from "src/hub/ShareClassManager.sol";
+import {AssetId, newAssetId} from "../src/common/types/AssetId.sol";
 
-import {CommonDeployer, CommonInput, CommonReport, CommonActionBatcher} from "script/CommonDeployer.s.sol";
+import {Hub} from "../src/hub/Hub.sol";
+import {Holdings} from "../src/hub/Holdings.sol";
+import {Accounting} from "../src/hub/Accounting.sol";
+import {HubHelpers} from "../src/hub/HubHelpers.sol";
+import {HubRegistry} from "../src/hub/HubRegistry.sol";
+import {ShareClassManager} from "../src/hub/ShareClassManager.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/ManagersDeployer.s.sol
+++ b/script/ManagersDeployer.s.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {VaultDecoder} from "src/managers/decoders/VaultDecoder.sol";
-import {CircleDecoder} from "src/managers/decoders/CircleDecoder.sol";
-import {OnOfframpManagerFactory} from "src/managers/OnOfframpManager.sol";
-import {MerkleProofManagerFactory} from "src/managers/MerkleProofManager.sol";
+import {CommonInput} from "./CommonDeployer.s.sol";
+import {SpokeDeployer, SpokeReport, SpokeActionBatcher} from "./SpokeDeployer.s.sol";
 
-import {CommonInput} from "script/CommonDeployer.s.sol";
-import {SpokeDeployer, SpokeReport, SpokeActionBatcher} from "script/SpokeDeployer.s.sol";
+import {VaultDecoder} from "../src/managers/decoders/VaultDecoder.sol";
+import {CircleDecoder} from "../src/managers/decoders/CircleDecoder.sol";
+import {OnOfframpManagerFactory} from "../src/managers/OnOfframpManager.sol";
+import {MerkleProofManagerFactory} from "../src/managers/MerkleProofManager.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/SpokeDeployer.s.sol
+++ b/script/SpokeDeployer.s.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Spoke} from "src/spoke/Spoke.sol";
-import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
-import {ContractUpdater} from "src/spoke/ContractUpdater.sol";
-import {TokenFactory} from "src/spoke/factories/TokenFactory.sol";
+import {CommonDeployer, CommonInput, CommonReport, CommonActionBatcher} from "./CommonDeployer.s.sol";
 
-import {CommonDeployer, CommonInput, CommonReport, CommonActionBatcher} from "script/CommonDeployer.s.sol";
+import {Spoke} from "../src/spoke/Spoke.sol";
+import {BalanceSheet} from "../src/spoke/BalanceSheet.sol";
+import {ContractUpdater} from "../src/spoke/ContractUpdater.sol";
+import {TokenFactory} from "../src/spoke/factories/TokenFactory.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/TestData.s.sol
+++ b/script/TestData.s.sol
@@ -1,38 +1,38 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ERC20} from "src/misc/ERC20.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {IdentityValuation} from "src/misc/IdentityValuation.sol";
+import {FullDeployer} from "./FullDeployer.s.sol";
 
-import {Guardian} from "src/common/Guardian.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
-import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {ERC20} from "../src/misc/ERC20.sol";
+import {D18, d18} from "../src/misc/types/D18.sol";
+import {CastLib} from "../src/misc/libraries/CastLib.sol";
+import {IdentityValuation} from "../src/misc/IdentityValuation.sol";
 
-import {Hub} from "src/hub/Hub.sol";
-import {HubRegistry} from "src/hub/HubRegistry.sol";
-import {ShareClassManager} from "src/hub/ShareClassManager.sol";
+import {Guardian} from "../src/common/Guardian.sol";
+import {PoolId} from "../src/common/types/PoolId.sol";
+import {AccountId} from "../src/common/types/AccountId.sol";
+import {ShareClassId} from "../src/common/types/ShareClassId.sol";
+import {AssetId, newAssetId} from "../src/common/types/AssetId.sol";
+import {VaultUpdateKind} from "../src/common/libraries/MessageLib.sol";
 
-import {Spoke} from "src/spoke/Spoke.sol";
-import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import {Hub} from "../src/hub/Hub.sol";
+import {HubRegistry} from "../src/hub/HubRegistry.sol";
+import {ShareClassManager} from "../src/hub/ShareClassManager.sol";
 
-import {SyncManager} from "src/vaults/SyncManager.sol";
-import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {AsyncRequestManager} from "src/vaults/AsyncRequestManager.sol";
-import {AsyncVaultFactory} from "src/vaults/factories/AsyncVaultFactory.sol";
-import {SyncDepositVaultFactory} from "src/vaults/factories/SyncDepositVaultFactory.sol";
+import {Spoke} from "../src/spoke/Spoke.sol";
+import {BalanceSheet} from "../src/spoke/BalanceSheet.sol";
+import {IShareToken} from "../src/spoke/interfaces/IShareToken.sol";
+import {UpdateContractMessageLib} from "../src/spoke/libraries/UpdateContractMessageLib.sol";
 
-import {RedemptionRestrictions} from "src/hooks/RedemptionRestrictions.sol";
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {SyncManager} from "../src/vaults/SyncManager.sol";
+import {SyncDepositVault} from "../src/vaults/SyncDepositVault.sol";
+import {IAsyncVault} from "../src/vaults/interfaces/IAsyncVault.sol";
+import {AsyncRequestManager} from "../src/vaults/AsyncRequestManager.sol";
+import {AsyncVaultFactory} from "../src/vaults/factories/AsyncVaultFactory.sol";
+import {SyncDepositVaultFactory} from "../src/vaults/factories/SyncDepositVaultFactory.sol";
 
-import {FullDeployer} from "script/FullDeployer.s.sol";
+import {RedemptionRestrictions} from "../src/hooks/RedemptionRestrictions.sol";
+import {UpdateRestrictionMessageLib} from "../src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/VaultsDeployer.s.sol
+++ b/script/VaultsDeployer.s.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Escrow} from "src/misc/Escrow.sol";
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
+import {CommonInput} from "./CommonDeployer.s.sol";
+import {SpokeDeployer, SpokeReport, SpokeActionBatcher} from "./SpokeDeployer.s.sol";
 
-import {Spoke} from "src/spoke/Spoke.sol";
+import {Escrow} from "../src/misc/Escrow.sol";
+import {IEscrow} from "../src/misc/interfaces/IEscrow.sol";
 
-import {SyncManager} from "src/vaults/SyncManager.sol";
-import {VaultRouter} from "src/vaults/VaultRouter.sol";
-import {AsyncRequestManager} from "src/vaults/AsyncRequestManager.sol";
-import {AsyncVaultFactory} from "src/vaults/factories/AsyncVaultFactory.sol";
-import {SyncDepositVaultFactory} from "src/vaults/factories/SyncDepositVaultFactory.sol";
+import {Spoke} from "../src/spoke/Spoke.sol";
 
-import {CommonInput} from "script/CommonDeployer.s.sol";
-import {SpokeDeployer, SpokeReport, SpokeActionBatcher} from "script/SpokeDeployer.s.sol";
+import {SyncManager} from "../src/vaults/SyncManager.sol";
+import {VaultRouter} from "../src/vaults/VaultRouter.sol";
+import {AsyncRequestManager} from "../src/vaults/AsyncRequestManager.sol";
+import {AsyncVaultFactory} from "../src/vaults/factories/AsyncVaultFactory.sol";
+import {SyncDepositVaultFactory} from "../src/vaults/factories/SyncDepositVaultFactory.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/WireAdapters.s.sol
+++ b/script/WireAdapters.s.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Guardian} from "src/common/Guardian.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IAxelarAdapter} from "src/common/interfaces/adapters/IAxelarAdapter.sol";
-import {IWormholeAdapter} from "src/common/interfaces/adapters/IWormholeAdapter.sol";
+import {Guardian} from "../src/common/Guardian.sol";
+import {IAdapter} from "../src/common/interfaces/IAdapter.sol";
+import {IAxelarAdapter} from "../src/common/interfaces/adapters/IAxelarAdapter.sol";
+import {IWormholeAdapter} from "../src/common/interfaces/adapters/IWormholeAdapter.sol";
 
 import "forge-std/Script.sol";
 

--- a/script/utils/README.md
+++ b/script/utils/README.md
@@ -1,0 +1,261 @@
+# Solidity Import Management Script
+
+A comprehensive Python script for managing Solidity imports with automatic relative path conversion, unused import detection, and intelligent import organization.
+
+## 🎯 Overview
+
+This script transforms your Solidity codebase to use clean, relative import paths making it dependency-ready while maintaining perfect organization and removing unused imports.
+
+### Key Features
+
+- ✅ **Absolute → Relative Path Conversion**: Converts `src/`, `script/`, `test/` imports to proper relative paths
+- ✅ **Same-Directory Import Detection**: `src/misc/interfaces/IERC165.sol` → `./IERC165.sol`
+- ✅ **Smart Cross-Directory Imports**: `src/hub/Hub.sol` importing `src/misc/Auth.sol` → `../misc/Auth.sol`
+- ✅ **Test-to-Source Imports**: Preserves `src/` prefix when needed (e.g., test files importing source)
+- ✅ **Priority-Based Organization**: Groups imports by logical categories with proper spacing
+- ✅ **Unused Import Detection**: Identifies and removes unused imports
+- ✅ **Multi-line Import Support**: Handles complex import statements across multiple lines
+- ✅ **Local Import Prefixing**: Adds `./` to local subdirectory imports
+- ✅ **Path Optimization**: Removes redundant `/src/` components in paths
+
+## 🚀 Quick Start
+
+### Basic Usage
+
+```bash
+# Default: Check for unused imports
+python3 script/utils/fix_imports.py
+
+# Organize imports AND convert to relative paths (recommended)
+python3 script/utils/fix_imports.py --organize
+
+# Check if imports are properly ordered (CI-friendly)
+python3 script/utils/fix_imports.py --check-order
+
+# Check if all imports use relative paths (CI-friendly) 
+python3 script/utils/fix_imports.py --check-relative
+```
+
+### Process Specific Files
+
+```bash
+# Fix imports in a specific file
+python3 script/utils/fix_imports.py --organize --file src/hub/Hub.sol
+
+# Check unused imports in a specific file
+python3 script/utils/fix_imports.py --check-unused --file src/misc/Auth.sol
+```
+
+## 📋 Command Reference
+
+| Command                    | Description                                      | Exit Code on Issues |
+| -------------------------- | ------------------------------------------------ | ------------------- |
+| `--check-unused`           | Check for unused imports (default)               | ❌                   |
+| `--fix-unused`             | Remove unused imports                            | ➖                   |
+| `--organize`               | **Organize imports + convert to relative paths** | ➖                   |
+| `--organize --no-relative` | Organize imports only (skip relative conversion) | ➖                   |
+| `--check-order`            | Check import organization (dry-run)              | ❌                   |
+| `--check-relative`         | Check for absolute imports                       | ❌                   |
+| `--fix-relative`           | Convert absolute to relative imports only        | ➖                   |
+| `--file <path>`            | Process specific file                            | ➖                   |
+
+**Legend**: ❌ = Exits with error code for CI, ➖ = Always exits successfully
+
+## 📄 Examples
+
+### Complete Workflow
+```bash
+# 1. Check current state
+python3 script/utils/fix_imports.py --check-relative
+python3 script/utils/fix_imports.py --check-order
+
+# 2. Fix everything
+python3 script/utils/fix_imports.py --organize
+
+# 3. Verify changes
+forge build
+python3 script/utils/fix_imports.py --check-relative
+
+# 4. Clean up unused imports
+python3 script/utils/fix_imports.py --fix-unused
+```
+
+### Specific File Processing
+```bash
+# Check specific file
+python3 script/utils/fix_imports.py --check-unused --file src/hub/Hub.sol
+
+# Fix specific file  
+python3 script/utils/fix_imports.py --organize --file src/hub/Hub.sol
+```
+
+## 🔄 Import Transformations
+
+### Absolute → Relative Path Conversion
+
+**Same Directory:**
+```solidity
+// Before
+import {IERC165} from "src/misc/interfaces/IERC165.sol";
+
+// After  
+import {IERC165} from "./IERC165.sol";
+```
+
+**Cross Directory:**
+```solidity
+// Before
+import {Auth} from "src/misc/Auth.sol";
+
+// After (from src/hub/Hub.sol)
+import {Auth} from "../misc/Auth.sol";
+```
+
+**Script Imports:**
+```solidity
+// Before
+import {CommonInput} from "script/CommonDeployer.s.sol";
+
+// After (from script/ManagersDeployer.s.sol)
+import {CommonInput} from "./CommonDeployer.s.sol";
+```
+
+**Test-to-Source Imports:**
+```solidity
+// Before  
+import {Hub} from "src/hub/Hub.sol";
+
+// After (from test/hub/unit/Hub.t.sol)
+import {Hub} from "../../../src/hub/Hub.sol";
+```
+
+### Local Import Prefixing
+
+```solidity
+// Before
+import {IHub} from "interfaces/IHub.sol";
+
+// After
+import {IHub} from "./interfaces/IHub.sol";
+```
+
+### Path Optimization
+
+```solidity
+// Before
+import {Auth} from "../../../src/misc/Auth.sol";
+
+// After (when both files are in src/)
+import {Auth} from "../../misc/Auth.sol";
+```
+
+## 📊 Import Priority System
+
+Imports are automatically organized into priority groups with empty lines between categories:
+
+```python
+IMPORT_PRIORITY = [
+    ".",        # Current directory (highest priority)
+    "misc",     # Utilities, base contracts
+    "common",   # Shared components  
+    "hub",      # Hub contracts
+    "spoke",    # Spoke contracts
+    "vaults",   # Vault contracts
+    "hooks",    # Hook contracts
+    "managers", # Manager contracts
+    "script",   # Deployment scripts
+    "test",     # Test files
+    "mocks",    # Mock contracts
+    "forge-std" # Forge standard library
+]
+```
+
+### Organized Output Example
+
+```solidity
+pragma solidity ^0.8.28;
+
+import {IHoldings} from "./interfaces/IHoldings.sol";
+import {IHub} from "./interfaces/IHub.sol";
+
+import {Auth} from "../misc/Auth.sol";
+import {D18} from "../misc/types/D18.sol";
+import {MathLib} from "../misc/libraries/MathLib.sol";
+
+import {PoolId} from "../common/types/PoolId.sol";
+import {IGateway} from "../common/interfaces/IGateway.sol";
+
+import "forge-std/Test.sol";
+```
+
+## 📝 How It Works
+
+### 1. Path Resolution
+- **Same Directory Detection**: Files in the same directory use `./filename.sol`
+- **Subdirectory Detection**: `./subdir/filename.sol` 
+- **Parent Directory**: `../filename.sol`
+- **Cross-Directory**: `../other/filename.sol`
+
+### 2. Smart Source Detection
+- **Test files** → **Source files**: Keeps `src/` prefix
+- **Source files** → **Source files**: Removes `src/` prefix for cleaner paths
+- **Script files** → **Source files**: Keeps `src/` prefix
+- **Same-base imports** (test→test, script→script): Uses clean relative paths
+
+### 3. File Existence Validation
+The script validates paths by checking file existence to avoid:
+- Creating invalid imports
+- Adding unnecessary `src/` prefixes
+- Breaking existing valid imports
+
+### 4. Multi-line Import Handling
+```solidity
+// Handles complex imports like:
+import {
+    VeryLongInterfaceName,
+    AnotherLongInterfaceName,
+    YetAnotherLongName
+} from "src/common/interfaces/IComplexInterface.sol";
+```
+
+## 🔧 Technical Details
+
+### File Processing
+- **Scanned Files**: All `*.sol` files excluding `lib/`, `out/`, `cache/`, `broadcast/`
+- **Regex Patterns**: Handles both single and multi-line imports
+- **Path Normalization**: Uses Python `pathlib` for cross-platform compatibility
+
+### Import Categories
+The script categorizes imports by analyzing the import path structure:
+- **Current directory** (`.`): Same directory or immediate subdirectories
+- **Project directories**: Based on first directory component in path
+- **Library imports**: `forge-std` and similar external libraries
+
+### Error Handling
+- **Graceful failures**: Invalid imports are left unchanged
+- **Validation**: Checks file existence before modifications
+- **Backup safety**: Only writes files when changes are needed
+
+## 🐛 Troubleshooting
+
+### Common Issues
+
+**Import not being converted:**
+- Check if file actually exists at the target path
+- Verify the import syntax is standard Solidity format
+- Check that file isn't in excluded directories (`lib/`, `out/`, etc.)
+
+**Wrong relative path generated:**
+- Ensure both source and target files are in expected locations
+- Check for symbolic links or unusual file system setups
+
+**Imports being incorrectly grouped:**
+- Path-based grouping may group similar paths from different base directories
+- This is aesthetic only and doesn't affect compilation
+
+### Debug Mode
+Add debug prints by modifying the script temporarily:
+```python
+print(f"Converting: {current_file} -> {import_path}")
+print(f"Result: {result}")
+```

--- a/script/utils/README.md
+++ b/script/utils/README.md
@@ -8,11 +8,16 @@ This script transforms your Solidity codebase to use clean, relative import path
 
 ### Key Features
 
+- ✅ **Bidirectional Path Conversion**: Convert between relative ↔ absolute imports seamlessly
+- ✅ **File Reorganization Workflow**: Safe file moving with automatic import path management
 - ✅ **Absolute → Relative Path Conversion**: Converts `src/`, `script/`, `test/` imports to proper relative paths
+- ✅ **Relative → Absolute Path Conversion**: Convert relative paths to absolute for file reorganization
 - ✅ **Same-Directory Import Detection**: `src/misc/interfaces/IERC165.sol` → `./IERC165.sol`
 - ✅ **Smart Cross-Directory Imports**: `src/hub/Hub.sol` importing `src/misc/Auth.sol` → `../misc/Auth.sol`
 - ✅ **Test-to-Source Imports**: Preserves `src/` prefix when needed (e.g., test files importing source)
 - ✅ **Priority-Based Organization**: Groups imports by logical categories with proper spacing
+- ✅ **Advanced Subgrouping**: Organizes imports by base directory (`../`, `src`, `test`, `script`)
+- ✅ **Roundtrip Idempotency**: Ensures relative ↔ absolute conversions are lossless
 - ✅ **Unused Import Detection**: Identifies and removes unused imports
 - ✅ **Multi-line Import Support**: Handles complex import statements across multiple lines
 - ✅ **Local Import Prefixing**: Adds `./` to local subdirectory imports
@@ -36,6 +41,39 @@ python3 script/utils/fix_imports.py --check-order
 python3 script/utils/fix_imports.py --check-relative
 ```
 
+## 🔄 **File Reorganization Workflow**
+
+When you need to move/reorganize files in your repository, use this **safe workflow** to avoid breaking import paths:
+
+### Step 1: Convert to Absolute Imports
+```bash
+python3 script/utils/fix_imports.py --fix-absolute
+```
+This converts all relative imports (`./`, `../`) to absolute paths (`src/`, `test/`, `script/`), making them immune to file moves.
+
+### Step 2: Move Your Files
+Move, rename, or reorganize your files as needed. The absolute imports won't break.
+
+### Step 3: Update Absolute Paths (if needed) 
+If you moved files to different base directories, update the absolute paths:
+```bash
+# Example: If you moved src/hub/Hub.sol to src/core/Hub.sol
+find . -name "*.sol" -exec sed -i 's|src/hub/Hub.sol|src/core/Hub.sol|g' {} \;
+```
+
+### Step 4: Convert Back to Relative Imports
+```bash
+python3 script/utils/fix_imports.py --fix-relative
+```
+This converts all absolute imports back to clean relative paths.
+
+### 🧪 **Idempotency Testing**
+```bash
+# Test that relative ↔ absolute ↔ relative conversion is lossless
+python3 script/utils/fix_imports.py --test-roundtrip
+```
+Perfect for CI to ensure conversion reliability!
+
 ### Process Specific Files
 
 ```bash
@@ -48,16 +86,19 @@ python3 script/utils/fix_imports.py --check-unused --file src/misc/Auth.sol
 
 ## 📋 Command Reference
 
-| Command                    | Description                                      | Exit Code on Issues |
-| -------------------------- | ------------------------------------------------ | ------------------- |
-| `--check-unused`           | Check for unused imports (default)               | ❌                   |
-| `--fix-unused`             | Remove unused imports                            | ➖                   |
-| `--organize`               | **Organize imports + convert to relative paths** | ➖                   |
-| `--organize --no-relative` | Organize imports only (skip relative conversion) | ➖                   |
-| `--check-order`            | Check import organization (dry-run)              | ❌                   |
-| `--check-relative`         | Check for absolute imports                       | ❌                   |
-| `--fix-relative`           | Convert absolute to relative imports only        | ➖                   |
-| `--file <path>`            | Process specific file                            | ➖                   |
+| Command                    | Description                                         | Exit Code on Issues |
+| -------------------------- | --------------------------------------------------- | ------------------- |
+| `--check-unused`           | Check for unused imports (default)                  | ❌                   |
+| `--fix-unused`             | Remove unused imports                               | ➖                   |
+| `--organize`               | **Organize imports + convert to relative paths**    | ➖                   |
+| `--organize --no-relative` | Organize imports only (skip relative conversion)    | ➖                   |
+| `--check-order`            | Check import organization (dry-run)                 | ❌                   |
+| `--check-relative`         | Check for absolute imports                          | ❌                   |
+| `--fix-relative`           | Convert absolute to relative imports only           | ➖                   |
+| `--check-absolute`         | Check for relative imports                          | ❌                   |
+| `--fix-absolute`           | **Convert relative to absolute imports**            | ➖                   |
+| `--test-roundtrip`         | **Test relative ↔ absolute conversion is lossless** | ❌                   |
+| `--file <path>`            | Process specific file                               | ➖                   |
 
 **Legend**: ❌ = Exits with error code for CI, ➖ = Always exits successfully
 
@@ -78,6 +119,24 @@ python3 script/utils/fix_imports.py --check-relative
 
 # 4. Clean up unused imports
 python3 script/utils/fix_imports.py --fix-unused
+```
+
+### File Reorganization Workflow
+```bash
+# 1. Convert to absolute paths for safe file moving
+python3 script/utils/fix_imports.py --fix-absolute
+
+# 2. Move/reorganize files as needed
+# ... move your files ...
+
+# 3. Update absolute paths if needed (example)
+find . -name "*.sol" -exec sed -i 's|src/old/path|src/new/path|g' {} \;
+
+# 4. Convert back to relative paths
+python3 script/utils/fix_imports.py --fix-relative
+
+# 5. Verify everything is back to original state
+python3 script/utils/fix_imports.py --test-roundtrip
 ```
 
 ### Specific File Processing

--- a/script/utils/README.md
+++ b/script/utils/README.md
@@ -151,7 +151,7 @@ import {Auth} from "../../misc/Auth.sol";
 
 ## 📊 Import Priority System
 
-Imports are automatically organized into priority groups with empty lines between categories:
+Imports are automatically organized into priority groups with **subgroup separation** for enhanced clarity:
 
 ```python
 IMPORT_PRIORITY = [
@@ -170,8 +170,20 @@ IMPORT_PRIORITY = [
 ]
 ```
 
+### 🎯 **Advanced Subgrouping**
+
+Within each priority category, imports are further organized by their **base directory**:
+
+1. **`../` imports** (direct relative paths)
+2. **`src/` imports** (via src directory)  
+3. **`test/` imports** (via test directory)
+4. **`script/` imports** (via script directory)
+
+**Each subgroup is separated by empty lines** for maximum clarity.
+
 ### Organized Output Example
 
+**Simple organization:**
 ```solidity
 pragma solidity ^0.8.28;
 
@@ -186,6 +198,26 @@ import {PoolId} from "../common/types/PoolId.sol";
 import {IGateway} from "../common/interfaces/IGateway.sol";
 
 import "forge-std/Test.sol";
+```
+
+**Advanced subgrouping example:**
+```solidity
+pragma solidity ^0.8.28;
+
+// Current directory imports
+import {LocalInterface} from "./interfaces/ILocal.sol";
+
+// Common category - '../' subgroup (direct relative)
+import {SharedUtil} from "../common/SharedUtil.sol";
+
+// Common category - 'src' subgroup (via src/)  
+import {CommonType} from "../../src/common/types/CommonType.sol";
+
+// Common category - 'test' subgroup (via test/)
+import {MockCommon} from "../test/common/mocks/MockCommon.sol";
+
+// Hub category - 'src' subgroup
+import {IHub} from "../../src/hub/interfaces/IHub.sol";
 ```
 
 ## 📝 How It Works

--- a/script/utils/fix_imports.py
+++ b/script/utils/fix_imports.py
@@ -263,12 +263,9 @@ def get_import_category(path: str) -> str:
             elif cleaned_path.startswith('./'):
                 cleaned_path = cleaned_path[2:]  # Remove './'
         
-        # If path originally started with ./ and the cleaned path is for current directory, return '.'
+        # If path originally started with ./ then it's a current directory import
         if path.startswith('./'):
-            path_parts = cleaned_path.split('/')
-            # Check if first part is a known current directory subdirectory or if it's just a file
-            if len(path_parts) == 1 or path_parts[0] in ['interfaces', 'types', 'libraries', 'factories', 'mocks']:
-                return '.'
+            return '.'
         
         # Split the cleaned path and find relevant directory
         path_parts = cleaned_path.split('/')
@@ -283,7 +280,7 @@ def get_import_category(path: str) -> str:
         path_parts = path.split('/')
         
         # Check if first part is a known subdirectory or if it's just a file
-        if len(path_parts) == 1 or path_parts[0] in ['interfaces', 'types', 'libraries', 'factories', 'mocks']:
+        if len(path_parts) == 1 or path_parts[0] in ['interfaces', 'types', 'libraries', 'factories', 'mocks', 'utils']:
             return '.'
         
         # Otherwise check for known directories
@@ -823,8 +820,8 @@ def convert_import_to_relative(import_stmt: str, current_file: str) -> str:
         first_part = path_parts[0]
         
         # Only add ./ if the first part looks like a local subdirectory
-        # Common local subdirectories: interfaces, types, libraries, factories, mocks
-        if first_part in ['interfaces', 'types', 'libraries', 'factories', 'mocks']:
+        # Common local subdirectories: interfaces, types, libraries, factories, mocks, utils
+        if first_part in ['interfaces', 'types', 'libraries', 'factories', 'mocks', 'utils']:
             prefixed_path = f"./{current_path}"
             new_import = import_stmt.replace(f'"{current_path}"', f'"{prefixed_path}"')
             return new_import

--- a/src/common/BaseValuation.sol
+++ b/src/common/BaseValuation.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
+import {AssetId} from "./types/AssetId.sol";
+import {IBaseValuation} from "./interfaces/IBaseValuation.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IBaseValuation} from "src/common/interfaces/IBaseValuation.sol";
+import {Auth} from "../misc/Auth.sol";
+import {IERC6909Decimals} from "../misc/interfaces/IERC6909.sol";
 
 abstract contract BaseValuation is Auth, IBaseValuation {
     /// @notice ERC6909 dependency.

--- a/src/common/GasService.sol
+++ b/src/common/GasService.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IGasService} from "src/common/interfaces/IGasService.sol";
-import {MessageLib, MessageType, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {IGasService} from "./interfaces/IGasService.sol";
+import {MessageLib, MessageType, VaultUpdateKind} from "./libraries/MessageLib.sol";
 
 /// @title  GasService
 /// @notice This contract stores the gas limits (in gas units) for cross-chain message execution.

--- a/src/common/Gateway.sol
+++ b/src/common/Gateway.sol
@@ -1,21 +1,21 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {TransientArrayLib} from "src/misc/libraries/TransientArrayLib.sol";
-import {TransientBytesLib} from "src/misc/libraries/TransientBytesLib.sol";
-import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
-import {Recoverable, IRecoverable, ETH_ADDRESS} from "src/misc/Recoverable.sol";
+import {PoolId} from "./types/PoolId.sol";
+import {IRoot} from "./interfaces/IRoot.sol";
+import {IAdapter} from "./interfaces/IAdapter.sol";
+import {IGateway} from "./interfaces/IGateway.sol";
+import {IGasService} from "./interfaces/IGasService.sol";
+import {IMessageSender} from "./interfaces/IMessageSender.sol";
+import {IMessageHandler} from "./interfaces/IMessageHandler.sol";
+import {IMessageProcessor} from "./interfaces/IMessageProcessor.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {IGasService} from "src/common/interfaces/IGasService.sol";
-import {IMessageSender} from "src/common/interfaces/IMessageSender.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {IMessageProcessor} from "src/common/interfaces/IMessageProcessor.sol";
+import {Auth} from "../misc/Auth.sol";
+import {BytesLib} from "../misc/libraries/BytesLib.sol";
+import {TransientArrayLib} from "../misc/libraries/TransientArrayLib.sol";
+import {TransientBytesLib} from "../misc/libraries/TransientBytesLib.sol";
+import {TransientStorageLib} from "../misc/libraries/TransientStorageLib.sol";
+import {Recoverable, IRecoverable, ETH_ADDRESS} from "../misc/Recoverable.sol";
 
 /// @title  Gateway
 /// @notice Routing contract that forwards outgoing messages to multiple adapters (1 full message, n-1 proofs)

--- a/src/common/Guardian.sol
+++ b/src/common/Guardian.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {PoolId} from "./types/PoolId.sol";
+import {AssetId} from "./types/AssetId.sol";
+import {IRoot} from "./interfaces/IRoot.sol";
+import {IAdapter} from "./interfaces/IAdapter.sol";
+import {IGuardian, ISafe} from "./interfaces/IGuardian.sol";
+import {IRootMessageSender} from "./interfaces/IGatewaySenders.sol";
+import {IHubGuardianActions} from "./interfaces/IGuardianActions.sol";
+import {IMultiAdapter} from "./interfaces/adapters/IMultiAdapter.sol";
+import {IAxelarAdapter} from "./interfaces/adapters/IAxelarAdapter.sol";
+import {IWormholeAdapter} from "./interfaces/adapters/IWormholeAdapter.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IGuardian, ISafe} from "src/common/interfaces/IGuardian.sol";
-import {IRootMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {IHubGuardianActions} from "src/common/interfaces/IGuardianActions.sol";
-import {IMultiAdapter} from "src/common/interfaces/adapters/IMultiAdapter.sol";
-import {IAxelarAdapter} from "src/common/interfaces/adapters/IAxelarAdapter.sol";
-import {IWormholeAdapter} from "src/common/interfaces/adapters/IWormholeAdapter.sol";
+import {CastLib} from "../misc/libraries/CastLib.sol";
 
 contract Guardian is IGuardian {
     using CastLib for address;

--- a/src/common/MessageDispatcher.sol
+++ b/src/common/MessageDispatcher.sol
@@ -10,7 +10,12 @@ import {ITokenRecoverer} from "./interfaces/ITokenRecoverer.sol";
 import {IMessageDispatcher} from "./interfaces/IMessageDispatcher.sol";
 import {MessageLib, VaultUpdateKind} from "./libraries/MessageLib.sol";
 import {ISpokeMessageSender, IHubMessageSender, IRootMessageSender} from "./interfaces/IGatewaySenders.sol";
-import { ISpokeGatewayHandler, IBalanceSheetGatewayHandler, IHubGatewayHandler, IUpdateContractGatewayHandler } from "./interfaces/IGatewayHandlers.sol";
+import {
+    ISpokeGatewayHandler,
+    IBalanceSheetGatewayHandler,
+    IHubGatewayHandler,
+    IUpdateContractGatewayHandler
+} from "./interfaces/IGatewayHandlers.sol";
 
 import {Auth} from "../misc/Auth.sol";
 import {D18} from "../misc/types/D18.sol";

--- a/src/common/MessageDispatcher.sol
+++ b/src/common/MessageDispatcher.sol
@@ -1,29 +1,23 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18} from "src/misc/types/D18.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
+import {PoolId} from "./types/PoolId.sol";
+import {AssetId} from "./types/AssetId.sol";
+import {IRoot} from "./interfaces/IRoot.sol";
+import {IGateway} from "./interfaces/IGateway.sol";
+import {ShareClassId} from "./types/ShareClassId.sol";
+import {ITokenRecoverer} from "./interfaces/ITokenRecoverer.sol";
+import {IMessageDispatcher} from "./interfaces/IMessageDispatcher.sol";
+import {MessageLib, VaultUpdateKind} from "./libraries/MessageLib.sol";
+import {ISpokeMessageSender, IHubMessageSender, IRootMessageSender} from "./interfaces/IGatewaySenders.sol";
+import { ISpokeGatewayHandler, IBalanceSheetGatewayHandler, IHubGatewayHandler, IUpdateContractGatewayHandler } from "./interfaces/IGatewayHandlers.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {ITokenRecoverer} from "src/common/interfaces/ITokenRecoverer.sol";
-import {IMessageDispatcher} from "src/common/interfaces/IMessageDispatcher.sol";
-import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
-import {ISpokeMessageSender, IHubMessageSender, IRootMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-
-import {
-    ISpokeGatewayHandler,
-    IBalanceSheetGatewayHandler,
-    IHubGatewayHandler,
-    IUpdateContractGatewayHandler
-} from "src/common/interfaces/IGatewayHandlers.sol";
+import {Auth} from "../misc/Auth.sol";
+import {D18} from "../misc/types/D18.sol";
+import {CastLib} from "../misc/libraries/CastLib.sol";
+import {MathLib} from "../misc/libraries/MathLib.sol";
+import {BytesLib} from "../misc/libraries/BytesLib.sol";
+import {IRecoverable} from "../misc/interfaces/IRecoverable.sol";
 
 contract MessageDispatcher is Auth, IMessageDispatcher {
     using CastLib for *;

--- a/src/common/MessageProcessor.sol
+++ b/src/common/MessageProcessor.sol
@@ -1,28 +1,22 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18} from "src/misc/types/D18.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
+import {PoolId} from "./types/PoolId.sol";
+import {AssetId} from "./types/AssetId.sol";
+import {IRoot} from "./interfaces/IRoot.sol";
+import {ShareClassId} from "./types/ShareClassId.sol";
+import {IMessageHandler} from "./interfaces/IMessageHandler.sol";
+import {ITokenRecoverer} from "./interfaces/ITokenRecoverer.sol";
+import {IMessageProcessor} from "./interfaces/IMessageProcessor.sol";
+import {IMessageProperties} from "./interfaces/IMessageProperties.sol";
+import {MessageType, MessageLib, VaultUpdateKind} from "./libraries/MessageLib.sol";
+import { ISpokeGatewayHandler, IBalanceSheetGatewayHandler, IHubGatewayHandler, IUpdateContractGatewayHandler } from "./interfaces/IGatewayHandlers.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {ITokenRecoverer} from "src/common/interfaces/ITokenRecoverer.sol";
-import {IMessageProcessor} from "src/common/interfaces/IMessageProcessor.sol";
-import {IMessageProperties} from "src/common/interfaces/IMessageProperties.sol";
-import {MessageType, MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
-
-import {
-    ISpokeGatewayHandler,
-    IBalanceSheetGatewayHandler,
-    IHubGatewayHandler,
-    IUpdateContractGatewayHandler
-} from "src/common/interfaces/IGatewayHandlers.sol";
+import {Auth} from "../misc/Auth.sol";
+import {D18} from "../misc/types/D18.sol";
+import {CastLib} from "../misc/libraries/CastLib.sol";
+import {BytesLib} from "../misc/libraries/BytesLib.sol";
+import {IRecoverable} from "../misc/interfaces/IRecoverable.sol";
 
 contract MessageProcessor is Auth, IMessageProcessor {
     using CastLib for *;

--- a/src/common/MessageProcessor.sol
+++ b/src/common/MessageProcessor.sol
@@ -10,7 +10,12 @@ import {ITokenRecoverer} from "./interfaces/ITokenRecoverer.sol";
 import {IMessageProcessor} from "./interfaces/IMessageProcessor.sol";
 import {IMessageProperties} from "./interfaces/IMessageProperties.sol";
 import {MessageType, MessageLib, VaultUpdateKind} from "./libraries/MessageLib.sol";
-import { ISpokeGatewayHandler, IBalanceSheetGatewayHandler, IHubGatewayHandler, IUpdateContractGatewayHandler } from "./interfaces/IGatewayHandlers.sol";
+import {
+    ISpokeGatewayHandler,
+    IBalanceSheetGatewayHandler,
+    IHubGatewayHandler,
+    IUpdateContractGatewayHandler
+} from "./interfaces/IGatewayHandlers.sol";
 
 import {Auth} from "../misc/Auth.sol";
 import {D18} from "../misc/types/D18.sol";

--- a/src/common/PoolEscrow.sol
+++ b/src/common/PoolEscrow.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Escrow} from "src/misc/Escrow.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
+import {PoolId} from "./types/PoolId.sol";
+import {ShareClassId} from "./types/ShareClassId.sol";
+import {Holding, IPoolEscrow} from "./interfaces/IPoolEscrow.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {Holding, IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
+import {Escrow} from "../misc/Escrow.sol";
+import {Recoverable} from "../misc/Recoverable.sol";
 
 /// @title  Escrow
 /// @notice Escrow contract that holds assets for a specific pool separated by share classes.

--- a/src/common/Root.sol
+++ b/src/common/Root.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {IRoot} from "./interfaces/IRoot.sol";
 
-import {IRoot} from "src/common/interfaces/IRoot.sol";
+import {Auth} from "../misc/Auth.sol";
+import {IAuth} from "../misc/interfaces/IAuth.sol";
 
 /// @title  Root
 /// @notice Core contract that is a ward on all other deployed contracts.

--- a/src/common/TokenRecoverer.sol
+++ b/src/common/TokenRecoverer.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
+import {IRoot} from "./interfaces/IRoot.sol";
+import {ITokenRecoverer} from "./interfaces/ITokenRecoverer.sol";
 
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ITokenRecoverer} from "src/common/interfaces/ITokenRecoverer.sol";
+import {Auth} from "../misc/Auth.sol";
+import {IRecoverable} from "../misc/interfaces/IRecoverable.sol";
 
 contract TokenRecoverer is Auth, ITokenRecoverer {
     IRoot public immutable root;

--- a/src/common/adapters/AxelarAdapter.sol
+++ b/src/common/adapters/AxelarAdapter.sol
@@ -1,20 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {Auth} from "../../misc/Auth.sol";
+import {CastLib} from "../../misc/libraries/CastLib.sol";
 
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-
-import {
-    IAxelarAdapter,
-    IAdapter,
-    IAxelarGateway,
-    IAxelarGasService,
-    AxelarSource,
-    AxelarDestination,
-    IAxelarExecutable
-} from "src/common/interfaces/adapters/IAxelarAdapter.sol";
+import {IMessageHandler} from "../interfaces/IMessageHandler.sol";
+import { IAxelarAdapter, IAdapter, IAxelarGateway, IAxelarGasService, AxelarSource, AxelarDestination, IAxelarExecutable } from "../interfaces/adapters/IAxelarAdapter.sol";
 
 /// @title  Axelar Adapter
 /// @notice Routing contract that integrates with an Axelar Gateway

--- a/src/common/adapters/AxelarAdapter.sol
+++ b/src/common/adapters/AxelarAdapter.sol
@@ -5,7 +5,15 @@ import {Auth} from "../../misc/Auth.sol";
 import {CastLib} from "../../misc/libraries/CastLib.sol";
 
 import {IMessageHandler} from "../interfaces/IMessageHandler.sol";
-import { IAxelarAdapter, IAdapter, IAxelarGateway, IAxelarGasService, AxelarSource, AxelarDestination, IAxelarExecutable } from "../interfaces/adapters/IAxelarAdapter.sol";
+import {
+    IAxelarAdapter,
+    IAdapter,
+    IAxelarGateway,
+    IAxelarGasService,
+    AxelarSource,
+    AxelarDestination,
+    IAxelarExecutable
+} from "../interfaces/adapters/IAxelarAdapter.sol";
 
 /// @title  Axelar Adapter
 /// @notice Routing contract that integrates with an Axelar Gateway

--- a/src/common/adapters/MultiAdapter.sol
+++ b/src/common/adapters/MultiAdapter.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {ArrayLib} from "src/misc/libraries/ArrayLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {Auth} from "../../misc/Auth.sol";
+import {CastLib} from "../../misc/libraries/CastLib.sol";
+import {MathLib} from "../../misc/libraries/MathLib.sol";
+import {ArrayLib} from "../../misc/libraries/ArrayLib.sol";
+import {BytesLib} from "../../misc/libraries/BytesLib.sol";
 
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {IMultiAdapter, MAX_ADAPTER_COUNT} from "src/common/interfaces/adapters/IMultiAdapter.sol";
+import {IAdapter} from "../interfaces/IAdapter.sol";
+import {MessageProofLib} from "../libraries/MessageProofLib.sol";
+import {IMessageHandler} from "../interfaces/IMessageHandler.sol";
+import {IMultiAdapter, MAX_ADAPTER_COUNT} from "../interfaces/adapters/IMultiAdapter.sol";
 
 contract MultiAdapter is Auth, IMultiAdapter {
     using CastLib for *;

--- a/src/common/adapters/WormholeAdapter.sol
+++ b/src/common/adapters/WormholeAdapter.sol
@@ -1,20 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {Auth} from "../../misc/Auth.sol";
+import {CastLib} from "../../misc/libraries/CastLib.sol";
 
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-
-import {
-    IWormholeAdapter,
-    IAdapter,
-    IWormholeRelayer,
-    IWormholeDeliveryProvider,
-    IWormholeReceiver,
-    WormholeSource,
-    WormholeDestination
-} from "src/common/interfaces/adapters/IWormholeAdapter.sol";
+import {IMessageHandler} from "../interfaces/IMessageHandler.sol";
+import { IWormholeAdapter, IAdapter, IWormholeRelayer, IWormholeDeliveryProvider, IWormholeReceiver, WormholeSource, WormholeDestination } from "../interfaces/adapters/IWormholeAdapter.sol";
 
 /// @title  Wormhole Adapter
 /// @notice Routing contract that integrates with the Wormhole Relayer service

--- a/src/common/adapters/WormholeAdapter.sol
+++ b/src/common/adapters/WormholeAdapter.sol
@@ -5,7 +5,15 @@ import {Auth} from "../../misc/Auth.sol";
 import {CastLib} from "../../misc/libraries/CastLib.sol";
 
 import {IMessageHandler} from "../interfaces/IMessageHandler.sol";
-import { IWormholeAdapter, IAdapter, IWormholeRelayer, IWormholeDeliveryProvider, IWormholeReceiver, WormholeSource, WormholeDestination } from "../interfaces/adapters/IWormholeAdapter.sol";
+import {
+    IWormholeAdapter,
+    IAdapter,
+    IWormholeRelayer,
+    IWormholeDeliveryProvider,
+    IWormholeReceiver,
+    WormholeSource,
+    WormholeDestination
+} from "../interfaces/adapters/IWormholeAdapter.sol";
 
 /// @title  Wormhole Adapter
 /// @notice Routing contract that integrates with the Wormhole Relayer service

--- a/src/common/factories/PoolEscrowFactory.sol
+++ b/src/common/factories/PoolEscrowFactory.sol
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
+import {IPoolEscrowProvider, IPoolEscrowFactory} from "./interfaces/IPoolEscrowFactory.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {PoolEscrow} from "src/common/PoolEscrow.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {IPoolEscrowProvider, IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {Auth} from "../../misc/Auth.sol";
+
+import {PoolId} from "../types/PoolId.sol";
+import {PoolEscrow} from "../PoolEscrow.sol";
+import {IPoolEscrow} from "../interfaces/IPoolEscrow.sol";
 
 contract PoolEscrowFactory is Auth, IPoolEscrowFactory {
     address public immutable root;

--- a/src/common/factories/interfaces/IPoolEscrowFactory.sol
+++ b/src/common/factories/interfaces/IPoolEscrowFactory.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
+import {PoolId} from "../../types/PoolId.sol";
+import {IPoolEscrow} from "../../interfaces/IPoolEscrow.sol";
 
 interface IPoolEscrowProvider {
     /// @notice Returns the deterministic address of an escrow contract based on a given pool id wrapped into the

--- a/src/common/interfaces/IAdapter.sol
+++ b/src/common/interfaces/IAdapter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {IAuth} from "../../misc/interfaces/IAuth.sol";
 
 interface IAdapter is IAuth {
     error NotEntrypoint();

--- a/src/common/interfaces/IBaseValuation.sol
+++ b/src/common/interfaces/IBaseValuation.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {IValuation} from "./IValuation.sol";
 
 /// Provides a base implementation for all ERC7726 valuation in the system
 interface IBaseValuation is IValuation {

--- a/src/common/interfaces/IGateway.sol
+++ b/src/common/interfaces/IGateway.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
+import {IMessageSender} from "./IMessageSender.sol";
+import {IMessageHandler} from "./IMessageHandler.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {IMessageSender} from "src/common/interfaces/IMessageSender.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+import {IRecoverable} from "../../misc/interfaces/IRecoverable.sol";
+
+import {PoolId} from "../types/PoolId.sol";
 
 /// @notice Interface for dispatch-only gateway
 interface IGateway is IMessageHandler, IMessageSender, IRecoverable {

--- a/src/common/interfaces/IGatewayHandlers.sol
+++ b/src/common/interfaces/IGatewayHandlers.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {D18} from "src/misc/types/D18.sol";
+import {D18} from "../../misc/types/D18.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {PoolId} from "../types/PoolId.sol";
+import {AssetId} from "../types/AssetId.sol";
+import {ShareClassId} from "../types/ShareClassId.sol";
+import {VaultUpdateKind} from "../libraries/MessageLib.sol";
 
 /// -----------------------------------------------------
 ///  Hub Handlers

--- a/src/common/interfaces/IGatewaySenders.sol
+++ b/src/common/interfaces/IGatewaySenders.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {D18} from "src/misc/types/D18.sol";
+import {D18} from "../../misc/types/D18.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {PoolId} from "../types/PoolId.sol";
+import {AssetId} from "../types/AssetId.sol";
+import {ShareClassId} from "../types/ShareClassId.sol";
+import {VaultUpdateKind} from "../libraries/MessageLib.sol";
 
 interface ILocalCentrifugeId {
     function localCentrifugeId() external view returns (uint16);

--- a/src/common/interfaces/IGuardian.sol
+++ b/src/common/interfaces/IGuardian.sol
@@ -2,11 +2,11 @@
 pragma solidity >=0.5.0;
 
 import {IAdapter} from "./IAdapter.sol";
+import {IAxelarAdapter} from "./adapters/IAxelarAdapter.sol";
+import {IWormholeAdapter} from "./adapters/IWormholeAdapter.sol";
 
 import {PoolId} from "../types/PoolId.sol";
 import {AssetId} from "../types/AssetId.sol";
-import {IAxelarAdapter} from "./adapters/IAxelarAdapter.sol";
-import {IWormholeAdapter} from "./adapters/IWormholeAdapter.sol";
 
 interface ISafe {
     function isOwner(address signer) external view returns (bool);

--- a/src/common/interfaces/IGuardian.sol
+++ b/src/common/interfaces/IGuardian.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IAxelarAdapter} from "src/common/interfaces/adapters/IAxelarAdapter.sol";
-import {IWormholeAdapter} from "src/common/interfaces/adapters/IWormholeAdapter.sol";
+import {IAdapter} from "./IAdapter.sol";
+
+import {PoolId} from "../types/PoolId.sol";
+import {AssetId} from "../types/AssetId.sol";
+import {IAxelarAdapter} from "./adapters/IAxelarAdapter.sol";
+import {IWormholeAdapter} from "./adapters/IWormholeAdapter.sol";
 
 interface ISafe {
     function isOwner(address signer) external view returns (bool);

--- a/src/common/interfaces/IGuardianActions.sol
+++ b/src/common/interfaces/IGuardianActions.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
+import {PoolId} from "../types/PoolId.sol";
+import {AssetId} from "../types/AssetId.sol";
 
 interface IHubGuardianActions {
     /// @notice Creates a new pool.

--- a/src/common/interfaces/IMessageDispatcher.sol
+++ b/src/common/interfaces/IMessageDispatcher.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {ISpokeMessageSender, IHubMessageSender, IRootMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
+import {ISpokeMessageSender, IHubMessageSender, IRootMessageSender} from "./IGatewaySenders.sol";
 
 interface IMessageDispatcher is IRootMessageSender, ISpokeMessageSender, IHubMessageSender {
     /// @notice Emitted when a call to `file()` was performed.

--- a/src/common/interfaces/IMessageProcessor.sol
+++ b/src/common/interfaces/IMessageProcessor.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {IMessageProperties} from "src/common/interfaces/IMessageProperties.sol";
+import {IMessageHandler} from "./IMessageHandler.sol";
+import {IMessageProperties} from "./IMessageProperties.sol";
 
 interface IMessageProcessor is IMessageHandler, IMessageProperties {
     error InvalidSourceChain();

--- a/src/common/interfaces/IMessageProperties.sol
+++ b/src/common/interfaces/IMessageProperties.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {PoolId} from "src/common/types/PoolId.sol";
+import {PoolId} from "../types/PoolId.sol";
 
 /// @notice Defines methods to get properties from raw messages
 interface IMessageProperties {

--- a/src/common/interfaces/IPoolEscrow.sol
+++ b/src/common/interfaces/IPoolEscrow.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IRecoverable} from "src/misc/Recoverable.sol";
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
+import {IRecoverable} from "../../misc/Recoverable.sol";
+import {IEscrow} from "../../misc/interfaces/IEscrow.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "../types/PoolId.sol";
+import {ShareClassId} from "../types/ShareClassId.sol";
 
 struct Holding {
     uint128 total;

--- a/src/common/interfaces/ISnapshotHook.sol
+++ b/src/common/interfaces/ISnapshotHook.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "../types/PoolId.sol";
+import {ShareClassId} from "../types/ShareClassId.sol";
 
 /// @notice Hook interface that is called whenever the accounting system of the Hub, for a given share token on
 ///         1 network, as in a (poolId, scId, centrifugeId) tuple, is in a synchronous state. This means the assets

--- a/src/common/interfaces/ITokenRecoverer.sol
+++ b/src/common/interfaces/ITokenRecoverer.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
+import {IRecoverable} from "../../misc/interfaces/IRecoverable.sol";
 
 interface ITokenRecoverer {
     event RecoverTokens(

--- a/src/common/interfaces/ITransferHook.sol
+++ b/src/common/interfaces/ITransferHook.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {IERC165} from "src/misc/interfaces/IERC7575.sol";
+import {IERC165} from "../../misc/interfaces/IERC7575.sol";
 
 struct HookData {
     bytes16 from;

--- a/src/common/interfaces/IValuation.sol
+++ b/src/common/interfaces/IValuation.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {AssetId} from "src/common/types/AssetId.sol";
+import {AssetId} from "../types/AssetId.sol";
 
 /// Based on [ERC-7726](https://eips.ethereum.org/EIPS/eip-7726): Common Quote Oracle, but adapted for ERC6909.
 /// Interface for asset conversions.

--- a/src/common/interfaces/adapters/IAxelarAdapter.sol
+++ b/src/common/interfaces/adapters/IAxelarAdapter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {IAdapter} from "../IAdapter.sol";
 
 // From https://github.com/axelarnetwork/axelar-cgp-solidity/blob/main/contracts/interfaces/IAxelarGateway.sol
 interface IAxelarGateway {

--- a/src/common/interfaces/adapters/IMultiAdapter.sol
+++ b/src/common/interfaces/adapters/IMultiAdapter.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+import {IAdapter} from "../IAdapter.sol";
+import {IMessageHandler} from "../IMessageHandler.sol";
 
 uint8 constant MAX_ADAPTER_COUNT = 8;
 

--- a/src/common/interfaces/adapters/IWormholeAdapter.sol
+++ b/src/common/interfaces/adapters/IWormholeAdapter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
+import {IAdapter} from "../IAdapter.sol";
 
 // From https://github.com/wormhole-foundation/wormhole-solidity-sdk/blob/main/src/interfaces/IWormholeRelayer.sol#L75
 interface IWormholeRelayer {

--- a/src/common/libraries/MessageLib.sol
+++ b/src/common/libraries/MessageLib.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "../../misc/libraries/CastLib.sol";
+import {BytesLib} from "../../misc/libraries/BytesLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
+import {PoolId} from "../types/PoolId.sol";
+import {AssetId} from "../types/AssetId.sol";
 
 // NOTE: Should never exceed 254 messages because id == 255 corresponds to message proofs
 enum MessageType {

--- a/src/common/libraries/MessageProofLib.sol
+++ b/src/common/libraries/MessageProofLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {BytesLib} from "../../misc/libraries/BytesLib.sol";
 
 library MessageProofLib {
     using BytesLib for bytes;

--- a/src/common/libraries/PricingLib.sol
+++ b/src/common/libraries/PricingLib.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
-import {IERC6909MetadataExt} from "src/misc/interfaces/IERC6909.sol";
+import {D18, d18} from "../../misc/types/D18.sol";
+import {MathLib} from "../../misc/libraries/MathLib.sol";
+import {IERC20Metadata} from "../../misc/interfaces/IERC20.sol";
+import {IERC6909MetadataExt} from "../../misc/interfaces/IERC6909.sol";
 
 library PricingLib {
     using MathLib for *;

--- a/src/common/libraries/RequestCallbackMessageLib.sol
+++ b/src/common/libraries/RequestCallbackMessageLib.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "../../misc/libraries/CastLib.sol";
+import {BytesLib} from "../../misc/libraries/BytesLib.sol";
 
 enum RequestCallbackType {
     /// @dev Placeholder for null request callback type

--- a/src/common/libraries/RequestMessageLib.sol
+++ b/src/common/libraries/RequestMessageLib.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "../../misc/libraries/CastLib.sol";
+import {BytesLib} from "../../misc/libraries/BytesLib.sol";
 
 enum RequestType {
     /// @dev Placeholder for null request type

--- a/src/common/types/PoolId.sol
+++ b/src/common/types/PoolId.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {MathLib} from "../../misc/libraries/MathLib.sol";
 
 using MathLib for uint256;
 

--- a/src/common/types/ShareClassId.sol
+++ b/src/common/types/ShareClassId.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
+import {PoolId} from "./PoolId.sol";
 
 type ShareClassId is bytes16;
 

--- a/src/hooks/FreelyTransferable.sol
+++ b/src/hooks/FreelyTransferable.sol
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {IERC165} from "src/misc/interfaces/IERC7575.sol";
-import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
+import {IFreezable} from "./interfaces/IFreezable.sol";
+import {IMemberlist} from "./interfaces/IMemberlist.sol";
+import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "./libraries/UpdateRestrictionMessageLib.sol";
 
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ITransferHook, HookData, ESCROW_HOOK_ID} from "src/common/interfaces/ITransferHook.sol";
+import {Auth} from "../misc/Auth.sol";
+import {CastLib} from "../misc/libraries/CastLib.sol";
+import {BytesLib} from "../misc/libraries/BytesLib.sol";
+import {IERC165} from "../misc/interfaces/IERC7575.sol";
+import {BitmapLib} from "../misc/libraries/BitmapLib.sol";
 
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {IRoot} from "../common/interfaces/IRoot.sol";
+import {ITransferHook, HookData, ESCROW_HOOK_ID} from "../common/interfaces/ITransferHook.sol";
 
-import {IFreezable} from "src/hooks/interfaces/IFreezable.sol";
-import {IMemberlist} from "src/hooks/interfaces/IMemberlist.sol";
-import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {IShareToken} from "../spoke/interfaces/IShareToken.sol";
 
 /// @title  Freely Transferable
 /// @notice Hook implementation that:

--- a/src/hooks/FreezeOnly.sol
+++ b/src/hooks/FreezeOnly.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {IERC165} from "src/misc/interfaces/IERC7575.sol";
-import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
+import {IFreezable} from "./interfaces/IFreezable.sol";
+import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "./libraries/UpdateRestrictionMessageLib.sol";
 
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ITransferHook, HookData} from "src/common/interfaces/ITransferHook.sol";
+import {Auth} from "../misc/Auth.sol";
+import {CastLib} from "../misc/libraries/CastLib.sol";
+import {BytesLib} from "../misc/libraries/BytesLib.sol";
+import {IERC165} from "../misc/interfaces/IERC7575.sol";
+import {BitmapLib} from "../misc/libraries/BitmapLib.sol";
 
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {IRoot} from "../common/interfaces/IRoot.sol";
+import {ITransferHook, HookData} from "../common/interfaces/ITransferHook.sol";
 
-import {IFreezable} from "src/hooks/interfaces/IFreezable.sol";
-import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {IShareToken} from "../spoke/interfaces/IShareToken.sol";
 
 /// @title  Freeze Only
 /// @notice Hook implementation that:

--- a/src/hooks/FullRestrictions.sol
+++ b/src/hooks/FullRestrictions.sol
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {IERC165} from "src/misc/interfaces/IERC7575.sol";
-import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
+import {IFreezable} from "./interfaces/IFreezable.sol";
+import {IMemberlist} from "./interfaces/IMemberlist.sol";
+import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "./libraries/UpdateRestrictionMessageLib.sol";
 
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ITransferHook, HookData, ESCROW_HOOK_ID} from "src/common/interfaces/ITransferHook.sol";
+import {Auth} from "../misc/Auth.sol";
+import {CastLib} from "../misc/libraries/CastLib.sol";
+import {BytesLib} from "../misc/libraries/BytesLib.sol";
+import {IERC165} from "../misc/interfaces/IERC7575.sol";
+import {BitmapLib} from "../misc/libraries/BitmapLib.sol";
 
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {IRoot} from "../common/interfaces/IRoot.sol";
+import {ITransferHook, HookData, ESCROW_HOOK_ID} from "../common/interfaces/ITransferHook.sol";
 
-import {IFreezable} from "src/hooks/interfaces/IFreezable.sol";
-import {IMemberlist} from "src/hooks/interfaces/IMemberlist.sol";
-import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {IShareToken} from "../spoke/interfaces/IShareToken.sol";
 
 /// @title  Full Restrictions
 /// @notice Hook implementation that:

--- a/src/hooks/RedemptionRestrictions.sol
+++ b/src/hooks/RedemptionRestrictions.sol
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {IERC165} from "src/misc/interfaces/IERC7575.sol";
-import {BitmapLib} from "src/misc/libraries/BitmapLib.sol";
+import {IFreezable} from "./interfaces/IFreezable.sol";
+import {IMemberlist} from "./interfaces/IMemberlist.sol";
+import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "./libraries/UpdateRestrictionMessageLib.sol";
 
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ITransferHook, HookData, ESCROW_HOOK_ID} from "src/common/interfaces/ITransferHook.sol";
+import {Auth} from "../misc/Auth.sol";
+import {CastLib} from "../misc/libraries/CastLib.sol";
+import {BytesLib} from "../misc/libraries/BytesLib.sol";
+import {IERC165} from "../misc/interfaces/IERC7575.sol";
+import {BitmapLib} from "../misc/libraries/BitmapLib.sol";
 
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {IRoot} from "../common/interfaces/IRoot.sol";
+import {ITransferHook, HookData, ESCROW_HOOK_ID} from "../common/interfaces/ITransferHook.sol";
 
-import {IFreezable} from "src/hooks/interfaces/IFreezable.sol";
-import {IMemberlist} from "src/hooks/interfaces/IMemberlist.sol";
-import {UpdateRestrictionType, UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {IShareToken} from "../spoke/interfaces/IShareToken.sol";
 
 /// @title  Redemption Restrictions
 /// @notice Hook implementation that:

--- a/src/hooks/libraries/UpdateRestrictionMessageLib.sol
+++ b/src/hooks/libraries/UpdateRestrictionMessageLib.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "../../misc/libraries/CastLib.sol";
+import {BytesLib} from "../../misc/libraries/BytesLib.sol";
 
 enum UpdateRestrictionType {
     /// @dev Placeholder for null update restriction type

--- a/src/hub/Accounting.sol
+++ b/src/hub/Accounting.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
+import {IAccounting, JournalEntry} from "./interfaces/IAccounting.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
+import {Auth} from "../misc/Auth.sol";
+import {TransientStorageLib} from "../misc/libraries/TransientStorageLib.sol";
 
-import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
+import {PoolId} from "../common/types/PoolId.sol";
+import {AccountId} from "../common/types/AccountId.sol";
 
 /// @notice In a transaction there can be multiple journal entries for different pools,
 /// which can be interleaved. We want entries for the same pool to share the same journal ID.

--- a/src/hub/Holdings.sol
+++ b/src/hub/Holdings.sol
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18} from "src/misc/types/D18.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {IHubRegistry} from "./interfaces/IHubRegistry.sol";
+import {IHoldings, Holding, HoldingAccount, Snapshot} from "./interfaces/IHoldings.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
+import {Auth} from "../misc/Auth.sol";
+import {D18} from "../misc/types/D18.sol";
+import {MathLib} from "../misc/libraries/MathLib.sol";
 
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IHoldings, Holding, HoldingAccount, Snapshot} from "src/hub/interfaces/IHoldings.sol";
+import {PoolId} from "../common/types/PoolId.sol";
+import {AssetId} from "../common/types/AssetId.sol";
+import {AccountId} from "../common/types/AccountId.sol";
+import {PricingLib} from "../common/libraries/PricingLib.sol";
+import {ShareClassId} from "../common/types/ShareClassId.sol";
+import {IValuation} from "../common/interfaces/IValuation.sol";
+import {ISnapshotHook} from "../common/interfaces/ISnapshotHook.sol";
 
 /// @title  Holdings
 /// @notice Bookkeeping of the holdings and its associated accounting IDs for each pool.

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -1,31 +1,31 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18} from "src/misc/types/D18.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {Multicall, IMulticall} from "src/misc/Multicall.sol";
+import {IHoldings} from "./interfaces/IHoldings.sol";
+import {IHubHelpers} from "./interfaces/IHubHelpers.sol";
+import {IHubRegistry} from "./interfaces/IHubRegistry.sol";
+import {IHub, VaultUpdateKind} from "./interfaces/IHub.sol";
+import {IAccounting, JournalEntry} from "./interfaces/IAccounting.sol";
+import {IShareClassManager} from "./interfaces/IShareClassManager.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
-import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {IHubGatewayHandler} from "src/common/interfaces/IGatewayHandlers.sol";
-import {IHubGuardianActions} from "src/common/interfaces/IGuardianActions.sol";
-import {RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
-import {IPoolEscrow, IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {Auth} from "../misc/Auth.sol";
+import {D18} from "../misc/types/D18.sol";
+import {Recoverable} from "../misc/Recoverable.sol";
+import {MathLib} from "../misc/libraries/MathLib.sol";
+import {Multicall, IMulticall} from "../misc/Multicall.sol";
 
-import {IHoldings} from "src/hub/interfaces/IHoldings.sol";
-import {IHubHelpers} from "src/hub/interfaces/IHubHelpers.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IHub, VaultUpdateKind} from "src/hub/interfaces/IHub.sol";
-import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+import {PoolId} from "../common/types/PoolId.sol";
+import {AssetId} from "../common/types/AssetId.sol";
+import {AccountId} from "../common/types/AccountId.sol";
+import {IGateway} from "../common/interfaces/IGateway.sol";
+import {ShareClassId} from "../common/types/ShareClassId.sol";
+import {IValuation} from "../common/interfaces/IValuation.sol";
+import {ISnapshotHook} from "../common/interfaces/ISnapshotHook.sol";
+import {IHubMessageSender} from "../common/interfaces/IGatewaySenders.sol";
+import {IHubGatewayHandler} from "../common/interfaces/IGatewayHandlers.sol";
+import {IHubGuardianActions} from "../common/interfaces/IGuardianActions.sol";
+import {RequestCallbackMessageLib} from "../common/libraries/RequestCallbackMessageLib.sol";
+import {IPoolEscrow, IPoolEscrowFactory} from "../common/factories/interfaces/IPoolEscrowFactory.sol";
 
 /// @title  Hub
 /// @notice Central pool management contract, that brings together all functions in one place.

--- a/src/hub/HubHelpers.sol
+++ b/src/hub/HubHelpers.sol
@@ -1,25 +1,25 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {IHub, AccountType} from "./interfaces/IHub.sol";
+import {IAccounting} from "./interfaces/IAccounting.sol";
+import {IHubHelpers} from "./interfaces/IHubHelpers.sol";
+import {IHubRegistry} from "./interfaces/IHubRegistry.sol";
+import {IHoldings, HoldingAccount} from "./interfaces/IHoldings.sol";
+import {IShareClassManager} from "./interfaces/IShareClassManager.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {RequestMessageLib, RequestType} from "src/common/libraries/RequestMessageLib.sol";
-import {RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
+import {Auth} from "../misc/Auth.sol";
+import {D18, d18} from "../misc/types/D18.sol";
+import {MathLib} from "../misc/libraries/MathLib.sol";
 
-import {IHub, AccountType} from "src/hub/interfaces/IHub.sol";
-import {IAccounting} from "src/hub/interfaces/IAccounting.sol";
-import {IHubHelpers} from "src/hub/interfaces/IHubHelpers.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IHoldings, HoldingAccount} from "src/hub/interfaces/IHoldings.sol";
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+import {PoolId} from "../common/types/PoolId.sol";
+import {AssetId} from "../common/types/AssetId.sol";
+import {AccountId} from "../common/types/AccountId.sol";
+import {ShareClassId} from "../common/types/ShareClassId.sol";
+import {IValuation} from "../common/interfaces/IValuation.sol";
+import {IHubMessageSender} from "../common/interfaces/IGatewaySenders.sol";
+import {RequestMessageLib, RequestType} from "../common/libraries/RequestMessageLib.sol";
+import {RequestCallbackMessageLib} from "../common/libraries/RequestCallbackMessageLib.sol";
 
 contract HubHelpers is Auth, IHubHelpers {
     using MathLib for uint256;

--- a/src/hub/HubRegistry.sol
+++ b/src/hub/HubRegistry.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
+import {IHubRegistry} from "./interfaces/IHubRegistry.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {PoolId, newPoolId} from "src/common/types/PoolId.sol";
+import {Auth} from "../misc/Auth.sol";
+import {MathLib} from "../misc/libraries/MathLib.sol";
+import {IERC6909Decimals} from "../misc/interfaces/IERC6909.sol";
 
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
+import {AssetId} from "../common/types/AssetId.sol";
+import {PoolId, newPoolId} from "../common/types/PoolId.sol";
 
 /// @title  Hub Registry
 /// @notice Registry of all known pools, currencies, and assets.

--- a/src/hub/ShareClassManager.sol
+++ b/src/hub/ShareClassManager.sol
@@ -1,30 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {IHubRegistry} from "./interfaces/IHubRegistry.sol";
+import { IShareClassManager, EpochInvestAmounts, EpochRedeemAmounts, UserOrder, ShareClassMetadata, ShareClassMetrics, QueuedOrder, RequestType, EpochId } from "./interfaces/IShareClassManager.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {ShareClassId, newShareClassId} from "src/common/types/ShareClassId.sol";
+import {Auth} from "../misc/Auth.sol";
+import {D18, d18} from "../misc/types/D18.sol";
+import {CastLib} from "../misc/libraries/CastLib.sol";
+import {MathLib} from "../misc/libraries/MathLib.sol";
+import {BytesLib} from "../misc/libraries/BytesLib.sol";
 
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-
-import {
-    IShareClassManager,
-    EpochInvestAmounts,
-    EpochRedeemAmounts,
-    UserOrder,
-    ShareClassMetadata,
-    ShareClassMetrics,
-    QueuedOrder,
-    RequestType,
-    EpochId
-} from "src/hub/interfaces/IShareClassManager.sol";
+import {PoolId} from "../common/types/PoolId.sol";
+import {AssetId} from "../common/types/AssetId.sol";
+import {PricingLib} from "../common/libraries/PricingLib.sol";
+import {ShareClassId, newShareClassId} from "../common/types/ShareClassId.sol";
 
 /// @title  Share Class Manager
 /// @notice Manager for the share classes of a pool, and the core logic for tracking, approving, and fulfilling

--- a/src/hub/ShareClassManager.sol
+++ b/src/hub/ShareClassManager.sol
@@ -2,7 +2,17 @@
 pragma solidity 0.8.28;
 
 import {IHubRegistry} from "./interfaces/IHubRegistry.sol";
-import { IShareClassManager, EpochInvestAmounts, EpochRedeemAmounts, UserOrder, ShareClassMetadata, ShareClassMetrics, QueuedOrder, RequestType, EpochId } from "./interfaces/IShareClassManager.sol";
+import {
+    IShareClassManager,
+    EpochInvestAmounts,
+    EpochRedeemAmounts,
+    UserOrder,
+    ShareClassMetadata,
+    ShareClassMetrics,
+    QueuedOrder,
+    RequestType,
+    EpochId
+} from "./interfaces/IShareClassManager.sol";
 
 import {Auth} from "../misc/Auth.sol";
 import {D18, d18} from "../misc/types/D18.sol";

--- a/src/hub/interfaces/IAccounting.sol
+++ b/src/hub/interfaces/IAccounting.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
+import {AccountId} from "../../common/types/AccountId.sol";
 
 struct JournalEntry {
     uint128 value;

--- a/src/hub/interfaces/IHoldings.sol
+++ b/src/hub/interfaces/IHoldings.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {D18} from "src/misc/types/D18.sol";
+import {D18} from "../../misc/types/D18.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
+import {AssetId} from "../../common/types/AssetId.sol";
+import {AccountId} from "../../common/types/AccountId.sol";
+import {ShareClassId} from "../../common/types/ShareClassId.sol";
+import {IValuation} from "../../common/interfaces/IValuation.sol";
+import {ISnapshotHook} from "../../common/interfaces/ISnapshotHook.sol";
 
 struct Holding {
     uint128 assetAmount;

--- a/src/hub/interfaces/IHub.sol
+++ b/src/hub/interfaces/IHub.sol
@@ -1,22 +1,22 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {D18} from "src/misc/types/D18.sol";
+import {IHoldings} from "./IHoldings.sol";
+import {IHubRegistry} from "./IHubRegistry.sol";
+import {IAccounting, JournalEntry} from "./IAccounting.sol";
+import {IShareClassManager} from "./IShareClassManager.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
-import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
-import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
+import {D18} from "../../misc/types/D18.sol";
 
-import {IHoldings} from "src/hub/interfaces/IHoldings.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
+import {AssetId} from "../../common/types/AssetId.sol";
+import {AccountId} from "../../common/types/AccountId.sol";
+import {IGateway} from "../../common/interfaces/IGateway.sol";
+import {ShareClassId} from "../../common/types/ShareClassId.sol";
+import {IValuation} from "../../common/interfaces/IValuation.sol";
+import {VaultUpdateKind} from "../../common/libraries/MessageLib.sol";
+import {ISnapshotHook} from "../../common/interfaces/ISnapshotHook.sol";
+import {IHubMessageSender} from "../../common/interfaces/IGatewaySenders.sol";
 
 /// @notice Account types used by Hub
 enum AccountType {

--- a/src/hub/interfaces/IHubHelpers.sol
+++ b/src/hub/interfaces/IHubHelpers.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {D18} from "src/misc/types/D18.sol";
+import {HoldingAccount} from "./IHoldings.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {D18} from "../../misc/types/D18.sol";
 
-import {HoldingAccount} from "src/hub/interfaces/IHoldings.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
+import {AssetId} from "../../common/types/AssetId.sol";
+import {AccountId} from "../../common/types/AccountId.sol";
+import {ShareClassId} from "../../common/types/ShareClassId.sol";
 
 interface IHubHelpers {
     /// @notice Emitted when a call to `file()` was performed.

--- a/src/hub/interfaces/IHubRegistry.sol
+++ b/src/hub/interfaces/IHubRegistry.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
+import {IERC6909Decimals} from "../../misc/interfaces/IERC6909.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
+import {AssetId} from "../../common/types/AssetId.sol";
 
 interface IHubRegistry is IERC6909Decimals {
     event NewAsset(AssetId indexed assetId, uint8 decimals);

--- a/src/hub/interfaces/IShareClassManager.sol
+++ b/src/hub/interfaces/IShareClassManager.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {D18} from "src/misc/types/D18.sol";
+import {D18} from "../../misc/types/D18.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
+import {AssetId} from "../../common/types/AssetId.sol";
+import {ShareClassId} from "../../common/types/ShareClassId.sol";
 
 struct EpochRedeemAmounts {
     /// @dev Amount of shares pending to be redeemed at time of epoch

--- a/src/managers/MerkleProofManager.sol
+++ b/src/managers/MerkleProofManager.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MerkleProofLib} from "src/misc/libraries/MerkleProofLib.sol";
+import {IMerkleProofManagerFactory} from "./interfaces/IMerkleProofManagerFactory.sol";
+import {IMerkleProofManager, Call, PolicyLeaf} from "./interfaces/IMerkleProofManager.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {CastLib} from "../misc/libraries/CastLib.sol";
+import {MerkleProofLib} from "../misc/libraries/MerkleProofLib.sol";
 
-import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
-import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
-import {UpdateContractMessageLib, UpdateContractType} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import {PoolId} from "../common/types/PoolId.sol";
+import {ShareClassId} from "../common/types/ShareClassId.sol";
 
-import {IMerkleProofManagerFactory} from "src/managers/interfaces/IMerkleProofManagerFactory.sol";
-import {IMerkleProofManager, Call, PolicyLeaf} from "src/managers/interfaces/IMerkleProofManager.sol";
+import {IBalanceSheet} from "../spoke/interfaces/IBalanceSheet.sol";
+import {IUpdateContract} from "../spoke/interfaces/IUpdateContract.sol";
+import {UpdateContractMessageLib, UpdateContractType} from "../spoke/libraries/UpdateContractMessageLib.sol";
 
 /// @title  Merkle Proof Manager
 /// @author Inspired by Boring Vaults from Se7en-Seas

--- a/src/managers/OnOfframpManager.sol
+++ b/src/managers/OnOfframpManager.sol
@@ -1,21 +1,21 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {IERC165} from "src/misc/interfaces/IERC165.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
+import {IOnOfframpManager} from "./interfaces/IOnOfframpManager.sol";
+import {IOnOfframpManagerFactory} from "./interfaces/IOnOfframpManagerFactory.sol";
+import {IDepositManager, IWithdrawManager} from "./interfaces/IBalanceSheetManager.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {CastLib} from "../misc/libraries/CastLib.sol";
+import {IERC165} from "../misc/interfaces/IERC165.sol";
+import {SafeTransferLib} from "../misc/libraries/SafeTransferLib.sol";
 
-import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
-import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
-import {UpdateContractType, UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import {PoolId} from "../common/types/PoolId.sol";
+import {AssetId} from "../common/types/AssetId.sol";
+import {ShareClassId} from "../common/types/ShareClassId.sol";
 
-import {IOnOfframpManager} from "src/managers/interfaces/IOnOfframpManager.sol";
-import {IOnOfframpManagerFactory} from "src/managers/interfaces/IOnOfframpManagerFactory.sol";
-import {IDepositManager, IWithdrawManager} from "src/managers/interfaces/IBalanceSheetManager.sol";
+import {IBalanceSheet} from "../spoke/interfaces/IBalanceSheet.sol";
+import {IUpdateContract} from "../spoke/interfaces/IUpdateContract.sol";
+import {UpdateContractType, UpdateContractMessageLib} from "../spoke/libraries/UpdateContractMessageLib.sol";
 
 /// @title  OnOfframpManager
 /// @notice Balance sheet manager for depositing and withdrawing ERC20 assets.

--- a/src/managers/decoders/BaseDecoder.sol
+++ b/src/managers/decoders/BaseDecoder.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
+import {ShareClassId} from "../../common/types/ShareClassId.sol";
 
 contract BaseDecoder {
     error FunctionNotImplemented(bytes _calldata);

--- a/src/managers/decoders/CircleDecoder.sol
+++ b/src/managers/decoders/CircleDecoder.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {BaseDecoder} from "src/managers/decoders/BaseDecoder.sol";
+import {BaseDecoder} from "./BaseDecoder.sol";
 
 contract CircleDecoder is BaseDecoder {
     /// @notice Deposit assets into Circle to burn, in order to bridge to another chain

--- a/src/managers/decoders/VaultDecoder.sol
+++ b/src/managers/decoders/VaultDecoder.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {BaseDecoder} from "src/managers/decoders/BaseDecoder.sol";
+import {BaseDecoder} from "./BaseDecoder.sol";
 
 contract VaultDecoder is BaseDecoder {
     /// @notice Deposit into the ERC4626 vault

--- a/src/managers/interfaces/IBalanceSheetManager.sol
+++ b/src/managers/interfaces/IBalanceSheetManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IERC165} from "src/misc/interfaces/IERC165.sol";
+import {IERC165} from "../../misc/interfaces/IERC165.sol";
 
 interface IDepositManager is IERC165 {
     function deposit(address asset, uint256 tokenId, uint128 amount, address owner) external;

--- a/src/managers/interfaces/IMerkleProofManagerFactory.sol
+++ b/src/managers/interfaces/IMerkleProofManagerFactory.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
+import {IMerkleProofManager} from "./IMerkleProofManager.sol";
 
-import {IMerkleProofManager} from "src/managers/interfaces/IMerkleProofManager.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
 
 interface IMerkleProofManagerFactory {
     event DeployMerkleProofManager(PoolId indexed poolId, address indexed manager);

--- a/src/managers/interfaces/IOnOfframpManager.sol
+++ b/src/managers/interfaces/IOnOfframpManager.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IDepositManager, IWithdrawManager} from "./IBalanceSheetManager.sol";
 
-import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
+import {ShareClassId} from "../../common/types/ShareClassId.sol";
 
-import {IDepositManager, IWithdrawManager} from "src/managers/interfaces/IBalanceSheetManager.sol";
+import {IUpdateContract} from "../../spoke/interfaces/IUpdateContract.sol";
 
 interface IOnOfframpManager is IDepositManager, IWithdrawManager, IUpdateContract {
     event UpdateOnramp(address indexed asset, bool isEnabled);

--- a/src/managers/interfaces/IOnOfframpManagerFactory.sol
+++ b/src/managers/interfaces/IOnOfframpManagerFactory.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IOnOfframpManager} from "./IOnOfframpManager.sol";
 
-import {IOnOfframpManager} from "src/managers/interfaces/IOnOfframpManager.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
+import {ShareClassId} from "../../common/types/ShareClassId.sol";
 
 interface IOnOfframpManagerFactory {
     event DeployOnOfframpManager(PoolId indexed poolId, ShareClassId scId, address indexed manager);

--- a/src/misc/Auth.sol
+++ b/src/misc/Auth.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {IAuth} from "./interfaces/IAuth.sol";
 
 /// @title  Auth
 /// @notice Simple authentication pattern

--- a/src/misc/ERC20.sol
+++ b/src/misc/ERC20.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {EIP712Lib} from "src/misc/libraries/EIP712Lib.sol";
-import {SignatureLib} from "src/misc/libraries/SignatureLib.sol";
-import {IERC20, IERC20Metadata, IERC20Permit} from "src/misc/interfaces/IERC20.sol";
+import {Auth} from "./Auth.sol";
+import {EIP712Lib} from "./libraries/EIP712Lib.sol";
+import {SignatureLib} from "./libraries/SignatureLib.sol";
+import {IERC20, IERC20Metadata, IERC20Permit} from "./interfaces/IERC20.sol";
 
 /// @title  ERC20
 /// @notice Standard ERC-20 implementation, with mint/burn functionality and permit logic.

--- a/src/misc/Escrow.sol
+++ b/src/misc/Escrow.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
-import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
+import {Auth} from "./Auth.sol";
+import {IERC20} from "./interfaces/IERC20.sol";
+import {IEscrow} from "./interfaces/IEscrow.sol";
+import {IERC6909} from "./interfaces/IERC6909.sol";
+import {SafeTransferLib} from "./libraries/SafeTransferLib.sol";
 
 contract Escrow is Auth, IEscrow {
     constructor(address deployer) Auth(deployer) {}

--- a/src/misc/IdentityValuation.sol
+++ b/src/misc/IdentityValuation.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {d18} from "src/misc/types/D18.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
-import {IIdentityValuation} from "src/misc/interfaces/IIdentityValuation.sol";
+import {d18} from "./types/D18.sol";
+import {MathLib} from "./libraries/MathLib.sol";
+import {IERC6909Decimals} from "./interfaces/IERC6909.sol";
+import {IIdentityValuation} from "./interfaces/IIdentityValuation.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {BaseValuation} from "src/common/BaseValuation.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {AssetId} from "../common/types/AssetId.sol";
+import {BaseValuation} from "../common/BaseValuation.sol";
+import {PricingLib} from "../common/libraries/PricingLib.sol";
+import {IValuation} from "../common/interfaces/IValuation.sol";
 
 contract IdentityValuation is BaseValuation, IIdentityValuation {
     using MathLib for *;

--- a/src/misc/Multicall.sol
+++ b/src/misc/Multicall.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.28;
 // NOTE: This file has warning disabled due https://github.com/ethereum/solidity/issues/14359
 // If perform any change on it, please ensure no other warnings appears
 
-import {IMulticall} from "src/misc/interfaces/IMulticall.sol";
-import {ReentrancyProtection} from "src/misc/ReentrancyProtection.sol";
+import {IMulticall} from "./interfaces/IMulticall.sol";
+import {ReentrancyProtection} from "./ReentrancyProtection.sol";
 
 abstract contract Multicall is ReentrancyProtection, IMulticall {
     function multicall(bytes[] calldata data) public payable virtual protected {

--- a/src/misc/Recoverable.sol
+++ b/src/misc/Recoverable.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
-import {IRecoverable, ETH_ADDRESS} from "src/misc/interfaces/IRecoverable.sol";
+import {Auth} from "./Auth.sol";
+import {IERC6909} from "./interfaces/IERC6909.sol";
+import {SafeTransferLib} from "./libraries/SafeTransferLib.sol";
+import {IRecoverable, ETH_ADDRESS} from "./interfaces/IRecoverable.sol";
 
 abstract contract Recoverable is Auth, IRecoverable {
     /// @inheritdoc IRecoverable

--- a/src/misc/interfaces/IERC7575.sol
+++ b/src/misc/interfaces/IERC7575.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IERC165} from "src/misc/interfaces/IERC165.sol";
+import {IERC165} from "./IERC165.sol";
 
 interface IERC7575 is IERC165 {
     event Deposit(address indexed sender, address indexed owner, uint256 assets, uint256 shares);

--- a/src/misc/interfaces/IIdentityValuation.sol
+++ b/src/misc/interfaces/IIdentityValuation.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {IValuation} from "../../common/interfaces/IValuation.sol";
 
 /// @notice An IERC7726 valuation that always values 1:1.
 interface IIdentityValuation is IValuation {}

--- a/src/misc/libraries/SafeTransferLib.sol
+++ b/src/misc/libraries/SafeTransferLib.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
-import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
+import {IERC20} from "../interfaces/IERC20.sol";
+import {IERC7751} from "../interfaces/IERC7751.sol";
 
 /// @title  Safe Transfer Lib
 /// @author Modified from Uniswap v3 Periphery (libraries/TransferHelper.sol)

--- a/src/misc/libraries/TransientArrayLib.sol
+++ b/src/misc/libraries/TransientArrayLib.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
+import {TransientStorageLib} from "./TransientStorageLib.sol";
 
 /// @title  TransientArrayLib
 library TransientArrayLib {

--- a/src/misc/libraries/TransientBytesLib.sol
+++ b/src/misc/libraries/TransientBytesLib.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
+import {BytesLib} from "./BytesLib.sol";
+import {TransientStorageLib} from "./TransientStorageLib.sol";
 
 /// @title  TransientBytesLib
 library TransientBytesLib {

--- a/src/misc/types/D18.sol
+++ b/src/misc/types/D18.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.28;
 
 // Small library to handle fixed point number operations with 18 decimals with static typing support.
 
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {MathLib} from "../libraries/MathLib.sol";
 
 type D18 is uint128;
 

--- a/src/spoke/BalanceSheet.sol
+++ b/src/spoke/BalanceSheet.sol
@@ -1,30 +1,30 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
-import {Multicall, IMulticall} from "src/misc/Multicall.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
-import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
+import {ISpoke} from "./interfaces/ISpoke.sol";
+import {IShareToken} from "./interfaces/IShareToken.sol";
+import {IBalanceSheet, ShareQueueAmount, AssetQueueAmount} from "./interfaces/IBalanceSheet.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {IBalanceSheetGatewayHandler} from "src/common/interfaces/IGatewayHandlers.sol";
-import {IPoolEscrowProvider} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {Auth} from "../misc/Auth.sol";
+import {D18, d18} from "../misc/types/D18.sol";
+import {IAuth} from "../misc/interfaces/IAuth.sol";
+import {Recoverable} from "../misc/Recoverable.sol";
+import {CastLib} from "../misc/libraries/CastLib.sol";
+import {MathLib} from "../misc/libraries/MathLib.sol";
+import {IERC6909} from "../misc/interfaces/IERC6909.sol";
+import {Multicall, IMulticall} from "../misc/Multicall.sol";
+import {SafeTransferLib} from "../misc/libraries/SafeTransferLib.sol";
+import {TransientStorageLib} from "../misc/libraries/TransientStorageLib.sol";
 
-import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IBalanceSheet, ShareQueueAmount, AssetQueueAmount} from "src/spoke/interfaces/IBalanceSheet.sol";
+import {PoolId} from "../common/types/PoolId.sol";
+import {AssetId} from "../common/types/AssetId.sol";
+import {IRoot} from "../common/interfaces/IRoot.sol";
+import {IGateway} from "../common/interfaces/IGateway.sol";
+import {ShareClassId} from "../common/types/ShareClassId.sol";
+import {IPoolEscrow} from "../common/interfaces/IPoolEscrow.sol";
+import {ISpokeMessageSender} from "../common/interfaces/IGatewaySenders.sol";
+import {IBalanceSheetGatewayHandler} from "../common/interfaces/IGatewayHandlers.sol";
+import {IPoolEscrowProvider} from "../common/factories/interfaces/IPoolEscrowFactory.sol";
 
 /// @title  Balance Sheet
 /// @notice Management contract that integrates all balance sheet functions of a pool:

--- a/src/spoke/ContractUpdater.sol
+++ b/src/spoke/ContractUpdater.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
+import {IUpdateContract} from "./interfaces/IUpdateContract.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IUpdateContractGatewayHandler} from "src/common/interfaces/IGatewayHandlers.sol";
+import {Auth} from "../misc/Auth.sol";
 
-import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
+import {PoolId} from "../common/types/PoolId.sol";
+import {ShareClassId} from "../common/types/ShareClassId.sol";
+import {IUpdateContractGatewayHandler} from "../common/interfaces/IGatewayHandlers.sol";
 
 contract ContractUpdater is Auth, IUpdateContractGatewayHandler {
     event UpdateContract(PoolId indexed poolId, ShareClassId indexed scId, address target, bytes payload);

--- a/src/spoke/ShareToken.sol
+++ b/src/spoke/ShareToken.sol
@@ -1,21 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ERC20} from "src/misc/ERC20.sol";
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC7575Share, IERC165} from "src/misc/interfaces/IERC7575.sol";
+import {IShareToken, IERC1404} from "./interfaces/IShareToken.sol";
 
-import {IShareToken, IERC1404} from "src/spoke/interfaces/IShareToken.sol";
+import {ERC20} from "../misc/ERC20.sol";
+import {IERC20} from "../misc/interfaces/IERC20.sol";
+import {MathLib} from "../misc/libraries/MathLib.sol";
+import {IERC7575Share, IERC165} from "../misc/interfaces/IERC7575.sol";
 
-import {
-    ITransferHook,
-    HookData,
-    SUCCESS_CODE_ID,
-    SUCCESS_MESSAGE,
-    ERROR_CODE_ID,
-    ERROR_MESSAGE
-} from "src/common/interfaces/ITransferHook.sol";
+import { ITransferHook, HookData, SUCCESS_CODE_ID, SUCCESS_MESSAGE, ERROR_CODE_ID, ERROR_MESSAGE } from "../common/interfaces/ITransferHook.sol";
 
 /// @title  Share Token
 /// @notice Extension of ERC20 + ERC1404,

--- a/src/spoke/ShareToken.sol
+++ b/src/spoke/ShareToken.sol
@@ -8,7 +8,14 @@ import {IERC20} from "../misc/interfaces/IERC20.sol";
 import {MathLib} from "../misc/libraries/MathLib.sol";
 import {IERC7575Share, IERC165} from "../misc/interfaces/IERC7575.sol";
 
-import { ITransferHook, HookData, SUCCESS_CODE_ID, SUCCESS_MESSAGE, ERROR_CODE_ID, ERROR_MESSAGE } from "../common/interfaces/ITransferHook.sol";
+import {
+    ITransferHook,
+    HookData,
+    SUCCESS_CODE_ID,
+    SUCCESS_MESSAGE,
+    ERROR_CODE_ID,
+    ERROR_MESSAGE
+} from "../common/interfaces/ITransferHook.sol";
 
 /// @title  Share Token
 /// @notice Extension of ERC20 + ERC1404,

--- a/src/spoke/Spoke.sol
+++ b/src/spoke/Spoke.sol
@@ -1,36 +1,36 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18} from "src/misc/types/D18.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {IERC165} from "src/misc/interfaces/IERC7575.sol";
-import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
-import {IERC6909MetadataExt} from "src/misc/interfaces/IERC6909.sol";
-import {ReentrancyProtection} from "src/misc/ReentrancyProtection.sol";
+import {Price} from "./types/Price.sol";
+import {IVault} from "./interfaces/IVault.sol";
+import {IShareToken} from "./interfaces/IShareToken.sol";
+import {IVaultManager} from "./interfaces/IVaultManager.sol";
+import {IRequestManager} from "./interfaces/IRequestManager.sol";
+import {ITokenFactory} from "./factories/interfaces/ITokenFactory.sol";
+import {IVaultFactory} from "./factories/interfaces/IVaultFactory.sol";
+import {AssetIdKey, Pool, ShareClassDetails, VaultDetails, ISpoke} from "./interfaces/ISpoke.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {newAssetId, AssetId} from "src/common/types/AssetId.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
-import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {ISpokeGatewayHandler} from "src/common/interfaces/IGatewayHandlers.sol";
-import {VaultUpdateKind, MessageLib} from "src/common/libraries/MessageLib.sol";
-import {IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {Auth} from "../misc/Auth.sol";
+import {D18} from "../misc/types/D18.sol";
+import {Recoverable} from "../misc/Recoverable.sol";
+import {CastLib} from "../misc/libraries/CastLib.sol";
+import {MathLib} from "../misc/libraries/MathLib.sol";
+import {BytesLib} from "../misc/libraries/BytesLib.sol";
+import {IERC165} from "../misc/interfaces/IERC7575.sol";
+import {IERC20Metadata} from "../misc/interfaces/IERC20.sol";
+import {IERC6909MetadataExt} from "../misc/interfaces/IERC6909.sol";
+import {ReentrancyProtection} from "../misc/ReentrancyProtection.sol";
 
-import {Price} from "src/spoke/types/Price.sol";
-import {IVault} from "src/spoke/interfaces/IVault.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
-import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
-import {ITokenFactory} from "src/spoke/factories/interfaces/ITokenFactory.sol";
-import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
-import {AssetIdKey, Pool, ShareClassDetails, VaultDetails, ISpoke} from "src/spoke/interfaces/ISpoke.sol";
+import {PoolId} from "../common/types/PoolId.sol";
+import {IGateway} from "../common/interfaces/IGateway.sol";
+import {ShareClassId} from "../common/types/ShareClassId.sol";
+import {newAssetId, AssetId} from "../common/types/AssetId.sol";
+import {IPoolEscrow} from "../common/interfaces/IPoolEscrow.sol";
+import {ITransferHook} from "../common/interfaces/ITransferHook.sol";
+import {ISpokeMessageSender} from "../common/interfaces/IGatewaySenders.sol";
+import {ISpokeGatewayHandler} from "../common/interfaces/IGatewayHandlers.sol";
+import {VaultUpdateKind, MessageLib} from "../common/libraries/MessageLib.sol";
+import {IPoolEscrowFactory} from "../common/factories/interfaces/IPoolEscrowFactory.sol";
 
 /// @title  Spoke
 /// @notice This contract manages which pools & share classes exist, controlling allowed pool currencies,

--- a/src/spoke/factories/TokenFactory.sol
+++ b/src/spoke/factories/TokenFactory.sol
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
+import {ITokenFactory} from "./interfaces/ITokenFactory.sol";
 
-import {ShareToken} from "src/spoke/ShareToken.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {ITokenFactory} from "src/spoke/factories/interfaces/ITokenFactory.sol";
+import {Auth} from "../../misc/Auth.sol";
+
+import {ShareToken} from "../ShareToken.sol";
+import {IShareToken} from "../interfaces/IShareToken.sol";
 
 /// @title  Share Token Factory
 /// @dev    Utility for deploying new share class token contracts

--- a/src/spoke/factories/interfaces/ITokenFactory.sol
+++ b/src/spoke/factories/interfaces/ITokenFactory.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {IShareToken} from "../../interfaces/IShareToken.sol";
 
 interface ITokenFactory {
     event File(bytes32 what, address[] addr);

--- a/src/spoke/factories/interfaces/IVaultFactory.sol
+++ b/src/spoke/factories/interfaces/IVaultFactory.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "../../../common/types/PoolId.sol";
+import {ShareClassId} from "../../../common/types/ShareClassId.sol";
 
-import {IVault} from "src/spoke/interfaces/IVault.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {IVault} from "../../interfaces/IVault.sol";
+import {IShareToken} from "../../interfaces/IShareToken.sol";
 
 interface IVaultFactory {
     error UnsupportedTokenId();

--- a/src/spoke/interfaces/IBalanceSheet.sol
+++ b/src/spoke/interfaces/IBalanceSheet.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {D18} from "src/misc/types/D18.sol";
+import {ISpoke} from "./ISpoke.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {IPoolEscrowProvider} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {D18} from "../../misc/types/D18.sol";
 
-import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
+import {AssetId} from "../../common/types/AssetId.sol";
+import {IRoot} from "../../common/interfaces/IRoot.sol";
+import {ShareClassId} from "../../common/types/ShareClassId.sol";
+import {IPoolEscrow} from "../../common/interfaces/IPoolEscrow.sol";
+import {ISpokeMessageSender} from "../../common/interfaces/IGatewaySenders.sol";
+import {IPoolEscrowProvider} from "../../common/factories/interfaces/IPoolEscrowFactory.sol";
 
 struct ShareQueueAmount {
     // Net queued shares

--- a/src/spoke/interfaces/IRequestManager.sol
+++ b/src/spoke/interfaces/IRequestManager.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
+import {AssetId} from "../../common/types/AssetId.sol";
+import {ShareClassId} from "../../common/types/ShareClassId.sol";
 
 interface IRequestManager {
     error UnknownRequestCallbackType();

--- a/src/spoke/interfaces/IShareToken.sol
+++ b/src/spoke/interfaces/IShareToken.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
-import {IERC7575Share} from "src/misc/interfaces/IERC7575.sol";
+import {IERC20Metadata} from "../../misc/interfaces/IERC20.sol";
+import {IERC7575Share} from "../../misc/interfaces/IERC7575.sol";
 
 interface IERC1404 {
     /// @notice Detects if a transfer will be reverted and if so returns an appropriate reference code

--- a/src/spoke/interfaces/ISpoke.sol
+++ b/src/spoke/interfaces/ISpoke.sol
@@ -1,17 +1,18 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {D18} from "src/misc/types/D18.sol";
+import {IShareToken} from "./IShareToken.sol";
+import {IVault, VaultKind} from "./IVault.sol";
+import {IRequestManager} from "./IRequestManager.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {D18} from "../../misc/types/D18.sol";
 
-import {Price} from "src/spoke/types/Price.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IVault, VaultKind} from "src/spoke/interfaces/IVault.sol";
-import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
-import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
+import {AssetId} from "../../common/types/AssetId.sol";
+import {ShareClassId} from "../../common/types/ShareClassId.sol";
+
+import {Price} from "../types/Price.sol";
+import {IVaultFactory} from "../factories/interfaces/IVaultFactory.sol";
 
 /// @dev Centrifuge pools
 struct Pool {

--- a/src/spoke/interfaces/IUpdateContract.sol
+++ b/src/spoke/interfaces/IUpdateContract.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
+import {ShareClassId} from "../../common/types/ShareClassId.sol";
 
 interface IUpdateContract {
     error UnknownUpdateContractType();

--- a/src/spoke/interfaces/IVault.sol
+++ b/src/spoke/interfaces/IVault.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IVaultManager} from "./IVaultManager.sol";
 
-import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
+import {ShareClassId} from "../../common/types/ShareClassId.sol";
 
 enum VaultKind {
     /// @dev Refers to AsyncVault

--- a/src/spoke/interfaces/IVaultManager.sol
+++ b/src/spoke/interfaces/IVaultManager.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IVault} from "./IVault.sol";
 
-import {IVault} from "src/spoke/interfaces/IVault.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
+import {AssetId} from "../../common/types/AssetId.sol";
+import {ShareClassId} from "../../common/types/ShareClassId.sol";
 
 interface IVaultManager {
     error VaultAlreadyExists();

--- a/src/spoke/libraries/UpdateContractMessageLib.sol
+++ b/src/spoke/libraries/UpdateContractMessageLib.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {CastLib} from "../../misc/libraries/CastLib.sol";
+import {BytesLib} from "../../misc/libraries/BytesLib.sol";
 
 enum UpdateContractType {
     /// @dev Placeholder for null update restriction type

--- a/src/spoke/types/Price.sol
+++ b/src/spoke/types/Price.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
+import {D18, d18} from "../../misc/types/D18.sol";
 
 /// @dev Price struct that contains a price, the timestamp at which it was computed and the max age of the price.
 struct Price {

--- a/src/vaults/AsyncRequestManager.sol
+++ b/src/vaults/AsyncRequestManager.sol
@@ -1,38 +1,38 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {IBaseVault} from "./interfaces/IBaseVault.sol";
+import {IRedeemManager} from "./interfaces/IVaultManagers.sol";
+import {IDepositManager} from "./interfaces/IVaultManagers.sol";
+import {IAsyncRedeemManager} from "./interfaces/IVaultManagers.sol";
+import {IAsyncDepositManager} from "./interfaces/IVaultManagers.sol";
+import {IBaseRequestManager} from "./interfaces/IBaseRequestManager.sol";
+import {IAsyncVault, IAsyncRedeemVault} from "./interfaces/IAsyncVault.sol";
+import {IAsyncRequestManager, AsyncInvestmentState} from "./interfaces/IVaultManagers.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {ESCROW_HOOK_ID} from "src/common/interfaces/ITransferHook.sol";
-import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
-import {RequestCallbackType, RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
+import {Auth} from "../misc/Auth.sol";
+import {D18, d18} from "../misc/types/D18.sol";
+import {Recoverable} from "../misc/Recoverable.sol";
+import {CastLib} from "../misc/libraries/CastLib.sol";
+import {MathLib} from "../misc/libraries/MathLib.sol";
+import {IEscrow} from "../misc/interfaces/IEscrow.sol";
+import {BytesLib} from "../misc/libraries/BytesLib.sol";
 
-import {IVault} from "src/spoke/interfaces/IVault.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
-import {ISpoke, VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
-import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
-import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
+import {PoolId} from "../common/types/PoolId.sol";
+import {AssetId} from "../common/types/AssetId.sol";
+import {PricingLib} from "../common/libraries/PricingLib.sol";
+import {ShareClassId} from "../common/types/ShareClassId.sol";
+import {IPoolEscrow} from "../common/interfaces/IPoolEscrow.sol";
+import {ESCROW_HOOK_ID} from "../common/interfaces/ITransferHook.sol";
+import {RequestMessageLib} from "../common/libraries/RequestMessageLib.sol";
+import {RequestCallbackType, RequestCallbackMessageLib} from "../common/libraries/RequestCallbackMessageLib.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IAsyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
-import {IAsyncVault, IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IAsyncRequestManager, AsyncInvestmentState} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IVault} from "../spoke/interfaces/IVault.sol";
+import {IShareToken} from "../spoke/interfaces/IShareToken.sol";
+import {IBalanceSheet} from "../spoke/interfaces/IBalanceSheet.sol";
+import {ISpoke, VaultDetails} from "../spoke/interfaces/ISpoke.sol";
+import {IVaultManager} from "../spoke/interfaces/IVaultManager.sol";
+import {IRequestManager} from "../spoke/interfaces/IRequestManager.sol";
 
 /// @title  Async Request Manager
 /// @notice This is the main contract vaults interact with for

--- a/src/vaults/AsyncVault.sol
+++ b/src/vaults/AsyncVault.sol
@@ -1,21 +1,21 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "src/misc/interfaces/IERC7540.sol";
-import "src/misc/interfaces/IERC7575.sol";
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
+import {BaseVault} from "./BaseVaults.sol";
+import {BaseAsyncRedeemVault} from "./BaseVaults.sol";
+import {IAsyncVault} from "./interfaces/IAsyncVault.sol";
+import {IAsyncRequestManager} from "./interfaces/IVaultManagers.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import "../misc/interfaces/IERC7540.sol";
+import "../misc/interfaces/IERC7575.sol";
+import {IERC20} from "../misc/interfaces/IERC20.sol";
+import {SafeTransferLib} from "../misc/libraries/SafeTransferLib.sol";
 
-import {VaultKind} from "src/spoke/interfaces/IVault.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {PoolId} from "../common/types/PoolId.sol";
+import {ShareClassId} from "../common/types/ShareClassId.sol";
 
-import {BaseVault} from "src/vaults/BaseVaults.sol";
-import {BaseAsyncRedeemVault} from "src/vaults/BaseVaults.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {VaultKind} from "../spoke/interfaces/IVault.sol";
+import {IShareToken} from "../spoke/interfaces/IShareToken.sol";
 
 /// @title  AsyncVault
 /// @notice Asynchronous Tokenized Vault standard implementation for Centrifuge pools

--- a/src/vaults/BaseVaults.sol
+++ b/src/vaults/BaseVaults.sol
@@ -1,29 +1,29 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import "src/misc/interfaces/IERC7540.sol";
-import "src/misc/interfaces/IERC7575.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
-import {IERC7575} from "src/misc/interfaces/IERC7575.sol";
-import {EIP712Lib} from "src/misc/libraries/EIP712Lib.sol";
-import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
-import {SignatureLib} from "src/misc/libraries/SignatureLib.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
+import {IBaseVault} from "./interfaces/IBaseVault.sol";
+import {IAsyncRedeemVault} from "./interfaces/IAsyncVault.sol";
+import {IAsyncRedeemManager} from "./interfaces/IVaultManagers.sol";
+import {ISyncDepositManager} from "./interfaces/IVaultManagers.sol";
+import {IBaseRequestManager} from "./interfaces/IBaseRequestManager.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {Auth} from "../misc/Auth.sol";
+import "../misc/interfaces/IERC7540.sol";
+import "../misc/interfaces/IERC7575.sol";
+import {Recoverable} from "../misc/Recoverable.sol";
+import {IERC7575} from "../misc/interfaces/IERC7575.sol";
+import {EIP712Lib} from "../misc/libraries/EIP712Lib.sol";
+import {IERC20Metadata} from "../misc/interfaces/IERC20.sol";
+import {SignatureLib} from "../misc/libraries/SignatureLib.sol";
+import {SafeTransferLib} from "../misc/libraries/SafeTransferLib.sol";
 
-import {IVault} from "src/spoke/interfaces/IVaultManager.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
+import {PoolId} from "../common/types/PoolId.sol";
+import {IRoot} from "../common/interfaces/IRoot.sol";
+import {ShareClassId} from "../common/types/ShareClassId.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {ISyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
+import {IVault} from "../spoke/interfaces/IVaultManager.sol";
+import {IShareToken} from "../spoke/interfaces/IShareToken.sol";
+import {IVaultManager} from "../spoke/interfaces/IVaultManager.sol";
 
 abstract contract BaseVault is Auth, Recoverable, IBaseVault {
     /// @dev Requests for Centrifuge pool are non-fungible and all have ID = 0

--- a/src/vaults/SyncDepositVault.sol
+++ b/src/vaults/SyncDepositVault.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IERC165} from "src/misc/interfaces/IERC7575.sol";
+import {BaseVault} from "./BaseVaults.sol";
+import {IAsyncRedeemManager} from "./interfaces/IVaultManagers.sol";
+import {ISyncDepositManager} from "./interfaces/IVaultManagers.sol";
+import {IBaseRequestManager} from "./interfaces/IBaseRequestManager.sol";
+import {BaseAsyncRedeemVault, BaseSyncDepositVault} from "./BaseVaults.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IERC165} from "../misc/interfaces/IERC7575.sol";
 
-import {VaultKind} from "src/spoke/interfaces/IVault.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {PoolId} from "../common/types/PoolId.sol";
+import {ShareClassId} from "../common/types/ShareClassId.sol";
 
-import {BaseVault} from "src/vaults/BaseVaults.sol";
-import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {ISyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
-import {BaseAsyncRedeemVault, BaseSyncDepositVault} from "src/vaults/BaseVaults.sol";
+import {VaultKind} from "../spoke/interfaces/IVault.sol";
+import {IShareToken} from "../spoke/interfaces/IShareToken.sol";
 
 /// @title  SyncDepositVault
 /// @notice Partially (a)synchronous Tokenized Vault implementation with synchronous deposits

--- a/src/vaults/SyncManager.sol
+++ b/src/vaults/SyncManager.sol
@@ -1,27 +1,27 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18} from "src/misc/types/D18.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {IBaseVault} from "./interfaces/IBaseVault.sol";
+import {IDepositManager} from "./interfaces/IVaultManagers.sol";
+import {ISyncDepositManager} from "./interfaces/IVaultManagers.sol";
+import {ISyncManager, ISyncDepositValuation} from "./interfaces/IVaultManagers.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {Auth} from "../misc/Auth.sol";
+import {D18} from "../misc/types/D18.sol";
+import {Recoverable} from "../misc/Recoverable.sol";
+import {CastLib} from "../misc/libraries/CastLib.sol";
+import {MathLib} from "../misc/libraries/MathLib.sol";
+import {BytesLib} from "../misc/libraries/BytesLib.sol";
 
-import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
-import {ISpoke, VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
-import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
-import {UpdateContractMessageLib, UpdateContractType} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import {PoolId} from "../common/types/PoolId.sol";
+import {AssetId} from "../common/types/AssetId.sol";
+import {PricingLib} from "../common/libraries/PricingLib.sol";
+import {ShareClassId} from "../common/types/ShareClassId.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {ISyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {ISyncManager, ISyncDepositValuation} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IBalanceSheet} from "../spoke/interfaces/IBalanceSheet.sol";
+import {ISpoke, VaultDetails} from "../spoke/interfaces/ISpoke.sol";
+import {IUpdateContract} from "../spoke/interfaces/IUpdateContract.sol";
+import {UpdateContractMessageLib, UpdateContractType} from "../spoke/libraries/UpdateContractMessageLib.sol";
 
 /// @title  Sync Manager
 /// @notice This is the main contract for synchronous ERC-4626 deposits.

--- a/src/vaults/VaultRouter.sol
+++ b/src/vaults/VaultRouter.sol
@@ -1,25 +1,25 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
-import {Multicall, IMulticall} from "src/misc/Multicall.sol";
-import {IERC7540Deposit} from "src/misc/interfaces/IERC7540.sol";
-import {IERC20, IERC20Permit} from "src/misc/interfaces/IERC20.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
+import {BaseSyncDepositVault} from "./BaseVaults.sol";
+import {IBaseVault} from "./interfaces/IBaseVault.sol";
+import {IAsyncVault} from "./interfaces/IAsyncVault.sol";
+import {IVaultRouter} from "./interfaces/IVaultRouter.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {Auth} from "../misc/Auth.sol";
+import {Recoverable} from "../misc/Recoverable.sol";
+import {CastLib} from "../misc/libraries/CastLib.sol";
+import {IEscrow} from "../misc/interfaces/IEscrow.sol";
+import {Multicall, IMulticall} from "../misc/Multicall.sol";
+import {IERC7540Deposit} from "../misc/interfaces/IERC7540.sol";
+import {IERC20, IERC20Permit} from "../misc/interfaces/IERC20.sol";
+import {SafeTransferLib} from "../misc/libraries/SafeTransferLib.sol";
 
-import {ISpoke, VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
+import {PoolId} from "../common/types/PoolId.sol";
+import {IGateway} from "../common/interfaces/IGateway.sol";
+import {ShareClassId} from "../common/types/ShareClassId.sol";
 
-import {BaseSyncDepositVault} from "src/vaults/BaseVaults.sol";
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IVaultRouter} from "src/vaults/interfaces/IVaultRouter.sol";
+import {ISpoke, VaultDetails} from "../spoke/interfaces/ISpoke.sol";
 
 /// @title  VaultRouter
 /// @notice This is a helper contract, designed to be the entrypoint for EOAs.

--- a/src/vaults/factories/AsyncVaultFactory.sol
+++ b/src/vaults/factories/AsyncVaultFactory.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
+import {Auth} from "../../misc/Auth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
+import {ShareClassId} from "../../common/types/ShareClassId.sol";
 
-import {IVault} from "src/spoke/interfaces/IVault.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
+import {IVault} from "../../spoke/interfaces/IVault.sol";
+import {IShareToken} from "../../spoke/interfaces/IShareToken.sol";
+import {IVaultFactory} from "../../spoke/factories/interfaces/IVaultFactory.sol";
 
-import {AsyncVault} from "src/vaults/AsyncVault.sol";
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {AsyncVault} from "../AsyncVault.sol";
+import {IAsyncRequestManager} from "../interfaces/IVaultManagers.sol";
 
 /// @title  ERC7540 Vault Factory
 /// @dev    Utility for deploying new vault contracts

--- a/src/vaults/factories/SyncDepositVaultFactory.sol
+++ b/src/vaults/factories/SyncDepositVaultFactory.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {Auth} from "../../misc/Auth.sol";
+import {IAuth} from "../../misc/interfaces/IAuth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
+import {ShareClassId} from "../../common/types/ShareClassId.sol";
 
-import {IVault} from "src/spoke/interfaces/IVault.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
+import {IVault} from "../../spoke/interfaces/IVault.sol";
+import {IShareToken} from "../../spoke/interfaces/IShareToken.sol";
+import {IVaultFactory} from "../../spoke/factories/interfaces/IVaultFactory.sol";
 
-import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
-import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {ISyncDepositManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {SyncDepositVault} from "../SyncDepositVault.sol";
+import {IAsyncRedeemManager} from "../interfaces/IVaultManagers.sol";
+import {ISyncDepositManager} from "../interfaces/IVaultManagers.sol";
 
 /// @title  Sync Vault Factory
 /// @dev    Utility for deploying new vault contracts

--- a/src/vaults/interfaces/IAsyncVault.sol
+++ b/src/vaults/interfaces/IAsyncVault.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IERC7540Redeem, IERC7887Redeem, IERC7887Deposit, IERC7540Deposit} from "src/misc/interfaces/IERC7540.sol";
+import {IBaseVault} from "./IBaseVault.sol";
+import {IAsyncRedeemManager} from "./IVaultManagers.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncRedeemManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IERC7540Redeem, IERC7887Redeem, IERC7887Deposit, IERC7540Deposit} from "../../misc/interfaces/IERC7540.sol";
 
 /**
  * @title  IAsyncRedeemVault

--- a/src/vaults/interfaces/IBaseRequestManager.sol
+++ b/src/vaults/interfaces/IBaseRequestManager.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
+import {IBaseVault} from "./IBaseVault.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
+import {IEscrow} from "../../misc/interfaces/IEscrow.sol";
 
-import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
-import {IVaultManager} from "src/spoke/interfaces/IVaultManager.sol";
-import {IRequestManager} from "src/spoke/interfaces/IRequestManager.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
+import {IPoolEscrow} from "../../common/interfaces/IPoolEscrow.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {ISpoke} from "../../spoke/interfaces/ISpoke.sol";
+import {IVaultManager} from "../../spoke/interfaces/IVaultManager.sol";
+import {IRequestManager} from "../../spoke/interfaces/IRequestManager.sol";
 
 interface IBaseRequestManager is IVaultManager, IRequestManager {
     event File(bytes32 indexed what, address data);

--- a/src/vaults/interfaces/IBaseVault.sol
+++ b/src/vaults/interfaces/IBaseVault.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IERC7575} from "src/misc/interfaces/IERC7575.sol";
-import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
-import {IERC7540Operator, IERC7714, IERC7741} from "src/misc/interfaces/IERC7540.sol";
+import {IERC7575} from "../../misc/interfaces/IERC7575.sol";
+import {IRecoverable} from "../../misc/interfaces/IRecoverable.sol";
+import {IERC7540Operator, IERC7714, IERC7741} from "../../misc/interfaces/IERC7540.sol";
 
-import {IVault} from "src/spoke/interfaces/IVault.sol";
+import {IVault} from "../../spoke/interfaces/IVault.sol";
 
 /// @notice Interface for the all vault contracts
 /// @dev Must be implemented by all vaults

--- a/src/vaults/interfaces/IVaultManagers.sol
+++ b/src/vaults/interfaces/IVaultManagers.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity 0.8.28;
 
-import {D18} from "src/misc/types/D18.sol";
+import {IBaseVault} from "./IBaseVault.sol";
+import {IBaseRequestManager} from "./IBaseRequestManager.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {D18} from "../../misc/types/D18.sol";
 
-import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
+import {AssetId} from "../../common/types/AssetId.sol";
+import {ShareClassId} from "../../common/types/ShareClassId.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
+import {IUpdateContract} from "../../spoke/interfaces/IUpdateContract.sol";
 
 interface IDepositManager {
     /// @notice Processes owner's asset deposit after the epoch has been executed on the corresponding CP instance and

--- a/src/vaults/interfaces/IVaultRouter.sol
+++ b/src/vaults/interfaces/IVaultRouter.sol
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IMulticall} from "src/misc/interfaces/IMulticall.sol";
+import {IBaseVault} from "./IBaseVault.sol";
+import {IAsyncVault} from "./IAsyncVault.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {IMulticall} from "../../misc/interfaces/IMulticall.sol";
 
-import {BaseSyncDepositVault} from "src/vaults/BaseVaults.sol";
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {PoolId} from "../../common/types/PoolId.sol";
+import {ShareClassId} from "../../common/types/ShareClassId.sol";
+
+import {BaseSyncDepositVault} from "../BaseVaults.sol";
 
 interface IVaultRouter is IMulticall {
     // --- Events ---

--- a/test/adapters/Deployment.t.sol
+++ b/test/adapters/Deployment.t.sol
@@ -5,7 +5,13 @@ import {CommonDeploymentInputTest} from "../common/Deployment.t.sol";
 
 import {IWormholeRelayer, IWormholeDeliveryProvider} from "../../src/common/interfaces/adapters/IWormholeAdapter.sol";
 
-import { AdaptersDeployer, AdaptersActionBatcher, AdaptersInput, WormholeInput, AxelarInput } from "../../script/AdaptersDeployer.s.sol";
+import {
+    AdaptersDeployer,
+    AdaptersActionBatcher,
+    AdaptersInput,
+    WormholeInput,
+    AxelarInput
+} from "../../script/AdaptersDeployer.s.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/adapters/Deployment.t.sol
+++ b/test/adapters/Deployment.t.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {CommonDeploymentInputTest} from "../common/Deployment.t.sol";
+
 import {IWormholeRelayer, IWormholeDeliveryProvider} from "../../src/common/interfaces/adapters/IWormholeAdapter.sol";
 
 import { AdaptersDeployer, AdaptersActionBatcher, AdaptersInput, WormholeInput, AxelarInput } from "../../script/AdaptersDeployer.s.sol";

--- a/test/adapters/Deployment.t.sol
+++ b/test/adapters/Deployment.t.sol
@@ -1,19 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IWormholeRelayer, IWormholeDeliveryProvider} from "src/common/interfaces/adapters/IWormholeAdapter.sol";
+import {CommonDeploymentInputTest} from "../common/Deployment.t.sol";
+import {IWormholeRelayer, IWormholeDeliveryProvider} from "../../src/common/interfaces/adapters/IWormholeAdapter.sol";
 
-import {CommonDeploymentInputTest} from "test/common/Deployment.t.sol";
+import { AdaptersDeployer, AdaptersActionBatcher, AdaptersInput, WormholeInput, AxelarInput } from "../../script/AdaptersDeployer.s.sol";
 
 import "forge-std/Test.sol";
-
-import {
-    AdaptersDeployer,
-    AdaptersActionBatcher,
-    AdaptersInput,
-    WormholeInput,
-    AxelarInput
-} from "script/AdaptersDeployer.s.sol";
 
 contract AdaptersDeploymentInputTest is Test {
     address immutable WORMHOLE_RELAYER = makeAddr("WormholeRelayer");

--- a/test/common/Deployment.t.sol
+++ b/test/common/Deployment.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ISafe} from "src/common/interfaces/IGuardian.sol";
+import {ISafe} from "../../src/common/interfaces/IGuardian.sol";
 
-import {CommonDeployer, CommonInput, CommonActionBatcher} from "script/CommonDeployer.s.sol";
+import {CommonDeployer, CommonInput, CommonActionBatcher} from "../../script/CommonDeployer.s.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/mocks/MockAdapter.sol
+++ b/test/common/mocks/MockAdapter.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
+import "./Mock.sol";
 
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+import {Auth} from "../../../src/misc/Auth.sol";
 
-import "test/common/mocks/Mock.sol";
+import {IAdapter} from "../../../src/common/interfaces/IAdapter.sol";
+import {IMessageHandler} from "../../../src/common/interfaces/IMessageHandler.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/mocks/MockRoot.sol
+++ b/test/common/mocks/MockRoot.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "test/common/mocks/Mock.sol";
+import "./Mock.sol";
 
 contract MockRoot is Mock {
     function endorsed(address) public view returns (bool) {

--- a/test/common/mocks/MockValuation.sol
+++ b/test/common/mocks/MockValuation.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
+import {D18, d18} from "../../../src/misc/types/D18.sol";
+import {MathLib} from "../../../src/misc/libraries/MathLib.sol";
+import {IERC6909Decimals} from "../../../src/misc/interfaces/IERC6909.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {BaseValuation} from "src/common/BaseValuation.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {AssetId} from "../../../src/common/types/AssetId.sol";
+import {BaseValuation} from "../../../src/common/BaseValuation.sol";
+import {PricingLib} from "../../../src/common/libraries/PricingLib.sol";
+import {IValuation} from "../../../src/common/interfaces/IValuation.sol";
 
 struct Price {
     D18 value;

--- a/test/common/types/AccountId.t.sol
+++ b/test/common/types/AccountId.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {AccountId} from "src/common/types/AccountId.sol";
+import {AccountId} from "../../../src/common/types/AccountId.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/types/AssetId.t.sol
+++ b/test/common/types/AssetId.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
+import {AssetId, newAssetId} from "../../../src/common/types/AssetId.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/types/PoolId.t.sol
+++ b/test/common/types/PoolId.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {PoolId, newPoolId} from "src/common/types/PoolId.sol";
+import {PoolId, newPoolId} from "../../../src/common/types/PoolId.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/types/ShareClassId.t.sol
+++ b/test/common/types/ShareClassId.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId, newShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "../../../src/common/types/PoolId.sol";
+import {ShareClassId, newShareClassId} from "../../../src/common/types/ShareClassId.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/AxelarAdapter.t.sol
+++ b/test/common/unit/AxelarAdapter.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
 
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {AxelarAdapter, IAdapter, IAxelarExecutable} from "src/common/adapters/AxelarAdapter.sol";
+import {IMessageHandler} from "../../../src/common/interfaces/IMessageHandler.sol";
+import {AxelarAdapter, IAdapter, IAxelarExecutable} from "../../../src/common/adapters/AxelarAdapter.sol";
 
-import {Mock} from "test/common/mocks/Mock.sol";
+import {Mock} from "../mocks/Mock.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/GasService.t.sol
+++ b/test/common/unit/GasService.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {BytesLib} from "../../../src/misc/libraries/BytesLib.sol";
 
-import {GasService} from "src/common/GasService.sol";
-import {MAX_MESSAGE_COST} from "src/common/interfaces/IGasService.sol";
-import {MessageLib, MessageType, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import {GasService} from "../../../src/common/GasService.sol";
+import {MAX_MESSAGE_COST} from "../../../src/common/interfaces/IGasService.sol";
+import {MessageLib, MessageType, VaultUpdateKind} from "../../../src/common/libraries/MessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/Gateway.t.sol
+++ b/test/common/unit/Gateway.t.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth, IAuth} from "src/misc/Auth.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
-import {Recoverable, IRecoverable} from "src/misc/Recoverable.sol";
-import {TransientArrayLib} from "src/misc/libraries/TransientArrayLib.sol";
-import {TransientBytesLib} from "src/misc/libraries/TransientBytesLib.sol";
-import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
+import {Auth, IAuth} from "../../../src/misc/Auth.sol";
+import {BytesLib} from "../../../src/misc/libraries/BytesLib.sol";
+import {Recoverable, IRecoverable} from "../../../src/misc/Recoverable.sol";
+import {TransientArrayLib} from "../../../src/misc/libraries/TransientArrayLib.sol";
+import {TransientBytesLib} from "../../../src/misc/libraries/TransientBytesLib.sol";
+import {TransientStorageLib} from "../../../src/misc/libraries/TransientStorageLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {Gateway, IRoot, IGasService, IGateway} from "src/common/Gateway.sol";
-import {IMessageProperties} from "src/common/interfaces/IMessageProperties.sol";
+import {PoolId} from "../../../src/common/types/PoolId.sol";
+import {IAdapter} from "../../../src/common/interfaces/IAdapter.sol";
+import {Gateway, IRoot, IGasService, IGateway} from "../../../src/common/Gateway.sol";
+import {IMessageProperties} from "../../../src/common/interfaces/IMessageProperties.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/Guardian.t.sol
+++ b/test/common/unit/Guardian.t.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {AxelarAddressToString} from "./AxelarAdapter.t.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IGuardian} from "src/common/interfaces/IGuardian.sol";
-import {IHubGuardianActions} from "src/common/interfaces/IGuardianActions.sol";
-import {IAxelarAdapter} from "src/common/interfaces/adapters/IAxelarAdapter.sol";
-import {IWormholeAdapter} from "src/common/interfaces/adapters/IWormholeAdapter.sol";
-import {Guardian, ISafe, IMultiAdapter, IRoot, IRootMessageSender} from "src/common/Guardian.sol";
+import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
 
-import {AxelarAddressToString} from "test/common/unit/AxelarAdapter.t.sol";
+import {PoolId} from "../../../src/common/types/PoolId.sol";
+import {AssetId} from "../../../src/common/types/AssetId.sol";
+import {IAdapter} from "../../../src/common/interfaces/IAdapter.sol";
+import {IGuardian} from "../../../src/common/interfaces/IGuardian.sol";
+import {IHubGuardianActions} from "../../../src/common/interfaces/IGuardianActions.sol";
+import {IAxelarAdapter} from "../../../src/common/interfaces/adapters/IAxelarAdapter.sol";
+import {IWormholeAdapter} from "../../../src/common/interfaces/adapters/IWormholeAdapter.sol";
+import {Guardian, ISafe, IMultiAdapter, IRoot, IRootMessageSender} from "../../../src/common/Guardian.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/MultiAdapter.t.sol
+++ b/test/common/unit/MultiAdapter.t.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/Auth.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {IAuth} from "../../../src/misc/Auth.sol";
+import {BytesLib} from "../../../src/misc/libraries/BytesLib.sol";
 
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {MultiAdapter} from "src/common/adapters/MultiAdapter.sol";
-import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {IMultiAdapter, MAX_ADAPTER_COUNT} from "src/common/interfaces/adapters/IMultiAdapter.sol";
+import {IAdapter} from "../../../src/common/interfaces/IAdapter.sol";
+import {MultiAdapter} from "../../../src/common/adapters/MultiAdapter.sol";
+import {MessageProofLib} from "../../../src/common/libraries/MessageProofLib.sol";
+import {IMessageHandler} from "../../../src/common/interfaces/IMessageHandler.sol";
+import {IMultiAdapter, MAX_ADAPTER_COUNT} from "../../../src/common/interfaces/adapters/IMultiAdapter.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/PoolEscrow.t.sol
+++ b/test/common/unit/PoolEscrow.t.sol
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ERC20} from "src/misc/ERC20.sol";
-import {Escrow, IEscrow} from "src/misc/Escrow.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {ERC20} from "../../../src/misc/ERC20.sol";
+import {Escrow, IEscrow} from "../../../src/misc/Escrow.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
+import {MockERC6909} from "../../misc/mocks/MockERC6909.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {PoolEscrow, IPoolEscrow} from "src/common/PoolEscrow.sol";
-
-import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
+import {PoolId} from "../../../src/common/types/PoolId.sol";
+import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
+import {PoolEscrow, IPoolEscrow} from "../../../src/common/PoolEscrow.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/PoolEscrow.t.sol
+++ b/test/common/unit/PoolEscrow.t.sol
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
+import {MockERC6909} from "../../misc/mocks/MockERC6909.sol";
+
 import {ERC20} from "../../../src/misc/ERC20.sol";
 import {Escrow, IEscrow} from "../../../src/misc/Escrow.sol";
 import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
-import {MockERC6909} from "../../misc/mocks/MockERC6909.sol";
 
 import {PoolId} from "../../../src/common/types/PoolId.sol";
 import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";

--- a/test/common/unit/Root.t.sol
+++ b/test/common/unit/Root.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
 
-import {Root, IRoot} from "src/common/Root.sol";
+import {Root, IRoot} from "../../../src/common/Root.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/TokenRecoverer.t.sol
+++ b/test/common/unit/TokenRecoverer.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {IAuth} from "src/misc/Auth.sol";
-import {IRecoverable} from "src/misc/interfaces/IRecoverable.sol";
+import {IAuth} from "../../../src/misc/Auth.sol";
+import {IRecoverable} from "../../../src/misc/interfaces/IRecoverable.sol";
 
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {TokenRecoverer, ITokenRecoverer} from "src/common/TokenRecoverer.sol";
+import {IRoot} from "../../../src/common/interfaces/IRoot.sol";
+import {TokenRecoverer, ITokenRecoverer} from "../../../src/common/TokenRecoverer.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/WormholeAdapter.t.sol
+++ b/test/common/unit/WormholeAdapter.t.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
+import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
 
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {WormholeAdapter} from "src/common/adapters/WormholeAdapter.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {IWormholeAdapter} from "src/common/interfaces/adapters/IWormholeAdapter.sol";
+import {IAdapter} from "../../../src/common/interfaces/IAdapter.sol";
+import {WormholeAdapter} from "../../../src/common/adapters/WormholeAdapter.sol";
+import {IMessageHandler} from "../../../src/common/interfaces/IMessageHandler.sol";
+import {IWormholeAdapter} from "../../../src/common/interfaces/adapters/IWormholeAdapter.sol";
 
-import {Mock} from "test/common/mocks/Mock.sol";
+import {Mock} from "../mocks/Mock.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/factories/PoolEscrowFactory.t.sol
+++ b/test/common/unit/factories/PoolEscrowFactory.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {IAuth} from "../../../../src/misc/interfaces/IAuth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {PoolEscrow} from "src/common/PoolEscrow.sol";
-import {PoolEscrowFactory} from "src/common/factories/PoolEscrowFactory.sol";
-import {IPoolEscrowFactory} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {PoolId} from "../../../../src/common/types/PoolId.sol";
+import {PoolEscrow} from "../../../../src/common/PoolEscrow.sol";
+import {PoolEscrowFactory} from "../../../../src/common/factories/PoolEscrowFactory.sol";
+import {IPoolEscrowFactory} from "../../../../src/common/factories/interfaces/IPoolEscrowFactory.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/libraries/MessageLib.t.sol
+++ b/test/common/unit/libraries/MessageLib.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
-import {MessageType, MessageLib} from "src/common/libraries/MessageLib.sol";
+import {PoolId} from "../../../../src/common/types/PoolId.sol";
+import {AssetId} from "../../../../src/common/types/AssetId.sol";
+import {MessageProofLib} from "../../../../src/common/libraries/MessageProofLib.sol";
+import {MessageType, MessageLib} from "../../../../src/common/libraries/MessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/libraries/MessageProofLib.t.sol
+++ b/test/common/unit/libraries/MessageProofLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
+import {MessageProofLib} from "../../../../src/common/libraries/MessageProofLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/libraries/RequestCallbackMessageLib.t.sol
+++ b/test/common/unit/libraries/RequestCallbackMessageLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {RequestCallbackType, RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
+import {RequestCallbackType, RequestCallbackMessageLib} from "../../../../src/common/libraries/RequestCallbackMessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/common/unit/libraries/RequestCallbackMessageLib.t.sol
+++ b/test/common/unit/libraries/RequestCallbackMessageLib.t.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {RequestCallbackType, RequestCallbackMessageLib} from "../../../../src/common/libraries/RequestCallbackMessageLib.sol";
+import {
+    RequestCallbackType,
+    RequestCallbackMessageLib
+} from "../../../../src/common/libraries/RequestCallbackMessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hooks/Deployment.t.sol
+++ b/test/hooks/Deployment.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {IAuth} from "../../src/misc/interfaces/IAuth.sol";
 
-import {HooksDeployer, HooksActionBatcher} from "script/HooksDeployer.s.sol";
+import {CommonDeploymentInputTest} from "../common/Deployment.t.sol";
 
-import {CommonDeploymentInputTest} from "test/common/Deployment.t.sol";
+import {HooksDeployer, HooksActionBatcher} from "../../script/HooksDeployer.s.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hooks/integration/FreelyTransferable.t.sol
+++ b/test/hooks/integration/FreelyTransferable.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
 
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import "../../spoke/BaseTest.sol";
 
-import {FreelyTransferable} from "src/hooks/FreelyTransferable.sol";
+import {IAsyncRequestManager} from "../../../src/vaults/interfaces/IVaultManagers.sol";
 
-import "test/spoke/BaseTest.sol";
+import {FreelyTransferable} from "../../../src/hooks/FreelyTransferable.sol";
 
 contract FreelyTransferableTest is BaseTest {
     using CastLib for *;

--- a/test/hooks/integration/FreezeOnly.t.sol
+++ b/test/hooks/integration/FreezeOnly.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
 
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
+import {ITransferHook} from "../../../src/common/interfaces/ITransferHook.sol";
 
-import "test/spoke/BaseTest.sol";
+import "../../spoke/BaseTest.sol";
 
 contract FreezeOnlyTest is BaseTest {
     using CastLib for *;

--- a/test/hooks/integration/RedemptionRestrictions.t.sol
+++ b/test/hooks/integration/RedemptionRestrictions.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
 
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import "../../spoke/BaseTest.sol";
 
-import {RedemptionRestrictions} from "src/hooks/RedemptionRestrictions.sol";
+import {IAsyncRequestManager} from "../../../src/vaults/interfaces/IVaultManagers.sol";
 
-import "test/spoke/BaseTest.sol";
+import {RedemptionRestrictions} from "../../../src/hooks/RedemptionRestrictions.sol";
 
 contract RedemptionRestrictionsTest is BaseTest {
     using CastLib for *;

--- a/test/hooks/mocks/MockSnapshotHook.sol
+++ b/test/hooks/mocks/MockSnapshotHook.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
+import {PoolId} from "../../../src/common/types/PoolId.sol";
+import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
+import {ISnapshotHook} from "../../../src/common/interfaces/ISnapshotHook.sol";
 
 contract MockSnapshotHook is ISnapshotHook {
     mapping(PoolId => mapping(ShareClassId => mapping(uint16 centrifugeId => uint256 counter))) public synced;

--- a/test/hooks/unit/libraries/UpdateRestrictionManagerLib.t.sol
+++ b/test/hooks/unit/libraries/UpdateRestrictionManagerLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {UpdateRestrictionMessageLib} from "../../../../src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/Deployment.t.sol
+++ b/test/hub/Deployment.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {HubDeployer, HubActionBatcher} from "script/HubDeployer.s.sol";
+import {CommonDeploymentInputTest} from "../common/Deployment.t.sol";
 
-import {CommonDeploymentInputTest} from "test/common/Deployment.t.sol";
+import {HubDeployer, HubActionBatcher} from "../../script/HubDeployer.s.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/integration/BaseTest.sol
+++ b/test/hub/integration/BaseTest.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {D18, d18} from "../../../src/misc/types/D18.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
-import {MAX_MESSAGE_COST} from "src/common/interfaces/IGasService.sol";
+import {PoolId} from "../../../src/common/types/PoolId.sol";
+import {AccountId} from "../../../src/common/types/AccountId.sol";
+import {MockValuation} from "../../common/mocks/MockValuation.sol";
+import {IAdapter} from "../../../src/common/interfaces/IAdapter.sol";
+import {AssetId, newAssetId} from "../../../src/common/types/AssetId.sol";
+import {MAX_MESSAGE_COST} from "../../../src/common/interfaces/IGasService.sol";
 
-import {HubDeployer, HubActionBatcher, CommonInput} from "script/HubDeployer.s.sol";
+import {HubDeployer, HubActionBatcher, CommonInput} from "../../../script/HubDeployer.s.sol";
 
-import {MockVaults} from "test/hub/mocks/MockVaults.sol";
-import {MockValuation} from "test/common/mocks/MockValuation.sol";
+import {MockVaults} from "../mocks/MockVaults.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/integration/BaseTest.sol
+++ b/test/hub/integration/BaseTest.sol
@@ -4,9 +4,10 @@ pragma solidity ^0.8.28;
 import {D18, d18} from "../../../src/misc/types/D18.sol";
 import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
 
+import {MockValuation} from "../../common/mocks/MockValuation.sol";
+
 import {PoolId} from "../../../src/common/types/PoolId.sol";
 import {AccountId} from "../../../src/common/types/AccountId.sol";
-import {MockValuation} from "../../common/mocks/MockValuation.sol";
 import {IAdapter} from "../../../src/common/interfaces/IAdapter.sol";
 import {AssetId, newAssetId} from "../../../src/common/types/AssetId.sol";
 import {MAX_MESSAGE_COST} from "../../../src/common/interfaces/IGasService.sol";

--- a/test/hub/integration/BatchingAndPayment.t.sol
+++ b/test/hub/integration/BatchingAndPayment.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import "test/hub/integration/BaseTest.sol";
+import "./BaseTest.sol";
 
 contract TestBatchingAndPayment is BaseTest {
     /// Test the following:

--- a/test/hub/integration/Cases.t.sol
+++ b/test/hub/integration/Cases.t.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import "./BaseTest.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
-import {RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
+import {D18, d18} from "../../../src/misc/types/D18.sol";
+import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
+import {MathLib} from "../../../src/misc/libraries/MathLib.sol";
 
-import "test/hub/integration/BaseTest.sol";
+import {PoolId} from "../../../src/common/types/PoolId.sol";
+import {AssetId} from "../../../src/common/types/AssetId.sol";
+import {MessageLib} from "../../../src/common/libraries/MessageLib.sol";
+import {PricingLib} from "../../../src/common/libraries/PricingLib.sol";
+import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
+import {VaultUpdateKind} from "../../../src/common/libraries/MessageLib.sol";
+import {RequestCallbackMessageLib} from "../../../src/common/libraries/RequestCallbackMessageLib.sol";
 
 contract TestCases is BaseTest {
     using MathLib for *;

--- a/test/hub/mocks/MockVaults.sol
+++ b/test/hub/mocks/MockVaults.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
-import {D18} from "src/misc/types/D18.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {Auth} from "../../../src/misc/Auth.sol";
+import {D18} from "../../../src/misc/types/D18.sol";
+import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
+import {BytesLib} from "../../../src/misc/libraries/BytesLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
-import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
+import {PoolId} from "../../../src/common/types/PoolId.sol";
+import {AssetId} from "../../../src/common/types/AssetId.sol";
+import {IAdapter} from "../../../src/common/interfaces/IAdapter.sol";
+import {MessageLib} from "../../../src/common/libraries/MessageLib.sol";
+import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
+import {IMessageHandler} from "../../../src/common/interfaces/IMessageHandler.sol";
+import {RequestMessageLib} from "../../../src/common/libraries/RequestMessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/unit/Accounting.t.sol
+++ b/test/hub/unit/Accounting.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
+import {PoolId} from "../../../src/common/types/PoolId.sol";
+import {AccountId} from "../../../src/common/types/AccountId.sol";
 
-import {Accounting} from "src/hub/Accounting.sol";
-import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
+import {Accounting} from "../../../src/hub/Accounting.sol";
+import {IAccounting, JournalEntry} from "../../../src/hub/interfaces/IAccounting.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/unit/Holdings.t.sol
+++ b/test/hub/unit/Holdings.t.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {d18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {d18} from "../../../src/misc/types/D18.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
+import {PoolId} from "../../../src/common/types/PoolId.sol";
+import {AssetId} from "../../../src/common/types/AssetId.sol";
+import {AccountId} from "../../../src/common/types/AccountId.sol";
+import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
+import {IValuation} from "../../../src/common/interfaces/IValuation.sol";
 
-import {Holdings} from "src/hub/Holdings.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IHoldings, HoldingAccount} from "src/hub/interfaces/IHoldings.sol";
+import {Holdings} from "../../../src/hub/Holdings.sol";
+import {IHubRegistry} from "../../../src/hub/interfaces/IHubRegistry.sol";
+import {IHoldings, HoldingAccount} from "../../../src/hub/interfaces/IHoldings.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/unit/Hub.t.sol
+++ b/test/hub/unit/Hub.t.sol
@@ -1,24 +1,24 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {D18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {D18} from "../../../src/misc/types/D18.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IValuation} from "src/common/interfaces/IValuation.sol";
-import {ISnapshotHook} from "src/common/interfaces/ISnapshotHook.sol";
+import {PoolId} from "../../../src/common/types/PoolId.sol";
+import {AssetId} from "../../../src/common/types/AssetId.sol";
+import {AccountId} from "../../../src/common/types/AccountId.sol";
+import {IGateway} from "../../../src/common/interfaces/IGateway.sol";
+import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
+import {IValuation} from "../../../src/common/interfaces/IValuation.sol";
+import {ISnapshotHook} from "../../../src/common/interfaces/ISnapshotHook.sol";
 
-import {Hub} from "src/hub/Hub.sol";
-import {IHoldings} from "src/hub/interfaces/IHoldings.sol";
-import {IHubHelpers} from "src/hub/interfaces/IHubHelpers.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IHub, VaultUpdateKind} from "src/hub/interfaces/IHub.sol";
-import {IAccounting, JournalEntry} from "src/hub/interfaces/IAccounting.sol";
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+import {Hub} from "../../../src/hub/Hub.sol";
+import {IHoldings} from "../../../src/hub/interfaces/IHoldings.sol";
+import {IHubHelpers} from "../../../src/hub/interfaces/IHubHelpers.sol";
+import {IHubRegistry} from "../../../src/hub/interfaces/IHubRegistry.sol";
+import {IHub, VaultUpdateKind} from "../../../src/hub/interfaces/IHub.sol";
+import {IAccounting, JournalEntry} from "../../../src/hub/interfaces/IAccounting.sol";
+import {IShareClassManager} from "../../../src/hub/interfaces/IShareClassManager.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/unit/HubHelpers.t.sol
+++ b/test/hub/unit/HubHelpers.t.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {d18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {d18} from "../../../src/misc/types/D18.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IHubMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
+import {PoolId} from "../../../src/common/types/PoolId.sol";
+import {AssetId} from "../../../src/common/types/AssetId.sol";
+import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
+import {IHubMessageSender} from "../../../src/common/interfaces/IGatewaySenders.sol";
 
-import {HubHelpers} from "src/hub/HubHelpers.sol";
-import {IHoldings} from "src/hub/interfaces/IHoldings.sol";
-import {IAccounting} from "src/hub/interfaces/IAccounting.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+import {HubHelpers} from "../../../src/hub/HubHelpers.sol";
+import {IHoldings} from "../../../src/hub/interfaces/IHoldings.sol";
+import {IAccounting} from "../../../src/hub/interfaces/IAccounting.sol";
+import {IHubRegistry} from "../../../src/hub/interfaces/IHubRegistry.sol";
+import {IShareClassManager} from "../../../src/hub/interfaces/IShareClassManager.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/unit/HubRegistry.t.sol
+++ b/test/hub/unit/HubRegistry.t.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
+import {MathLib} from "../../../src/misc/libraries/MathLib.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {PoolId, newPoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {AssetId} from "../../../src/common/types/AssetId.sol";
+import {PoolId, newPoolId} from "../../../src/common/types/PoolId.sol";
+import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
 
-import {HubRegistry} from "src/hub/HubRegistry.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+import {HubRegistry} from "../../../src/hub/HubRegistry.sol";
+import {IHubRegistry} from "../../../src/hub/interfaces/IHubRegistry.sol";
+import {IShareClassManager} from "../../../src/hub/interfaces/IShareClassManager.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/unit/ShareClassManager.t.sol
+++ b/test/hub/unit/ShareClassManager.t.sol
@@ -14,7 +14,7 @@ import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
 import {ShareClassManager} from "../../../src/hub/ShareClassManager.sol";
 import {IHubRegistry} from "../../../src/hub/interfaces/IHubRegistry.sol";
 import {IShareClassManager} from "../../../src/hub/interfaces/IShareClassManager.sol";
-import { IShareClassManager, EpochInvestAmounts, EpochRedeemAmounts, UserOrder, ShareClassMetadata, ShareClassMetrics, QueuedOrder, RequestType } from "../../../src/hub/interfaces/IShareClassManager.sol";
+import {IShareClassManager, EpochInvestAmounts, EpochRedeemAmounts, UserOrder, QueuedOrder} from "../../../src/hub/interfaces/IShareClassManager.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/hub/unit/ShareClassManager.t.sol
+++ b/test/hub/unit/ShareClassManager.t.sol
@@ -1,32 +1,22 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {D18, d18} from "../../../src/misc/types/D18.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
+import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
+import {MathLib} from "../../../src/misc/libraries/MathLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {PoolId} from "../../../src/common/types/PoolId.sol";
+import {AssetId} from "../../../src/common/types/AssetId.sol";
+import {PricingLib} from "../../../src/common/libraries/PricingLib.sol";
+import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
 
-import {ShareClassManager} from "src/hub/ShareClassManager.sol";
-import {IHubRegistry} from "src/hub/interfaces/IHubRegistry.sol";
-import {IShareClassManager} from "src/hub/interfaces/IShareClassManager.sol";
+import {ShareClassManager} from "../../../src/hub/ShareClassManager.sol";
+import {IHubRegistry} from "../../../src/hub/interfaces/IHubRegistry.sol";
+import {IShareClassManager} from "../../../src/hub/interfaces/IShareClassManager.sol";
+import { IShareClassManager, EpochInvestAmounts, EpochRedeemAmounts, UserOrder, ShareClassMetadata, ShareClassMetrics, QueuedOrder, RequestType } from "../../../src/hub/interfaces/IShareClassManager.sol";
 
 import "forge-std/Test.sol";
-
-import {
-    IShareClassManager,
-    EpochInvestAmounts,
-    EpochRedeemAmounts,
-    UserOrder,
-    ShareClassMetadata,
-    ShareClassMetrics,
-    QueuedOrder,
-    RequestType
-} from "src/hub/interfaces/IShareClassManager.sol";
 
 uint16 constant CHAIN_ID = 1;
 uint64 constant POOL_ID = 42;

--- a/test/hub/unit/ShareClassManager.t.sol
+++ b/test/hub/unit/ShareClassManager.t.sol
@@ -14,7 +14,13 @@ import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
 import {ShareClassManager} from "../../../src/hub/ShareClassManager.sol";
 import {IHubRegistry} from "../../../src/hub/interfaces/IHubRegistry.sol";
 import {IShareClassManager} from "../../../src/hub/interfaces/IShareClassManager.sol";
-import {IShareClassManager, EpochInvestAmounts, EpochRedeemAmounts, UserOrder, QueuedOrder} from "../../../src/hub/interfaces/IShareClassManager.sol";
+import {
+    IShareClassManager,
+    EpochInvestAmounts,
+    EpochRedeemAmounts,
+    UserOrder,
+    QueuedOrder
+} from "../../../src/hub/interfaces/IShareClassManager.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -11,6 +11,8 @@ import {MathLib} from "../../src/misc/libraries/MathLib.sol";
 import {ETH_ADDRESS} from "../../src/misc/interfaces/IRecoverable.sol";
 import {IdentityValuation} from "../../src/misc/IdentityValuation.sol";
 
+import {MockValuation} from "../common/mocks/MockValuation.sol";
+
 import {Root} from "../../src/common/Root.sol";
 import {Gateway} from "../../src/common/Gateway.sol";
 import {Guardian} from "../../src/common/Guardian.sol";
@@ -18,7 +20,6 @@ import {PoolId} from "../../src/common/types/PoolId.sol";
 import {GasService} from "../../src/common/GasService.sol";
 import {AccountId} from "../../src/common/types/AccountId.sol";
 import {ISafe} from "../../src/common/interfaces/IGuardian.sol";
-import {MockValuation} from "../common/mocks/MockValuation.sol";
 import {IAdapter} from "../../src/common/interfaces/IAdapter.sol";
 import {PricingLib} from "../../src/common/libraries/PricingLib.sol";
 import {ShareClassId} from "../../src/common/types/ShareClassId.sol";
@@ -44,8 +45,9 @@ import {IAsyncVault} from "../../src/vaults/interfaces/IAsyncVault.sol";
 import {AsyncRequestManager} from "../../src/vaults/AsyncRequestManager.sol";
 import {IAsyncRedeemVault} from "../../src/vaults/interfaces/IAsyncVault.sol";
 
-import {FreezeOnly} from "../../src/hooks/FreezeOnly.sol";
 import {MockSnapshotHook} from "../hooks/mocks/MockSnapshotHook.sol";
+
+import {FreezeOnly} from "../../src/hooks/FreezeOnly.sol";
 import {FullRestrictions} from "../../src/hooks/FullRestrictions.sol";
 import {RedemptionRestrictions} from "../../src/hooks/RedemptionRestrictions.sol";
 import {UpdateRestrictionMessageLib} from "../../src/hooks/libraries/UpdateRestrictionMessageLib.sol";

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
+import {LocalAdapter} from "./adapters/LocalAdapter.sol";
+
 import {ERC20} from "../../src/misc/ERC20.sol";
 import {D18, d18} from "../../src/misc/types/D18.sol";
 import {IAuth} from "../../src/misc/interfaces/IAuth.sol";
@@ -51,8 +53,6 @@ import {UpdateRestrictionMessageLib} from "../../src/hooks/libraries/UpdateRestr
 import {FullDeployer, FullActionBatcher, CommonInput} from "../../script/FullDeployer.s.sol";
 
 import "forge-std/Test.sol";
-
-import {LocalAdapter} from "./adapters/LocalAdapter.sol";
 
 /// End to end testing assuming two full deployments in two different chains
 ///

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -1,58 +1,58 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {ERC20} from "src/misc/ERC20.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {ETH_ADDRESS} from "src/misc/interfaces/IRecoverable.sol";
-import {IdentityValuation} from "src/misc/IdentityValuation.sol";
+import {ERC20} from "../../src/misc/ERC20.sol";
+import {D18, d18} from "../../src/misc/types/D18.sol";
+import {IAuth} from "../../src/misc/interfaces/IAuth.sol";
+import {CastLib} from "../../src/misc/libraries/CastLib.sol";
+import {MathLib} from "../../src/misc/libraries/MathLib.sol";
+import {ETH_ADDRESS} from "../../src/misc/interfaces/IRecoverable.sol";
+import {IdentityValuation} from "../../src/misc/IdentityValuation.sol";
 
-import {Root} from "src/common/Root.sol";
-import {Gateway} from "src/common/Gateway.sol";
-import {Guardian} from "src/common/Guardian.sol";
-import {PoolId} from "src/common/types/PoolId.sol";
-import {GasService} from "src/common/GasService.sol";
-import {AccountId} from "src/common/types/AccountId.sol";
-import {ISafe} from "src/common/interfaces/IGuardian.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {AssetId, newAssetId} from "src/common/types/AssetId.sol";
-import {VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
-import {MAX_MESSAGE_COST} from "src/common/interfaces/IGasService.sol";
+import {Root} from "../../src/common/Root.sol";
+import {Gateway} from "../../src/common/Gateway.sol";
+import {Guardian} from "../../src/common/Guardian.sol";
+import {PoolId} from "../../src/common/types/PoolId.sol";
+import {GasService} from "../../src/common/GasService.sol";
+import {AccountId} from "../../src/common/types/AccountId.sol";
+import {ISafe} from "../../src/common/interfaces/IGuardian.sol";
+import {MockValuation} from "../common/mocks/MockValuation.sol";
+import {IAdapter} from "../../src/common/interfaces/IAdapter.sol";
+import {PricingLib} from "../../src/common/libraries/PricingLib.sol";
+import {ShareClassId} from "../../src/common/types/ShareClassId.sol";
+import {AssetId, newAssetId} from "../../src/common/types/AssetId.sol";
+import {VaultUpdateKind} from "../../src/common/libraries/MessageLib.sol";
+import {MAX_MESSAGE_COST} from "../../src/common/interfaces/IGasService.sol";
 
-import {Hub} from "src/hub/Hub.sol";
-import {Holdings} from "src/hub/Holdings.sol";
-import {Accounting} from "src/hub/Accounting.sol";
-import {HubRegistry} from "src/hub/HubRegistry.sol";
-import {ShareClassManager} from "src/hub/ShareClassManager.sol";
+import {Hub} from "../../src/hub/Hub.sol";
+import {Holdings} from "../../src/hub/Holdings.sol";
+import {Accounting} from "../../src/hub/Accounting.sol";
+import {HubRegistry} from "../../src/hub/HubRegistry.sol";
+import {ShareClassManager} from "../../src/hub/ShareClassManager.sol";
 
-import {Spoke} from "src/spoke/Spoke.sol";
-import {IVault} from "src/spoke/interfaces/IVault.sol";
-import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
-import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import {Spoke} from "../../src/spoke/Spoke.sol";
+import {IVault} from "../../src/spoke/interfaces/IVault.sol";
+import {BalanceSheet} from "../../src/spoke/BalanceSheet.sol";
+import {UpdateContractMessageLib} from "../../src/spoke/libraries/UpdateContractMessageLib.sol";
 
-import {SyncManager} from "src/vaults/SyncManager.sol";
-import {VaultRouter} from "src/vaults/VaultRouter.sol";
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {AsyncRequestManager} from "src/vaults/AsyncRequestManager.sol";
-import {IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {SyncManager} from "../../src/vaults/SyncManager.sol";
+import {VaultRouter} from "../../src/vaults/VaultRouter.sol";
+import {IBaseVault} from "../../src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncVault} from "../../src/vaults/interfaces/IAsyncVault.sol";
+import {AsyncRequestManager} from "../../src/vaults/AsyncRequestManager.sol";
+import {IAsyncRedeemVault} from "../../src/vaults/interfaces/IAsyncVault.sol";
 
-import {FreezeOnly} from "src/hooks/FreezeOnly.sol";
-import {FullRestrictions} from "src/hooks/FullRestrictions.sol";
-import {RedemptionRestrictions} from "src/hooks/RedemptionRestrictions.sol";
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {FreezeOnly} from "../../src/hooks/FreezeOnly.sol";
+import {MockSnapshotHook} from "../hooks/mocks/MockSnapshotHook.sol";
+import {FullRestrictions} from "../../src/hooks/FullRestrictions.sol";
+import {RedemptionRestrictions} from "../../src/hooks/RedemptionRestrictions.sol";
+import {UpdateRestrictionMessageLib} from "../../src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
-import {FullDeployer, FullActionBatcher, CommonInput} from "script/FullDeployer.s.sol";
-
-import {MockValuation} from "test/common/mocks/MockValuation.sol";
-import {MockSnapshotHook} from "test/hooks/mocks/MockSnapshotHook.sol";
-import {LocalAdapter} from "test/integration/adapters/LocalAdapter.sol";
+import {FullDeployer, FullActionBatcher, CommonInput} from "../../script/FullDeployer.s.sol";
 
 import "forge-std/Test.sol";
+
+import {LocalAdapter} from "./adapters/LocalAdapter.sol";
 
 /// End to end testing assuming two full deployments in two different chains
 ///

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {ERC20} from "src/misc/ERC20.sol";
+import {ERC20} from "../../src/misc/ERC20.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {MAX_MESSAGE_COST as GAS} from "src/common/interfaces/IGasService.sol";
+import {PoolId} from "../../src/common/types/PoolId.sol";
+import {MockValuation} from "../common/mocks/MockValuation.sol";
+import {ShareClassId} from "../../src/common/types/ShareClassId.sol";
+import {MAX_MESSAGE_COST as GAS} from "../../src/common/interfaces/IGasService.sol";
 
-import {FullDeployer, FullActionBatcher, CommonInput} from "script/FullDeployer.s.sol";
-
-import {MockValuation} from "test/common/mocks/MockValuation.sol";
+import {FullDeployer, FullActionBatcher, CommonInput} from "../../script/FullDeployer.s.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -3,8 +3,9 @@ pragma solidity ^0.8.28;
 
 import {ERC20} from "../../src/misc/ERC20.sol";
 
-import {PoolId} from "../../src/common/types/PoolId.sol";
 import {MockValuation} from "../common/mocks/MockValuation.sol";
+
+import {PoolId} from "../../src/common/types/PoolId.sol";
 import {ShareClassId} from "../../src/common/types/ShareClassId.sol";
 import {MAX_MESSAGE_COST as GAS} from "../../src/common/interfaces/IGasService.sol";
 

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.28;
 
 import {EndToEndFlows} from "./EndToEnd.t.sol";
+import {LocalAdapter} from "./adapters/LocalAdapter.sol";
 
 import {CastLib} from "../../src/misc/libraries/CastLib.sol";
 
@@ -20,8 +21,6 @@ import {IShareToken} from "../../src/spoke/interfaces/IShareToken.sol";
 import {FullDeployer} from "../../script/FullDeployer.s.sol";
 
 import "forge-std/Test.sol";
-
-import {LocalAdapter} from "./adapters/LocalAdapter.sol";
 
 enum CrossChainDirection {
     WithIntermediaryHub, // C -> A -> B (Hub is on A)

--- a/test/integration/ThreeChainEndToEnd.t.sol
+++ b/test/integration/ThreeChainEndToEnd.t.sol
@@ -1,26 +1,27 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {EndToEndFlows} from "./EndToEnd.t.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {ISafe} from "src/common/interfaces/IGuardian.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IMultiAdapter} from "src/common/interfaces/adapters/IMultiAdapter.sol";
+import {CastLib} from "../../src/misc/libraries/CastLib.sol";
 
-import {IHub} from "src/hub/interfaces/IHub.sol";
+import {PoolId} from "../../src/common/types/PoolId.sol";
+import {ISafe} from "../../src/common/interfaces/IGuardian.sol";
+import {IGateway} from "../../src/common/interfaces/IGateway.sol";
+import {MessageLib} from "../../src/common/libraries/MessageLib.sol";
+import {ShareClassId} from "../../src/common/types/ShareClassId.sol";
+import {IMultiAdapter} from "../../src/common/interfaces/adapters/IMultiAdapter.sol";
 
-import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
+import {IHub} from "../../src/hub/interfaces/IHub.sol";
 
-import {FullDeployer} from "script/FullDeployer.s.sol";
+import {ISpoke} from "../../src/spoke/interfaces/ISpoke.sol";
+import {IShareToken} from "../../src/spoke/interfaces/IShareToken.sol";
 
-import "test/integration/EndToEnd.t.sol";
-import {LocalAdapter} from "test/integration/adapters/LocalAdapter.sol";
+import {FullDeployer} from "../../script/FullDeployer.s.sol";
 
 import "forge-std/Test.sol";
+
+import {LocalAdapter} from "./adapters/LocalAdapter.sol";
 
 enum CrossChainDirection {
     WithIntermediaryHub, // C -> A -> B (Hub is on A)

--- a/test/integration/adapters/LocalAdapter.sol
+++ b/test/integration/adapters/LocalAdapter.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Auth} from "src/misc/Auth.sol";
+import {Auth} from "../../../src/misc/Auth.sol";
 
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {IMessageHandler} from "src/common/interfaces/IMessageHandler.sol";
+import {IAdapter} from "../../../src/common/interfaces/IAdapter.sol";
+import {IMessageHandler} from "../../../src/common/interfaces/IMessageHandler.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/managers/Deployment.t.sol
+++ b/test/managers/Deployment.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ManagersDeployer, ManagersActionBatcher} from "script/ManagersDeployer.s.sol";
+import {CommonDeploymentInputTest} from "../common/Deployment.t.sol";
 
-import {CommonDeploymentInputTest} from "test/common/Deployment.t.sol";
+import {ManagersDeployer, ManagersActionBatcher} from "../../script/ManagersDeployer.s.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/managers/integration/MerkleProofManager.t.sol
+++ b/test/managers/integration/MerkleProofManager.t.sol
@@ -1,24 +1,24 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/Auth.sol";
-import {D18, d18} from "src/misc/types/D18.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {IAuth} from "../../../src/misc/Auth.sol";
+import {D18, d18} from "../../../src/misc/types/D18.sol";
+import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {AssetId} from "../../../src/common/types/AssetId.sol";
+import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
 
-import {BalanceSheet} from "src/spoke/BalanceSheet.sol";
-import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import "../../spoke/BaseTest.sol";
+import {BalanceSheet} from "../../../src/spoke/BalanceSheet.sol";
+import {UpdateContractMessageLib} from "../../../src/spoke/libraries/UpdateContractMessageLib.sol";
 
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {UpdateRestrictionMessageLib} from "../../../src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
-import {VaultDecoder} from "src/managers/decoders/VaultDecoder.sol";
-import {MerkleProofManager, PolicyLeaf, Call} from "src/managers/MerkleProofManager.sol";
-import {IMerkleProofManager, IERC7751} from "src/managers/interfaces/IMerkleProofManager.sol";
+import {VaultDecoder} from "../../../src/managers/decoders/VaultDecoder.sol";
+import {MerkleProofManager, PolicyLeaf, Call} from "../../../src/managers/MerkleProofManager.sol";
+import {IMerkleProofManager, IERC7751} from "../../../src/managers/interfaces/IMerkleProofManager.sol";
 
-import "test/spoke/BaseTest.sol";
-import {MerkleTreeLib} from "test/managers/libraries/MerkleTreeLib.sol";
+import {MerkleTreeLib} from "../libraries/MerkleTreeLib.sol";
 
 abstract contract MerkleProofManagerBaseTest is BaseTest {
     using CastLib for *;

--- a/test/managers/integration/MerkleProofManager.t.sol
+++ b/test/managers/integration/MerkleProofManager.t.sol
@@ -9,6 +9,7 @@ import {AssetId} from "../../../src/common/types/AssetId.sol";
 import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
 
 import "../../spoke/BaseTest.sol";
+
 import {BalanceSheet} from "../../../src/spoke/BalanceSheet.sol";
 import {UpdateContractMessageLib} from "../../../src/spoke/libraries/UpdateContractMessageLib.sol";
 

--- a/test/managers/integration/OnOfframpManager.t.sol
+++ b/test/managers/integration/OnOfframpManager.t.sol
@@ -12,6 +12,7 @@ import {AssetId} from "../../../src/common/types/AssetId.sol";
 import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
 
 import "../../spoke/BaseTest.sol";
+
 import {UpdateContractMessageLib} from "../../../src/spoke/libraries/UpdateContractMessageLib.sol";
 
 import {UpdateRestrictionMessageLib} from "../../../src/hooks/libraries/UpdateRestrictionMessageLib.sol";

--- a/test/managers/integration/OnOfframpManager.t.sol
+++ b/test/managers/integration/OnOfframpManager.t.sol
@@ -1,25 +1,24 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {IERC165} from "src/misc/interfaces/IERC165.sol";
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
-import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
+import {D18, d18} from "../../../src/misc/types/D18.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
+import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
+import {IERC165} from "../../../src/misc/interfaces/IERC165.sol";
+import {IEscrow} from "../../../src/misc/interfaces/IEscrow.sol";
+import {IERC7751} from "../../../src/misc/interfaces/IERC7751.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
+import {AssetId} from "../../../src/common/types/AssetId.sol";
+import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
 
-import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import "../../spoke/BaseTest.sol";
+import {UpdateContractMessageLib} from "../../../src/spoke/libraries/UpdateContractMessageLib.sol";
 
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {UpdateRestrictionMessageLib} from "../../../src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
-import {OnOfframpManagerFactory} from "src/managers/OnOfframpManager.sol";
-import {IOnOfframpManager} from "src/managers/interfaces/IOnOfframpManager.sol";
-import {IDepositManager, IWithdrawManager} from "src/managers/interfaces/IBalanceSheetManager.sol";
-
-import "test/spoke/BaseTest.sol";
+import {OnOfframpManagerFactory} from "../../../src/managers/OnOfframpManager.sol";
+import {IOnOfframpManager} from "../../../src/managers/interfaces/IOnOfframpManager.sol";
+import {IDepositManager, IWithdrawManager} from "../../../src/managers/interfaces/IBalanceSheetManager.sol";
 
 abstract contract OnOfframpManagerBaseTest is BaseTest {
     using CastLib for *;

--- a/test/misc/mocks/MockERC6909.sol
+++ b/test/misc/mocks/MockERC6909.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IERC6909MetadataExt, IERC6909Fungible, IERC6909} from "src/misc/interfaces/IERC6909.sol";
+import {IERC6909MetadataExt, IERC6909Fungible, IERC6909} from "../../../src/misc/interfaces/IERC6909.sol";
 
 contract MockERC6909 is IERC6909MetadataExt, IERC6909Fungible {
     mapping(address owner => mapping(uint256 tokenId => uint256)) public balanceOf;

--- a/test/misc/unit/BaseValuation.t.sol
+++ b/test/misc/unit/BaseValuation.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {IERC6909Decimals} from "src/misc/interfaces/IERC6909.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
+import {IERC6909Decimals} from "../../../src/misc/interfaces/IERC6909.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {BaseValuation} from "src/common/BaseValuation.sol";
-import {IBaseValuation} from "src/common/interfaces/IBaseValuation.sol";
+import {AssetId} from "../../../src/common/types/AssetId.sol";
+import {BaseValuation} from "../../../src/common/BaseValuation.sol";
+import {IBaseValuation} from "../../../src/common/interfaces/IBaseValuation.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/EIP712Lib.t.sol
+++ b/test/misc/unit/EIP712Lib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "src/misc/libraries/EIP712Lib.sol";
+import "../../../src/misc/libraries/EIP712Lib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/ERC20.t.sol
+++ b/test/misc/unit/ERC20.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ERC20} from "src/misc/ERC20.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {IERC1271} from "src/misc/libraries/SignatureLib.sol";
-import {IERC20, IERC20Permit} from "src/misc/interfaces/IERC20.sol";
+import {ERC20} from "../../../src/misc/ERC20.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
+import {IERC1271} from "../../../src/misc/libraries/SignatureLib.sol";
+import {IERC20, IERC20Permit} from "../../../src/misc/interfaces/IERC20.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/IdentityValuation.t.sol
+++ b/test/misc/unit/IdentityValuation.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import {IdentityValuation} from "src/misc/IdentityValuation.sol";
+import {IdentityValuation} from "../../../src/misc/IdentityValuation.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
+import {AssetId} from "../../../src/common/types/AssetId.sol";
 
-import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
+import {MockERC6909} from "../mocks/MockERC6909.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/Multicall.t.sol
+++ b/test/misc/unit/Multicall.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import {Multicall} from "src/misc/Multicall.sol";
-import {IMulticall} from "src/misc/interfaces/IMulticall.sol";
-import {ReentrancyProtection} from "src/misc/ReentrancyProtection.sol";
+import {Multicall} from "../../../src/misc/Multicall.sol";
+import {IMulticall} from "../../../src/misc/interfaces/IMulticall.sol";
+import {ReentrancyProtection} from "../../../src/misc/ReentrancyProtection.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/Recoverable.t.sol
+++ b/test/misc/unit/Recoverable.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.28;
 
-import {ERC20} from "src/misc/ERC20.sol";
-import {Auth, IAuth} from "src/misc/Auth.sol";
-import {Recoverable} from "src/misc/Recoverable.sol";
+import {ERC20} from "../../../src/misc/ERC20.sol";
+import {Auth, IAuth} from "../../../src/misc/Auth.sol";
+import {Recoverable} from "../../../src/misc/Recoverable.sol";
 
-import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
+import {MockERC6909} from "../mocks/MockERC6909.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/SignatureLib.t.sol
+++ b/test/misc/unit/SignatureLib.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "src/misc/libraries/EIP712Lib.sol";
-import "src/misc/libraries/SignatureLib.sol";
+import "../../../src/misc/libraries/EIP712Lib.sol";
+import "../../../src/misc/libraries/SignatureLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/ArrayLib.t.sol
+++ b/test/misc/unit/libraries/ArrayLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ArrayLib} from "src/misc/libraries/ArrayLib.sol";
+import {ArrayLib} from "../../../../src/misc/libraries/ArrayLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/BytesLib.t.sol
+++ b/test/misc/unit/libraries/BytesLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {BytesLib} from "../../../../src/misc/libraries/BytesLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/CastLib.t.sol
+++ b/test/misc/unit/libraries/CastLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {CastLib} from "../../../../src/misc/libraries/CastLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/D18.t.sol
+++ b/test/misc/unit/libraries/D18.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import "src/misc/types/D18.sol";
-import "src/misc/libraries/MathLib.sol";
+import "../../../../src/misc/types/D18.sol";
+import "../../../../src/misc/libraries/MathLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/MathLib.t.sol
+++ b/test/misc/unit/libraries/MathLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.28;
 
-import "src/misc/libraries/MathLib.sol";
+import "../../../../src/misc/libraries/MathLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/MerkleProofLib.t.sol
+++ b/test/misc/unit/libraries/MerkleProofLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.28;
 
-import {MerkleProofLib} from "src/misc/libraries/MerkleProofLib.sol";
+import {MerkleProofLib} from "../../../../src/misc/libraries/MerkleProofLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/PricingLib.t.sol
+++ b/test/misc/unit/libraries/PricingLib.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC20Metadata} from "src/misc/interfaces/IERC20.sol";
+import {D18, d18} from "../../../../src/misc/types/D18.sol";
+import {MathLib} from "../../../../src/misc/libraries/MathLib.sol";
+import {IERC20Metadata} from "../../../../src/misc/interfaces/IERC20.sol";
 
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
+import {PricingLib} from "../../../../src/common/libraries/PricingLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/SafeTransferLib.t.sol
+++ b/test/misc/unit/libraries/SafeTransferLib.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
-import {SafeTransferLib} from "src/misc/libraries/SafeTransferLib.sol";
+import {IERC7751} from "../../../../src/misc/interfaces/IERC7751.sol";
+import {SafeTransferLib} from "../../../../src/misc/libraries/SafeTransferLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/StringLib.t.sol
+++ b/test/misc/unit/libraries/StringLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "src/misc/libraries/StringLib.sol";
+import "../../../../src/misc/libraries/StringLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/TransientArrayLib.t.sol
+++ b/test/misc/unit/libraries/TransientArrayLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {TransientArrayLib} from "src/misc/libraries/TransientArrayLib.sol";
+import {TransientArrayLib} from "../../../../src/misc/libraries/TransientArrayLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/TransientBytesLib.t.sol
+++ b/test/misc/unit/libraries/TransientBytesLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {TransientBytesLib} from "src/misc/libraries/TransientBytesLib.sol";
+import {TransientBytesLib} from "../../../../src/misc/libraries/TransientBytesLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/misc/unit/libraries/TransientStorageLib.t.sol
+++ b/test/misc/unit/libraries/TransientStorageLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {TransientStorageLib} from "src/misc/libraries/TransientStorageLib.sol";
+import {TransientStorageLib} from "../../../../src/misc/libraries/TransientStorageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/spoke/BaseTest.sol
+++ b/test/spoke/BaseTest.sol
@@ -28,7 +28,9 @@ import {IVaultFactory} from "../../src/spoke/factories/interfaces/IVaultFactory.
 
 import {AsyncVault} from "../../src/vaults/AsyncVault.sol";
 
-import {ExtendedSpokeDeployer, ExtendedSpokeActionBatcher, CommonInput} from "../../script/ExtendedSpokeDeployer.s.sol";
+import {
+    ExtendedSpokeDeployer, ExtendedSpokeActionBatcher, CommonInput
+} from "../../script/ExtendedSpokeDeployer.s.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/spoke/BaseTest.sol
+++ b/test/spoke/BaseTest.sol
@@ -2,31 +2,31 @@
 pragma solidity 0.8.28;
 pragma abicoder v2;
 
-import "src/misc/interfaces/IERC20.sol";
-import {ERC20} from "src/misc/ERC20.sol";
-import {IERC6909Fungible} from "src/misc/interfaces/IERC6909.sol";
+import {MockSafe} from "./mocks/MockSafe.sol";
+import {MockCentrifugeChain} from "./mocks/MockCentrifugeChain.sol";
 
-import {AssetId} from "src/common/types/AssetId.sol";
-import {newAssetId} from "src/common/types/AssetId.sol";
-import {ISafe} from "src/common/interfaces/IGuardian.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {PoolId, newPoolId} from "src/common/types/PoolId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {MAX_MESSAGE_COST} from "src/common/interfaces/IGasService.sol";
-import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
+import "../../src/misc/interfaces/IERC20.sol";
+import {ERC20} from "../../src/misc/ERC20.sol";
+import {MockERC6909} from "../misc/mocks/MockERC6909.sol";
+import {IERC6909Fungible} from "../../src/misc/interfaces/IERC6909.sol";
 
-import {VaultKind} from "src/spoke/interfaces/IVault.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {IVaultFactory} from "src/spoke/factories/interfaces/IVaultFactory.sol";
+import {AssetId} from "../../src/common/types/AssetId.sol";
+import {MockAdapter} from "../common/mocks/MockAdapter.sol";
+import {newAssetId} from "../../src/common/types/AssetId.sol";
+import {ISafe} from "../../src/common/interfaces/IGuardian.sol";
+import {IAdapter} from "../../src/common/interfaces/IAdapter.sol";
+import {PoolId, newPoolId} from "../../src/common/types/PoolId.sol";
+import {ShareClassId} from "../../src/common/types/ShareClassId.sol";
+import {MAX_MESSAGE_COST} from "../../src/common/interfaces/IGasService.sol";
+import {MessageLib, VaultUpdateKind} from "../../src/common/libraries/MessageLib.sol";
 
-import {AsyncVault} from "src/vaults/AsyncVault.sol";
+import {VaultKind} from "../../src/spoke/interfaces/IVault.sol";
+import {IShareToken} from "../../src/spoke/interfaces/IShareToken.sol";
+import {IVaultFactory} from "../../src/spoke/factories/interfaces/IVaultFactory.sol";
 
-import {ExtendedSpokeDeployer, ExtendedSpokeActionBatcher, CommonInput} from "script/ExtendedSpokeDeployer.s.sol";
+import {AsyncVault} from "../../src/vaults/AsyncVault.sol";
 
-import {MockSafe} from "test/spoke/mocks/MockSafe.sol";
-import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
-import {MockAdapter} from "test/common/mocks/MockAdapter.sol";
-import {MockCentrifugeChain} from "test/spoke/mocks/MockCentrifugeChain.sol";
+import {ExtendedSpokeDeployer, ExtendedSpokeActionBatcher, CommonInput} from "../../script/ExtendedSpokeDeployer.s.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/spoke/BaseTest.sol
+++ b/test/spoke/BaseTest.sol
@@ -5,13 +5,15 @@ pragma abicoder v2;
 import {MockSafe} from "./mocks/MockSafe.sol";
 import {MockCentrifugeChain} from "./mocks/MockCentrifugeChain.sol";
 
+import {MockERC6909} from "../misc/mocks/MockERC6909.sol";
+
 import "../../src/misc/interfaces/IERC20.sol";
 import {ERC20} from "../../src/misc/ERC20.sol";
-import {MockERC6909} from "../misc/mocks/MockERC6909.sol";
 import {IERC6909Fungible} from "../../src/misc/interfaces/IERC6909.sol";
 
-import {AssetId} from "../../src/common/types/AssetId.sol";
 import {MockAdapter} from "../common/mocks/MockAdapter.sol";
+
+import {AssetId} from "../../src/common/types/AssetId.sol";
 import {newAssetId} from "../../src/common/types/AssetId.sol";
 import {ISafe} from "../../src/common/interfaces/IGuardian.sol";
 import {IAdapter} from "../../src/common/interfaces/IAdapter.sol";

--- a/test/spoke/Deployment.t.sol
+++ b/test/spoke/Deployment.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {SpokeDeployer, SpokeActionBatcher} from "script/SpokeDeployer.s.sol";
+import {CommonDeploymentInputTest} from "../common/Deployment.t.sol";
 
-import {CommonDeploymentInputTest} from "test/common/Deployment.t.sol";
+import {SpokeDeployer, SpokeActionBatcher} from "../../script/SpokeDeployer.s.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/spoke/integration/AssetShareConversion.t.sol
+++ b/test/spoke/integration/AssetShareConversion.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "test/spoke/BaseTest.sol";
+import "../BaseTest.sol";
 
 contract AssetShareConversionTest is BaseTest {
     function testAssetShareConversion(bytes16 scId) public {

--- a/test/spoke/integration/AsyncRequestManager.t.sol
+++ b/test/spoke/integration/AsyncRequestManager.t.sol
@@ -2,22 +2,22 @@
 pragma solidity 0.8.28;
 pragma abicoder v2;
 
-import {d18, D18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
+import {d18, D18} from "../../../src/misc/types/D18.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
+import {MathLib} from "../../../src/misc/libraries/MathLib.sol";
+import {IEscrow} from "../../../src/misc/interfaces/IEscrow.sol";
 
-import {PricingLib} from "src/common/libraries/PricingLib.sol";
+import {PricingLib} from "../../../src/common/libraries/PricingLib.sol";
 
-import {VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
+import {VaultDetails} from "../../../src/spoke/interfaces/ISpoke.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {AsyncRequestManager} from "src/vaults/AsyncRequestManager.sol";
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
+import {IBaseVault} from "../../../src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncVault} from "../../../src/vaults/interfaces/IAsyncVault.sol";
+import {AsyncRequestManager} from "../../../src/vaults/AsyncRequestManager.sol";
+import {IAsyncRequestManager} from "../../../src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseRequestManager} from "../../../src/vaults/interfaces/IBaseRequestManager.sol";
 
-import "test/spoke/BaseTest.sol";
+import "../BaseTest.sol";
 
 interface VaultLike {
     function priceComputedAt() external view returns (uint64);

--- a/test/spoke/integration/Burn.t.sol
+++ b/test/spoke/integration/Burn.t.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
+import {IERC20} from "../../../src/misc/interfaces/IERC20.sol";
 
-import "test/spoke/BaseTest.sol";
+import "../BaseTest.sol";
 
 contract BurnTest is BaseTest {
     function testBurn(uint256 amount) public {

--- a/test/spoke/integration/Deposit.t.sol
+++ b/test/spoke/integration/Deposit.t.sol
@@ -1,21 +1,21 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18} from "src/misc/types/D18.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
+import {D18} from "../../../src/misc/types/D18.sol";
+import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
+import {MathLib} from "../../../src/misc/libraries/MathLib.sol";
+import {IERC7751} from "../../../src/misc/interfaces/IERC7751.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
+import {PoolId} from "../../../src/common/types/PoolId.sol";
+import {AssetId} from "../../../src/common/types/AssetId.sol";
+import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
+import {RequestMessageLib} from "../../../src/common/libraries/RequestMessageLib.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseVault} from "../../../src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncVault} from "../../../src/vaults/interfaces/IAsyncVault.sol";
+import {IAsyncRequestManager} from "../../../src/vaults/interfaces/IVaultManagers.sol";
 
-import "test/spoke/BaseTest.sol";
+import "../BaseTest.sol";
 
 contract DepositTest is BaseTest {
     using MessageLib for *;

--- a/test/spoke/integration/DepositRedeem.t.sol
+++ b/test/spoke/integration/DepositRedeem.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18} from "src/misc/types/D18.sol";
+import {D18} from "../../../src/misc/types/D18.sol";
 
-import "test/spoke/BaseTest.sol";
+import "../BaseTest.sol";
 
 contract DepositRedeem is BaseTest {
     function testPartialDepositAndRedeemExecutions(bytes16 scId) public {

--- a/test/spoke/integration/Mint.t.sol
+++ b/test/spoke/integration/Mint.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
 
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
+import {ITransferHook} from "../../../src/common/interfaces/ITransferHook.sol";
 
-import "test/spoke/BaseTest.sol";
+import "../BaseTest.sol";
 
 contract MintTest is BaseTest {
     function testMint(uint256 amount) public {

--- a/test/spoke/integration/Operator.t.sol
+++ b/test/spoke/integration/Operator.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
+import {IERC20} from "../../../src/misc/interfaces/IERC20.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {IBaseVault} from "../../../src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncVault} from "../../../src/vaults/interfaces/IAsyncVault.sol";
 
-import "test/spoke/BaseTest.sol";
+import "../BaseTest.sol";
 
 contract OperatorTest is BaseTest {
     function testDepositAsOperator(uint256 amount) public {

--- a/test/spoke/integration/Redeem.t.sol
+++ b/test/spoke/integration/Redeem.t.sol
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {D18} from "../../../src/misc/types/D18.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
+import {IERC20} from "../../../src/misc/interfaces/IERC20.sol";
+import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {RequestMessageLib} from "src/common/libraries/RequestMessageLib.sol";
+import {PoolId} from "../../../src/common/types/PoolId.sol";
+import {AssetId} from "../../../src/common/types/AssetId.sol";
+import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
+import {RequestMessageLib} from "../../../src/common/libraries/RequestMessageLib.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseVault} from "../../../src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncRequestManager} from "../../../src/vaults/interfaces/IVaultManagers.sol";
 
-import "test/spoke/BaseTest.sol";
+import "../BaseTest.sol";
 
 contract RedeemTest is BaseTest {
     using MessageLib for *;

--- a/test/spoke/integration/Spoke.t.sol
+++ b/test/spoke/integration/Spoke.t.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
 import {MockERC6909} from "../../misc/mocks/MockERC6909.sol";
+
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
 import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
 import {BytesLib} from "../../../src/misc/libraries/BytesLib.sol";
 

--- a/test/spoke/integration/Spoke.t.sol
+++ b/test/spoke/integration/Spoke.t.sol
@@ -1,31 +1,32 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {BytesLib} from "src/misc/libraries/BytesLib.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
+import {MockERC6909} from "../../misc/mocks/MockERC6909.sol";
+import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
+import {BytesLib} from "../../../src/misc/libraries/BytesLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
+import {PoolId} from "../../../src/common/types/PoolId.sol";
+import {AssetId} from "../../../src/common/types/AssetId.sol";
+import {IGateway} from "../../../src/common/interfaces/IGateway.sol";
+import {MessageLib} from "../../../src/common/libraries/MessageLib.sol";
+import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
+import {ITransferHook} from "../../../src/common/interfaces/ITransferHook.sol";
 
-import {ShareToken} from "src/spoke/ShareToken.sol";
-import {IVault} from "src/spoke/interfaces/IVaultManager.sol";
-import {ISpoke, VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
-import {IUpdateContract} from "src/spoke/interfaces/IUpdateContract.sol";
+import {ShareToken} from "../../../src/spoke/ShareToken.sol";
+import {IVault} from "../../../src/spoke/interfaces/IVaultManager.sol";
+import {ISpoke, VaultDetails} from "../../../src/spoke/interfaces/ISpoke.sol";
+import {IUpdateContract} from "../../../src/spoke/interfaces/IUpdateContract.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {AsyncVaultFactory} from "src/vaults/factories/AsyncVaultFactory.sol";
+import {IBaseVault} from "../../../src/vaults/interfaces/IBaseVault.sol";
+import {AsyncVaultFactory} from "../../../src/vaults/factories/AsyncVaultFactory.sol";
 
-import {IMemberlist} from "src/hooks/interfaces/IMemberlist.sol";
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {IMemberlist} from "../../../src/hooks/interfaces/IMemberlist.sol";
+import {UpdateRestrictionMessageLib} from "../../../src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
-import "test/spoke/BaseTest.sol";
-import {MockHook} from "test/spoke/mocks/MockHook.sol";
-import {MockERC6909} from "test/misc/mocks/MockERC6909.sol";
+import {MockHook} from "../mocks/MockHook.sol";
+
+import "../BaseTest.sol";
 
 contract SpokeTestHelper is BaseTest {
     PoolId poolId;

--- a/test/spoke/integration/SyncDeposit.t.sol
+++ b/test/spoke/integration/SyncDeposit.t.sol
@@ -1,28 +1,28 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
+import {D18, d18} from "../../../src/misc/types/D18.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
+import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
+import {MathLib} from "../../../src/misc/libraries/MathLib.sol";
+import {IERC7751} from "../../../src/misc/interfaces/IERC7751.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
+import {PoolId} from "../../../src/common/types/PoolId.sol";
+import {AssetId} from "../../../src/common/types/AssetId.sol";
+import {MessageLib} from "../../../src/common/libraries/MessageLib.sol";
+import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
+import {ITransferHook} from "../../../src/common/interfaces/ITransferHook.sol";
 
-import {VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
-import {IVault} from "src/spoke/interfaces/IVaultManager.sol";
-import {IBalanceSheet} from "src/spoke/interfaces/IBalanceSheet.sol";
+import {VaultDetails} from "../../../src/spoke/interfaces/ISpoke.sol";
+import {IVault} from "../../../src/spoke/interfaces/IVaultManager.sol";
+import {IBalanceSheet} from "../../../src/spoke/interfaces/IBalanceSheet.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
-import {ISyncManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IAsyncRedeemVault} from "src/vaults/interfaces/IAsyncVault.sol";
+import {IBaseVault} from "../../../src/vaults/interfaces/IBaseVault.sol";
+import {SyncDepositVault} from "../../../src/vaults/SyncDepositVault.sol";
+import {ISyncManager} from "../../../src/vaults/interfaces/IVaultManagers.sol";
+import {IAsyncRedeemVault} from "../../../src/vaults/interfaces/IAsyncVault.sol";
 
-import "test/spoke/BaseTest.sol";
+import "../BaseTest.sol";
 
 contract SyncDepositTestHelper is BaseTest {
     using CastLib for *;

--- a/test/spoke/integration/SyncManager.t.sol
+++ b/test/spoke/integration/SyncManager.t.sol
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import {D18, d18} from "../../../src/misc/types/D18.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
+import {MathLib} from "../../../src/misc/libraries/MathLib.sol";
 
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
+import {MessageLib} from "../../../src/common/libraries/MessageLib.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
-import {ISyncManager} from "src/vaults/interfaces/IVaultManagers.sol";
-import {IBaseRequestManager} from "src/vaults/interfaces/IBaseRequestManager.sol";
-import {ISyncManager, ISyncDepositValuation} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseVault} from "../../../src/vaults/interfaces/IBaseVault.sol";
+import {SyncDepositVault} from "../../../src/vaults/SyncDepositVault.sol";
+import {ISyncManager} from "../../../src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseRequestManager} from "../../../src/vaults/interfaces/IBaseRequestManager.sol";
+import {ISyncManager, ISyncDepositValuation} from "../../../src/vaults/interfaces/IVaultManagers.sol";
 
-import "test/spoke/BaseTest.sol";
+import "../BaseTest.sol";
 
 contract SyncManagerBaseTest is BaseTest {
     function _deploySyncDepositVault(D18 pricePoolPerShare, D18 pricePoolPerAsset)

--- a/test/spoke/integration/VaultRouter.t.sol
+++ b/test/spoke/integration/VaultRouter.t.sol
@@ -1,23 +1,23 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "src/misc/interfaces/IERC20.sol";
-import "src/misc/interfaces/IERC7540.sol";
-import "src/misc/interfaces/IERC7575.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
+import "../../../src/misc/interfaces/IERC20.sol";
+import "../../../src/misc/interfaces/IERC7540.sol";
+import "../../../src/misc/interfaces/IERC7575.sol";
+import {MathLib} from "../../../src/misc/libraries/MathLib.sol";
+import {IERC7751} from "../../../src/misc/interfaces/IERC7751.sol";
 
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
+import {MessageLib} from "../../../src/common/libraries/MessageLib.sol";
 
-import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
+import {ISpoke} from "../../../src/spoke/interfaces/ISpoke.sol";
 
-import {VaultRouter} from "src/vaults/VaultRouter.sol";
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IVaultRouter} from "src/vaults/interfaces/IVaultRouter.sol";
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {VaultRouter} from "../../../src/vaults/VaultRouter.sol";
+import {IBaseVault} from "../../../src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncVault} from "../../../src/vaults/interfaces/IAsyncVault.sol";
+import {IVaultRouter} from "../../../src/vaults/interfaces/IVaultRouter.sol";
+import {IAsyncRequestManager} from "../../../src/vaults/interfaces/IVaultManagers.sol";
 
-import "test/spoke/BaseTest.sol";
+import "../BaseTest.sol";
 
 contract VaultRouterTest is BaseTest {
     using MessageLib for *;

--- a/test/spoke/mocks/MockCentrifugeChain.sol
+++ b/test/spoke/mocks/MockCentrifugeChain.sol
@@ -1,23 +1,23 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
+import {D18, d18} from "../../../src/misc/types/D18.sol";
+import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {IAdapter} from "src/common/interfaces/IAdapter.sol";
-import {MessageProofLib} from "src/common/libraries/MessageProofLib.sol";
-import {MessageLib, VaultUpdateKind} from "src/common/libraries/MessageLib.sol";
-import {RequestCallbackMessageLib} from "src/common/libraries/RequestCallbackMessageLib.sol";
+import {PoolId} from "../../../src/common/types/PoolId.sol";
+import {IAdapter} from "../../../src/common/interfaces/IAdapter.sol";
+import {MessageProofLib} from "../../../src/common/libraries/MessageProofLib.sol";
+import {MessageLib, VaultUpdateKind} from "../../../src/common/libraries/MessageLib.sol";
+import {RequestCallbackMessageLib} from "../../../src/common/libraries/RequestCallbackMessageLib.sol";
 
-import {Spoke} from "src/spoke/Spoke.sol";
-import {VaultDetails} from "src/spoke/interfaces/ISpoke.sol";
-import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import {Spoke} from "../../../src/spoke/Spoke.sol";
+import {VaultDetails} from "../../../src/spoke/interfaces/ISpoke.sol";
+import {UpdateContractMessageLib} from "../../../src/spoke/libraries/UpdateContractMessageLib.sol";
 
-import {SyncManager} from "src/vaults/SyncManager.sol";
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
+import {SyncManager} from "../../../src/vaults/SyncManager.sol";
+import {IBaseVault} from "../../../src/vaults/interfaces/IBaseVault.sol";
 
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {UpdateRestrictionMessageLib} from "../../../src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/spoke/mocks/MockFullRestrictions.sol
+++ b/test/spoke/mocks/MockFullRestrictions.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "src/hooks/FullRestrictions.sol";
+import "../../common/mocks/Mock.sol";
 
-import "test/common/mocks/Mock.sol";
+import "../../../src/hooks/FullRestrictions.sol";
 
 contract MockFullRestrictions is FullRestrictions, Mock {
     constructor(address root_, address deployer) FullRestrictions(root_, deployer) {}

--- a/test/spoke/mocks/MockHook.sol
+++ b/test/spoke/mocks/MockHook.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.28;
 import {IERC165} from "../../../src/misc/interfaces/IERC7575.sol";
 
 import "../../common/mocks/Mock.sol";
+
 import {ITransferHook} from "../../../src/common/interfaces/ITransferHook.sol";
 
 contract MockHook is Mock {

--- a/test/spoke/mocks/MockHook.sol
+++ b/test/spoke/mocks/MockHook.sol
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IERC165} from "src/misc/interfaces/IERC7575.sol";
+import {IERC165} from "../../../src/misc/interfaces/IERC7575.sol";
 
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
-
-import "test/common/mocks/Mock.sol";
+import "../../common/mocks/Mock.sol";
+import {ITransferHook} from "../../../src/common/interfaces/ITransferHook.sol";
 
 contract MockHook is Mock {
     function supportsInterface(bytes4 interfaceId) external pure returns (bool) {

--- a/test/spoke/mocks/MockSafe.sol
+++ b/test/spoke/mocks/MockSafe.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ISafe} from "src/common/Guardian.sol";
-
-import {Mock} from "test/common/mocks/Mock.sol";
+import {Mock} from "../../common/mocks/Mock.sol";
+import {ISafe} from "../../../src/common/Guardian.sol";
 
 contract MockSafe is Mock, ISafe {
     constructor(address[] memory owners, uint256 threshold) {

--- a/test/spoke/mocks/MockSafe.sol
+++ b/test/spoke/mocks/MockSafe.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {Mock} from "../../common/mocks/Mock.sol";
+
 import {ISafe} from "../../../src/common/Guardian.sol";
 
 contract MockSafe is Mock, ISafe {

--- a/test/spoke/unit/AsyncVault.t.sol
+++ b/test/spoke/unit/AsyncVault.t.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "src/misc/interfaces/IERC7540.sol";
-import "src/misc/interfaces/IERC7575.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
+import "../../../src/misc/interfaces/IERC7540.sol";
+import "../../../src/misc/interfaces/IERC7575.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
+import {MathLib} from "../../../src/misc/libraries/MathLib.sol";
 
-import {IBaseVault} from "src/vaults/interfaces/IBaseVault.sol";
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {IBaseVault} from "../../../src/vaults/interfaces/IBaseVault.sol";
+import {IAsyncRequestManager} from "../../../src/vaults/interfaces/IVaultManagers.sol";
 
-import "test/spoke/BaseTest.sol";
+import "../BaseTest.sol";
 
 contract AsyncVaultTest is BaseTest {
     // Deployment

--- a/test/spoke/unit/BalanceSheet.t.sol
+++ b/test/spoke/unit/BalanceSheet.t.sol
@@ -1,27 +1,27 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {D18, d18} from "src/misc/types/D18.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {IEscrow} from "src/misc/interfaces/IEscrow.sol";
-import {IERC6909} from "src/misc/interfaces/IERC6909.sol";
+import {D18, d18} from "../../../src/misc/types/D18.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
+import {IERC20} from "../../../src/misc/interfaces/IERC20.sol";
+import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
+import {IEscrow} from "../../../src/misc/interfaces/IEscrow.sol";
+import {IERC6909} from "../../../src/misc/interfaces/IERC6909.sol";
 
-import {PoolId} from "src/common/types/PoolId.sol";
-import {AssetId} from "src/common/types/AssetId.sol";
-import {IRoot} from "src/common/interfaces/IRoot.sol";
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {ShareClassId} from "src/common/types/ShareClassId.sol";
-import {IPoolEscrow} from "src/common/interfaces/IPoolEscrow.sol";
-import {ISpokeMessageSender} from "src/common/interfaces/IGatewaySenders.sol";
-import {IPoolEscrowProvider} from "src/common/factories/interfaces/IPoolEscrowFactory.sol";
+import {PoolId} from "../../../src/common/types/PoolId.sol";
+import {AssetId} from "../../../src/common/types/AssetId.sol";
+import {IRoot} from "../../../src/common/interfaces/IRoot.sol";
+import {IGateway} from "../../../src/common/interfaces/IGateway.sol";
+import {ShareClassId} from "../../../src/common/types/ShareClassId.sol";
+import {IPoolEscrow} from "../../../src/common/interfaces/IPoolEscrow.sol";
+import {ISpokeMessageSender} from "../../../src/common/interfaces/IGatewaySenders.sol";
+import {IPoolEscrowProvider} from "../../../src/common/factories/interfaces/IPoolEscrowFactory.sol";
 
-import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {BalanceSheet, IBalanceSheet} from "src/spoke/BalanceSheet.sol";
+import {ISpoke} from "../../../src/spoke/interfaces/ISpoke.sol";
+import {IShareToken} from "../../../src/spoke/interfaces/IShareToken.sol";
+import {BalanceSheet, IBalanceSheet} from "../../../src/spoke/BalanceSheet.sol";
 
-import {UpdateRestrictionMessageLib} from "src/hooks/libraries/UpdateRestrictionMessageLib.sol";
+import {UpdateRestrictionMessageLib} from "../../../src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/spoke/unit/RestrictedTransfers.t.sol
+++ b/test/spoke/unit/RestrictedTransfers.t.sol
@@ -1,17 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IERC165} from "src/misc/interfaces/IERC7575.sol";
+import {IERC165} from "../../../src/misc/interfaces/IERC7575.sol";
 
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
+import {MockRoot} from "../../common/mocks/MockRoot.sol";
+import {ITransferHook} from "../../../src/common/interfaces/ITransferHook.sol";
 
-import {ShareToken} from "src/spoke/ShareToken.sol";
+import {ShareToken} from "../../../src/spoke/ShareToken.sol";
 
-import {IFreezable} from "src/hooks/interfaces/IFreezable.sol";
-import {FullRestrictions} from "src/hooks/FullRestrictions.sol";
-import {IMemberlist} from "src/hooks/interfaces/IMemberlist.sol";
-
-import {MockRoot} from "test/common/mocks/MockRoot.sol";
+import {IFreezable} from "../../../src/hooks/interfaces/IFreezable.sol";
+import {FullRestrictions} from "../../../src/hooks/FullRestrictions.sol";
+import {IMemberlist} from "../../../src/hooks/interfaces/IMemberlist.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/spoke/unit/RestrictedTransfers.t.sol
+++ b/test/spoke/unit/RestrictedTransfers.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.28;
 import {IERC165} from "../../../src/misc/interfaces/IERC7575.sol";
 
 import {MockRoot} from "../../common/mocks/MockRoot.sol";
+
 import {ITransferHook} from "../../../src/common/interfaces/ITransferHook.sol";
 
 import {ShareToken} from "../../../src/spoke/ShareToken.sol";

--- a/test/spoke/unit/ShareToken.t.sol
+++ b/test/spoke/unit/ShareToken.t.sol
@@ -8,6 +8,7 @@ import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
 import {IERC20} from "../../../src/misc/interfaces/IERC20.sol";
 
 import {MockRoot} from "../../common/mocks/MockRoot.sol";
+
 import {ITransferHook} from "../../../src/common/interfaces/ITransferHook.sol";
 
 import {ShareToken} from "../../../src/spoke/ShareToken.sol";

--- a/test/spoke/unit/ShareToken.t.sol
+++ b/test/spoke/unit/ShareToken.t.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {ERC20} from "src/misc/ERC20.sol";
-import "src/misc/interfaces/IERC7540.sol";
-import "src/misc/interfaces/IERC7575.sol";
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
-import {IERC20} from "src/misc/interfaces/IERC20.sol";
+import {ERC20} from "../../../src/misc/ERC20.sol";
+import "../../../src/misc/interfaces/IERC7540.sol";
+import "../../../src/misc/interfaces/IERC7575.sol";
+import {IAuth} from "../../../src/misc/interfaces/IAuth.sol";
+import {IERC20} from "../../../src/misc/interfaces/IERC20.sol";
 
-import {ITransferHook} from "src/common/interfaces/ITransferHook.sol";
+import {MockRoot} from "../../common/mocks/MockRoot.sol";
+import {ITransferHook} from "../../../src/common/interfaces/ITransferHook.sol";
 
-import {ShareToken} from "src/spoke/ShareToken.sol";
+import {ShareToken} from "../../../src/spoke/ShareToken.sol";
 
-import {MockRoot} from "test/common/mocks/MockRoot.sol";
-import {MockFullRestrictions} from "test/spoke/mocks/MockFullRestrictions.sol";
+import {MockFullRestrictions} from "../mocks/MockFullRestrictions.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/spoke/unit/VaultRouter.t.sol
+++ b/test/spoke/unit/VaultRouter.t.sol
@@ -1,25 +1,25 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "src/misc/interfaces/IERC20.sol";
-import "src/misc/interfaces/IERC7540.sol";
-import "src/misc/interfaces/IERC7575.sol";
-import {CastLib} from "src/misc/libraries/CastLib.sol";
-import {MathLib} from "src/misc/libraries/MathLib.sol";
-import {IERC7751} from "src/misc/interfaces/IERC7751.sol";
+import "../../../src/misc/interfaces/IERC20.sol";
+import "../../../src/misc/interfaces/IERC7540.sol";
+import "../../../src/misc/interfaces/IERC7575.sol";
+import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
+import {MathLib} from "../../../src/misc/libraries/MathLib.sol";
+import {IERC7751} from "../../../src/misc/interfaces/IERC7751.sol";
 
-import {IGateway} from "src/common/interfaces/IGateway.sol";
-import {MessageLib} from "src/common/libraries/MessageLib.sol";
+import {IGateway} from "../../../src/common/interfaces/IGateway.sol";
+import {MessageLib} from "../../../src/common/libraries/MessageLib.sol";
 
-import {ISpoke} from "src/spoke/interfaces/ISpoke.sol";
+import {ISpoke} from "../../../src/spoke/interfaces/ISpoke.sol";
 
-import {VaultRouter} from "src/vaults/VaultRouter.sol";
-import {SyncDepositVault} from "src/vaults/SyncDepositVault.sol";
-import {IAsyncVault} from "src/vaults/interfaces/IAsyncVault.sol";
-import {IVaultRouter} from "src/vaults/interfaces/IVaultRouter.sol";
-import {IAsyncRequestManager} from "src/vaults/interfaces/IVaultManagers.sol";
+import {VaultRouter} from "../../../src/vaults/VaultRouter.sol";
+import {SyncDepositVault} from "../../../src/vaults/SyncDepositVault.sol";
+import {IAsyncVault} from "../../../src/vaults/interfaces/IAsyncVault.sol";
+import {IVaultRouter} from "../../../src/vaults/interfaces/IVaultRouter.sol";
+import {IAsyncRequestManager} from "../../../src/vaults/interfaces/IVaultManagers.sol";
 
-import "test/spoke/BaseTest.sol";
+import "../BaseTest.sol";
 
 interface Authlike {
     function rely(address) external;

--- a/test/spoke/unit/factories/TokenFactory.t.sol
+++ b/test/spoke/unit/factories/TokenFactory.t.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {IAuth} from "src/misc/interfaces/IAuth.sol";
+import {IAuth} from "../../../../src/misc/interfaces/IAuth.sol";
 
-import {Root} from "src/common/Root.sol";
+import {Root} from "../../../../src/common/Root.sol";
 
-import {ShareToken} from "src/spoke/ShareToken.sol";
-import {VaultKind} from "src/spoke/interfaces/IVault.sol";
-import {IShareToken} from "src/spoke/interfaces/IShareToken.sol";
-import {TokenFactory} from "src/spoke/factories/TokenFactory.sol";
-
-import {BaseTest} from "test/spoke/BaseTest.sol";
+import {ShareToken} from "../../../../src/spoke/ShareToken.sol";
+import {VaultKind} from "../../../../src/spoke/interfaces/IVault.sol";
+import {IShareToken} from "../../../../src/spoke/interfaces/IShareToken.sol";
+import {TokenFactory} from "../../../../src/spoke/factories/TokenFactory.sol";
 
 import "forge-std/Test.sol";
+
+import {BaseTest} from "../../BaseTest.sol";
 
 interface SpokeLike {
     function getShare(uint64 poolId, bytes16 scId) external view returns (address);

--- a/test/spoke/unit/libraries/UpdateContractMessageLib.t.sol
+++ b/test/spoke/unit/libraries/UpdateContractMessageLib.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {UpdateContractMessageLib} from "src/spoke/libraries/UpdateContractMessageLib.sol";
+import {UpdateContractMessageLib} from "../../../../src/spoke/libraries/UpdateContractMessageLib.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/vaults/Deployment.t.sol
+++ b/test/vaults/Deployment.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {VaultsDeployer, VaultsActionBatcher} from "script/VaultsDeployer.s.sol";
+import {CommonDeploymentInputTest} from "../common/Deployment.t.sol";
 
-import {CommonDeploymentInputTest} from "test/common/Deployment.t.sol";
+import {VaultsDeployer, VaultsActionBatcher} from "../../script/VaultsDeployer.s.sol";
 
 import "forge-std/Test.sol";
 


### PR DESCRIPTION
Applies complete import management overhaul: 
* Dependency-ready relative paths
* File reorganization

### Overview
Transforms the `fix_imports.py` script from basic import organization to a comprehensive import management system with bidirectional path conversion, advanced subgrouping, and safe file reorganization workflows.

### Major Features Added

**1. Relative Path Conversion System**
- `--fix-relative`: Convert `centrifuge-v3/src/`, `src/`, `test/`, `script/` imports to proper relative paths
- `--check-relative`: Check for absolute imports (CI-friendly)
- Automatically integrated into `--organize` command (use `--no-relative` to opt-out)
- Handles complex cross-directory imports (`src/hub/Hub.sol` importing `src/misc/Auth.sol` → `../misc/Auth.sol`)
- Smart same-directory detection (`src/misc/interfaces/IERC165.sol` → `./IERC165.sol`)
- Local import prefixing (adds `./` to subdirectory imports)
- Path optimization (removes redundant `/src/` components)

**2. Absolute Path Conversion System**
- `--fix-absolute`: Convert relative imports (`./`, `../`) → absolute paths (`src/`, `test/`, `script/`)  
- `--check-absolute`: Check for relative imports (CI-friendly)
- Enables safe file reorganization by making imports immune to file moves

**3. Advanced Import Subgrouping**
- Within each priority category, imports organized by base directory: `../` → `src` → `test` → `script`
- Each subgroup separated by empty lines for maximum clarity
- Example: Common imports grouped as `../common/` (direct relative) then `../../src/common/` (via src)
- Maintains existing priority system: `.` (current) → `misc` → `common` → `hub` → `spoke` → etc.

**4. Roundtrip Idempotency Testing**
- `--test-roundtrip`: Verify relative ↔ absolute ↔ relative conversion is lossless
- Saves original state, performs full conversion cycle, validates no differences
- Perfect for CI to ensure script reliability
- **Validation result**: 241 files tested, 0 differences after roundtrip

**5. Safe File Reorganization Workflow**
```bash
fix_imports.py --fix-absolute    # Convert to absolute (immune to moves)
# Move/reorganize files safely  
fix_imports.py --fix-relative    # Convert back to clean relative paths
fix_imports.py --test-roundtrip  # Verify idempotency
```

**6. Enhanced Multi-line Import Support**
- Updated regex patterns to handle complex multi-line imports
- Improved import extraction and replacement logic
- Robust handling of imports spanning multiple lines with varying whitespace

### Command Line Interface Additions
- `--fix-relative` - Convert absolute to relative imports
- `--check-relative` - Check for absolute imports (CI)
- `--fix-absolute` - Convert relative to absolute imports  
- `--check-absolute` - Check for relative imports (CI)
- `--test-roundtrip` - Test conversion idempotency (CI)
- `--no-relative` - Skip relative conversion in `--organize`

### Core Implementation Details
- `convert_to_relative_path()` - Smart relative path calculation with cross-directory support
- `convert_import_to_relative()` - Full import statement conversion with edge case handling
- `convert_relative_to_absolute_path()` - Reverse conversion for file reorganization
- `convert_import_to_absolute()` - Import statement absolute conversion
- `get_import_subgroup()` - Base directory classification for advanced subgrouping
- `test_roundtrip_idempotency()` - Comprehensive conversion validation

### Validation Results
- **Roundtrip test**: 241 files, 0 differences after full conversion cycle
- **Backward compatibility**: All existing functionality preserved

### Impact
- **Repository can now be used as dependency** - relative paths resolve correctly
- **Safe file reorganization** - move files without breaking imports
- **Enhanced code organization** - cleaner, more logical import grouping
- **CI-friendly validation** - automated testing of import path consistency

**Files Modified:**
- `script/utils/fix_imports.py` - Complete feature overhaul (500+ lines added)
- `script/utils/README.md` - Comprehensive documentation update 
- All `*.sol` files are the mere result of applying `python3 script/utils/fix_imports.py --organize `