### PR TITLE
feat: vault factory create2 salts

### DIFF
--- a/script/VaultsDeployer.s.sol
+++ b/script/VaultsDeployer.s.sol
@@ -129,7 +129,7 @@ contract VaultsDeployer is SpokeDeployer {
 
         asyncVaultFactory = AsyncVaultFactory(
             create3(
-                generateSalt("asyncVaultFactory-2"),
+                generateSalt("asyncVaultFactory-3"),
                 abi.encodePacked(
                     type(AsyncVaultFactory).creationCode, abi.encode(address(root), asyncRequestManager, batcher)
                 )
@@ -138,7 +138,7 @@ contract VaultsDeployer is SpokeDeployer {
 
         syncDepositVaultFactory = SyncDepositVaultFactory(
             create3(
-                generateSalt("syncDepositVaultFactory-2"),
+                generateSalt("syncDepositVaultFactory-3"),
                 abi.encodePacked(
                     type(SyncDepositVaultFactory).creationCode,
                     abi.encode(address(root), syncManager, asyncRequestManager, batcher)

--- a/src/vaults/factories/AsyncVaultFactory.sol
+++ b/src/vaults/factories/AsyncVaultFactory.sol
@@ -35,7 +35,7 @@ contract AsyncVaultFactory is Auth, IVaultFactory {
     ) public auth returns (IVault) {
         require(tokenId == 0, UnsupportedTokenId());
 
-        bytes32 salt = _generateSalt(poolId, scId, asset);
+        bytes32 salt = keccak256(abi.encode(poolId, scId, asset));
         AsyncVault vault = new AsyncVault{salt: salt}(poolId, scId, asset, token, root, asyncRequestManager);
 
         vault.rely(root);
@@ -50,13 +50,5 @@ contract AsyncVaultFactory is Auth, IVaultFactory {
 
         vault.deny(address(this));
         return vault;
-    }
-
-    /// @notice Generate deterministic salt for CREATE2 deployment
-    /// @dev Uses keccak256 hash of encoded poolId, scId, and asset address to ensure
-    ///      deterministic vault addresses across all chains. Same inputs will always
-    ///      produce the same salt, enabling predictable cross-chain vault addresses.
-    function _generateSalt(PoolId poolId, ShareClassId scId, address asset) internal pure returns (bytes32 salt) {
-        salt = keccak256(abi.encode(poolId, scId, asset));
     }
 }

--- a/src/vaults/factories/AsyncVaultFactory.sol
+++ b/src/vaults/factories/AsyncVaultFactory.sol
@@ -34,7 +34,9 @@ contract AsyncVaultFactory is Auth, IVaultFactory {
         address[] calldata wards_
     ) public auth returns (IVault) {
         require(tokenId == 0, UnsupportedTokenId());
-        AsyncVault vault = new AsyncVault(poolId, scId, asset, token, root, asyncRequestManager);
+
+        bytes32 salt = _generateSalt(poolId, scId, asset);
+        AsyncVault vault = new AsyncVault{salt: salt}(poolId, scId, asset, token, root, asyncRequestManager);
 
         vault.rely(root);
         vault.rely(address(asyncRequestManager));
@@ -48,5 +50,13 @@ contract AsyncVaultFactory is Auth, IVaultFactory {
 
         vault.deny(address(this));
         return vault;
+    }
+
+    /// @notice Generate deterministic salt for CREATE2 deployment
+    /// @dev Uses keccak256 hash of encoded poolId, scId, and asset address to ensure
+    ///      deterministic vault addresses across all chains. Same inputs will always
+    ///      produce the same salt, enabling predictable cross-chain vault addresses.
+    function _generateSalt(PoolId poolId, ShareClassId scId, address asset) internal pure returns (bytes32 salt) {
+        salt = keccak256(abi.encode(poolId, scId, asset));
     }
 }

--- a/src/vaults/factories/SyncDepositVaultFactory.sol
+++ b/src/vaults/factories/SyncDepositVaultFactory.sol
@@ -43,8 +43,10 @@ contract SyncDepositVaultFactory is Auth, IVaultFactory {
         address[] calldata wards_
     ) public auth returns (IVault) {
         require(tokenId == 0, UnsupportedTokenId());
+
+        bytes32 salt = _generateSalt(poolId, scId, asset);
         SyncDepositVault vault =
-            new SyncDepositVault(poolId, scId, asset, token, root, syncDepositManager, asyncRedeemManager);
+            new SyncDepositVault{salt: salt}(poolId, scId, asset, token, root, syncDepositManager, asyncRedeemManager);
 
         vault.rely(root);
         vault.rely(address(syncDepositManager));
@@ -60,5 +62,13 @@ contract SyncDepositVaultFactory is Auth, IVaultFactory {
 
         vault.deny(address(this));
         return vault;
+    }
+
+    /// @notice Generate deterministic salt for CREATE2 deployment
+    /// @dev Uses keccak256 hash of encoded poolId, scId, and asset address to ensure
+    ///      deterministic vault addresses across all chains. Same inputs will always
+    ///      produce the same salt, enabling predictable cross-chain vault addresses.
+    function _generateSalt(PoolId poolId, ShareClassId scId, address asset) internal pure returns (bytes32 salt) {
+        salt = keccak256(abi.encode(poolId, scId, asset));
     }
 }

--- a/src/vaults/factories/SyncDepositVaultFactory.sol
+++ b/src/vaults/factories/SyncDepositVaultFactory.sol
@@ -44,7 +44,7 @@ contract SyncDepositVaultFactory is Auth, IVaultFactory {
     ) public auth returns (IVault) {
         require(tokenId == 0, UnsupportedTokenId());
 
-        bytes32 salt = _generateSalt(poolId, scId, asset);
+        bytes32 salt = keccak256(abi.encode(poolId, scId, asset));
         SyncDepositVault vault =
             new SyncDepositVault{salt: salt}(poolId, scId, asset, token, root, syncDepositManager, asyncRedeemManager);
 
@@ -62,13 +62,5 @@ contract SyncDepositVaultFactory is Auth, IVaultFactory {
 
         vault.deny(address(this));
         return vault;
-    }
-
-    /// @notice Generate deterministic salt for CREATE2 deployment
-    /// @dev Uses keccak256 hash of encoded poolId, scId, and asset address to ensure
-    ///      deterministic vault addresses across all chains. Same inputs will always
-    ///      produce the same salt, enabling predictable cross-chain vault addresses.
-    function _generateSalt(PoolId poolId, ShareClassId scId, address asset) internal pure returns (bytes32 salt) {
-        salt = keccak256(abi.encode(poolId, scId, asset));
     }
 }


### PR DESCRIPTION
Adds `create2` vault salts to both vault factories which ensures deterministic vault addresses for the same `(poolId, shareClassId, assetAddress)` triplet across different chains