### PR TITLE
Fix: gas service estimation for addPool

### DIFF
--- a/script/CommonDeployer.s.sol
+++ b/script/CommonDeployer.s.sol
@@ -161,7 +161,7 @@ abstract contract CommonDeployer is Script, JsonRegistry, CreateXScript {
 
         gasService = GasService(
             create3(
-                generateSalt("gasService"),
+                generateSalt("gasService-2"),
                 abi.encodePacked(type(GasService).creationCode, abi.encode(input.batchGasLimit))
             )
         );

--- a/src/common/GasService.sol
+++ b/src/common/GasService.sol
@@ -51,7 +51,7 @@ contract GasService is IGasService {
         recoverTokens = BASE_COST + 82906;
         registerAsset = BASE_COST + 34329;
         request = BASE_COST + 86084; // request deposit case
-        notifyPool = BASE_COST + 38190;
+        notifyPool = BASE_COST + 1154806; // create escrow case
         notifyShareClass = BASE_COST + 1775916;
         notifyPricePoolPerShare = BASE_COST + 30496;
         notifyPricePoolPerAsset = BASE_COST + 35759;


### PR DESCRIPTION
The gas value of addPool was taken from an EndToEnd in the same chain where the Escrow creation is not taken into account. The correct maximum estimation should be taken from a test using different chains 