### PR TITLE
tests: add full multichain validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           FOUNDRY_PROFILE: ci
           FORK_TESTS: false
 
-  fork-tests:
+  fork-investment-tests:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -37,8 +37,8 @@ jobs:
         with:
           version: nightly
 
-      - name: Run fork tests
-        run: forge test --match-path "test/integration/fork/**/*.sol" --deny-warnings
+      - name: Run fork investment flow tests
+        run: forge test --match-path "test/integration/fork/ForkTestInvestments*.sol" --deny-warnings
         env:
           FOUNDRY_PROFILE: ci
           FORK_TESTS: true

--- a/.github/workflows/weekly-validation.yml
+++ b/.github/workflows/weekly-validation.yml
@@ -1,0 +1,71 @@
+name: Weekly Chain Validation
+
+on:
+  schedule:
+    # Run every Monday at 6:00 AM UTC (7:00 AM CET)
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    # Allow manual triggering for testing
+
+jobs:
+  validate-chains:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      matrix:
+        chain:
+          - name: "Ethereum"
+            test: "test_validateEthereum"
+            emoji: "🌐"
+            # rpc_secret: "ETH_RPC_URL"
+          - name: "Base"
+            test: "test_validateBase"
+            emoji: "🔵"
+            # rpc_secret: "BASE_RPC_URL"
+          - name: "Arbitrum"
+            test: "test_validateArbitrum"
+            emoji: "🔶"
+            # rpc_secret: "ARBITRUM_RPC_URL"
+          - name: "Avalanche"
+            test: "test_validateAvalanche"
+            emoji: "🏔️"
+            # rpc_secret: "AVAX_RPC_URL"
+          - name: "BNB"
+            test: "test_validateBNB"
+            emoji: "🟡"
+            # rpc_secret: "BNB_RPC_URL"
+          - name: "Plume"
+            test: "test_validatePlume"
+            emoji: "🟣"
+            # rpc_secret: "PLUME_RPC_URL"
+    
+    name: "Validate ${{ matrix.chain.name }}"
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+      
+      - name: Create build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            cache
+            out
+          key: ${{ runner.os }}-foundry-${{ hashFiles('lib/**', 'src/**', 'test/**') }}
+          restore-keys: |
+            ${{ runner.os }}-foundry-
+      
+      - name: Install dependencies
+        run: forge install --no-commit
+      
+      - name: Validate ${{ matrix.chain.name }} deployment
+        # env:
+        #   ${{ matrix.chain.rpc_secret }}: ${{ secrets[matrix.chain.rpc_secret] }}
+        run: |
+          echo "${{ matrix.chain.emoji }} Validating ${{ matrix.chain.name }} deployment..."
+          forge test --match-test ${{ matrix.chain.test }} -vv

--- a/test/integration/fork/ChainConfigs.sol
+++ b/test/integration/fork/ChainConfigs.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.28;
+
+import {IntegrationConstants} from "../utils/IntegrationConstants.sol";
+
+/// @title ChainConfigs
+/// @notice Centralized configuration for multi-chain fork testing
+library ChainConfigs {
+    struct ChainConfig {
+        string name;
+        string envVarName;
+        string publicRpc;
+        uint16 centrifugeId;
+        uint16 wormholeId;
+        string axelarId; // Empty string if not supported
+        address usdc;
+        address poolAdmin;
+        address adminSafe;
+        bool hasAxelar;
+    }
+
+    /// @notice Returns configuration for all supported chains
+    function getAllChains() internal pure returns (ChainConfig[6] memory) {
+        return [
+            ChainConfig({
+                name: "Ethereum",
+                envVarName: "ETH_RPC_URL",
+                publicRpc: IntegrationConstants.RPC_ETHEREUM,
+                centrifugeId: IntegrationConstants.ETH_CENTRIFUGE_ID,
+                wormholeId: IntegrationConstants.ETH_WORMHOLE_ID,
+                axelarId: IntegrationConstants.ETH_AXELAR_ID,
+                usdc: IntegrationConstants.ETH_USDC,
+                poolAdmin: IntegrationConstants.ETH_DEFAULT_POOL_ADMIN,
+                adminSafe: IntegrationConstants.ETH_ADMIN_SAFE,
+                hasAxelar: true
+            }),
+            ChainConfig({
+                name: "Base",
+                envVarName: "BASE_RPC_URL",
+                publicRpc: IntegrationConstants.RPC_BASE,
+                centrifugeId: IntegrationConstants.BASE_CENTRIFUGE_ID,
+                wormholeId: IntegrationConstants.BASE_WORMHOLE_ID,
+                axelarId: IntegrationConstants.BASE_AXELAR_ID,
+                usdc: IntegrationConstants.BASE_USDC,
+                poolAdmin: IntegrationConstants.ETH_DEFAULT_POOL_ADMIN,
+                adminSafe: IntegrationConstants.BASE_ADMIN_SAFE,
+                hasAxelar: true
+            }),
+            ChainConfig({
+                name: "Arbitrum",
+                envVarName: "ARBITRUM_RPC_URL",
+                publicRpc: IntegrationConstants.RPC_ARBITRUM,
+                centrifugeId: IntegrationConstants.ARBITRUM_CENTRIFUGE_ID,
+                wormholeId: IntegrationConstants.ARBITRUM_WORMHOLE_ID,
+                axelarId: IntegrationConstants.ARBITRUM_AXELAR_ID,
+                usdc: IntegrationConstants.ARBITRUM_USDC,
+                poolAdmin: IntegrationConstants.ETH_DEFAULT_POOL_ADMIN,
+                adminSafe: IntegrationConstants.ARBITRUM_ADMIN_SAFE,
+                hasAxelar: true
+            }),
+            ChainConfig({
+                name: "Avalanche",
+                envVarName: "AVAX_RPC_URL",
+                publicRpc: IntegrationConstants.RPC_AVALANCHE,
+                centrifugeId: IntegrationConstants.AVAX_CENTRIFUGE_ID,
+                wormholeId: IntegrationConstants.AVAX_WORMHOLE_ID,
+                axelarId: IntegrationConstants.AVAX_AXELAR_ID,
+                usdc: IntegrationConstants.AVA_USDC,
+                poolAdmin: IntegrationConstants.ETH_DEFAULT_POOL_ADMIN,
+                adminSafe: IntegrationConstants.AVAX_ADMIN_SAFE,
+                hasAxelar: true
+            }),
+            ChainConfig({
+                name: "BNB",
+                envVarName: "BNB_RPC_URL",
+                publicRpc: IntegrationConstants.RPC_BNB,
+                centrifugeId: IntegrationConstants.BNB_CENTRIFUGE_ID,
+                wormholeId: IntegrationConstants.BNB_WORMHOLE_ID,
+                axelarId: IntegrationConstants.BNB_AXELAR_ID,
+                usdc: IntegrationConstants.BNB_USDC,
+                poolAdmin: IntegrationConstants.ETH_DEFAULT_POOL_ADMIN,
+                adminSafe: IntegrationConstants.BNB_ADMIN_SAFE,
+                hasAxelar: true
+            }),
+            ChainConfig({
+                name: "Plume",
+                envVarName: "PLUME_RPC_URL",
+                publicRpc: IntegrationConstants.RPC_PLUME,
+                centrifugeId: IntegrationConstants.PLUME_CENTRIFUGE_ID,
+                wormholeId: IntegrationConstants.PLUME_WORMHOLE_ID,
+                axelarId: "", // Plume doesn't support Axelar
+                usdc: IntegrationConstants.PLUME_PUSD, // pUSD instead of USDC until USDC exists
+                poolAdmin: IntegrationConstants.PLUME_POOL_ADMIN,
+                adminSafe: IntegrationConstants.PLUME_ADMIN_SAFE,
+                hasAxelar: false
+            })
+        ];
+    }
+
+    /// @notice Returns configuration for a specific chain by name
+    function getChainConfig(string memory chainName) internal pure returns (ChainConfig memory) {
+        ChainConfig[6] memory chains = getAllChains();
+
+        bytes32 nameHash = keccak256(bytes(chainName));
+        for (uint256 i = 0; i < chains.length; i++) {
+            if (keccak256(bytes(chains[i].name)) == nameHash) {
+                return chains[i];
+            }
+        }
+
+        revert("Chain configuration not found");
+    }
+}

--- a/test/integration/fork/ForkTestBase.sol
+++ b/test/integration/fork/ForkTestBase.sol
@@ -59,7 +59,7 @@ contract ForkTestBase is EndToEndFlows {
         return IntegrationConstants.RPC_ETHEREUM;
     }
 
-    function _poolAdmin() internal pure virtual returns (address) {
+    function _poolAdmin() internal view virtual returns (address) {
         return IntegrationConstants.ETH_DEFAULT_POOL_ADMIN;
     }
 

--- a/test/integration/fork/ForkTestLiveValidation.sol
+++ b/test/integration/fork/ForkTestLiveValidation.sol
@@ -661,39 +661,15 @@ contract ForkTestLiveValidation is ForkTestAsyncInvestments {
     /// @notice Validates CFG token ward permissions (Ethereum only for now)
     function _validateCFGToken() internal view {
         _validateWard(IntegrationConstants.CFG, IntegrationConstants.V2_ROOT);
-
         _validateWard(IntegrationConstants.CFG, IntegrationConstants.IOU_CFG);
         // TODO(later): ROOT ward on CFG not yet implemented, WIP
         // _validateWard(IntegrationConstants.CFG, root);
 
+        _validateWard(IntegrationConstants.WCFG, IntegrationConstants.V2_ROOT);
         _validateWard(IntegrationConstants.WCFG, IntegrationConstants.IOU_CFG);
-
-        _validateOnlyExpectedWards(IntegrationConstants.CFG, _getExpectedCFGWards());
-
-        _validateOnlyExpectedWards(IntegrationConstants.WCFG, _getExpectedWCFGWards());
-    }
-
-    /// @notice Returns the expected wards for CFG token: V2_ROOT, IOU_CFG, (later also ROOT)
-    function _getExpectedCFGWards() private pure returns (address[] memory) {
-        address[] memory expectedWards = new address[](2); // Will be 3 when ROOT is added
-        expectedWards[0] = IntegrationConstants.V2_ROOT;
-        expectedWards[1] = IntegrationConstants.IOU_CFG;
-        // expectedWards[2] = root; // Future: when ROOT is added as ward on CFG
-        return expectedWards;
-    }
-
-    /// @notice Returns the expected wards for WCFG token
-    function _getExpectedWCFGWards() private pure returns (address[] memory) {
-        address[] memory expectedWards = new address[](1);
-        expectedWards[0] = IntegrationConstants.IOU_CFG;
-        return expectedWards;
-    }
-
-    /// @notice Validates that a contract only has the expected wards
-    function _validateOnlyExpectedWards(address contractAddr, address[] memory expectedWards) internal view {
-        for (uint256 i = 0; i < expectedWards.length; i++) {
-            _validateWard(contractAddr, expectedWards[i]);
-        }
+        // NOTE: Need to be removed soon
+        _validateWard(IntegrationConstants.WCFG, IntegrationConstants.WCFG_MULTISIG);
+        _validateWard(IntegrationConstants.WCFG, IntegrationConstants.CHAINBRIDGE_ERC20_HANDLER);
     }
 
     /// @notice Validates that one address has ward permissions on another contract

--- a/test/integration/fork/MultiChainValidation.sol
+++ b/test/integration/fork/MultiChainValidation.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {ChainConfigs} from "./ChainConfigs.sol";
+import {ForkTestLiveValidation} from "./ForkTestLiveValidation.sol";
+
+import "forge-std/Test.sol";
+
+import {VMLabeling} from "../utils/VMLabeling.sol";
+
+/// @title MultiChainValidation
+/// @notice Contract for validating protocol deployments across multiple chains
+contract MultiChainValidation is Test, VMLabeling {
+    struct ForkContext {
+        uint256 forkId;
+        string chainName;
+    }
+
+    mapping(string => ForkContext) public forkContexts;
+
+    function setUp() public {
+        _setupVMLabels();
+
+        ChainConfigs.ChainConfig[6] memory chainConfigs = ChainConfigs.getAllChains();
+
+        for (uint256 i = 0; i < chainConfigs.length; i++) {
+            ChainConfigs.ChainConfig memory config = chainConfigs[i];
+            string memory rpcUrl = _resolveRpcUrl(config);
+            uint256 forkId = vm.createFork(rpcUrl);
+            forkContexts[config.name] = ForkContext({forkId: forkId, chainName: config.name});
+        }
+    }
+
+    function test_validateEthereum() public {
+        _validateChain("Ethereum");
+    }
+
+    function test_validateBase() public {
+        _validateChain("Base");
+    }
+
+    function test_validateArbitrum() public {
+        _validateChain("Arbitrum");
+    }
+
+    function test_validateAvalanche() public {
+        _validateChain("Avalanche");
+    }
+
+    function test_validateBNB() public {
+        _validateChain("BNB");
+    }
+
+    function test_validatePlume() public {
+        _validateChain("Plume");
+    }
+
+    /// @notice Validates deployment on a specific chain
+    function _validateChain(string memory chainName) internal {
+        ForkContext memory context = forkContexts[chainName];
+        ChainConfigs.ChainConfig memory config = ChainConfigs.getChainConfig(chainName);
+
+        vm.selectFork(context.forkId);
+
+        ForkTestLiveValidation validator = new ForkTestLiveValidation();
+        validator._initializeContractAddresses();
+
+        validator._configureChain(config.adminSafe, config.centrifugeId);
+
+        validator.validateDeployment();
+    }
+
+    /// @notice Resolves RPC URL using environment variable with config fallback
+    function _resolveRpcUrl(ChainConfigs.ChainConfig memory config) internal view returns (string memory) {
+        try vm.envString(config.envVarName) returns (string memory envRpc) {
+            if (bytes(envRpc).length > 0) {
+                return envRpc;
+            }
+        } catch {
+            // Environment variable not set or empty, use config fallback
+        }
+        return config.publicRpc;
+    }
+}

--- a/test/integration/utils/ChainConfigs.sol
+++ b/test/integration/utils/ChainConfigs.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.28;
 
-import {IntegrationConstants} from "../utils/IntegrationConstants.sol";
+import {IntegrationConstants} from "./IntegrationConstants.sol";
 
 /// @title ChainConfigs
 /// @notice Centralized configuration for multi-chain fork testing
@@ -89,7 +89,7 @@ library ChainConfigs {
                 centrifugeId: IntegrationConstants.PLUME_CENTRIFUGE_ID,
                 wormholeId: IntegrationConstants.PLUME_WORMHOLE_ID,
                 axelarId: "", // Plume doesn't support Axelar
-                usdc: IntegrationConstants.PLUME_PUSD, // pUSD instead of USDC until USDC exists
+                usdc: IntegrationConstants.PLUME_PUSD, // pUSD instead of USDC
                 poolAdmin: IntegrationConstants.PLUME_POOL_ADMIN,
                 adminSafe: IntegrationConstants.PLUME_ADMIN_SAFE,
                 hasAxelar: false

--- a/test/integration/utils/IntegrationConstants.sol
+++ b/test/integration/utils/IntegrationConstants.sol
@@ -72,11 +72,17 @@ library IntegrationConstants {
     address constant POOL_ESCROW_FACTORY = 0xD166B3210edBeEdEa73c7b2e8aB64BDd30c980E9;
     address constant ETH_ADMIN_SAFE = 0xD9D30ab47c0f096b0AA67e9B8B1624504a63e7FD;
     address constant BASE_ADMIN_SAFE = 0x8b83962fB9dB346a20c95D98d4E312f17f4C0d9b;
+    address constant ARBITRUM_ADMIN_SAFE = 0xa36caE0ACd40C6BbA61014282f6AE51c7807A433;
     address constant AVAX_ADMIN_SAFE = 0xb6642fEd2221e177dD29581BB6d1959Bd1c54185;
+    address constant BNB_ADMIN_SAFE = 0x57066D897cB9cDef21b9Ecd7CecdD1d39b6eE445;
+    address constant PLUME_ADMIN_SAFE = 0x2d442069f78561F817d92c94924D5EaddA9C5767;
 
     // Token addresses
     address constant ETH_USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address constant BASE_USDC = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
+    address constant ARBITRUM_USDC = 0xaf88d065e77c8cC2239327C5EDb3A432268e5831;
     address constant AVA_USDC = 0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E;
+    address constant BNB_USDC = 0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d;
     address constant PLUME_PUSD = 0xdddD73F5Df1F0DC31373357beAC77545dC5A6f3F;
 
     // Pool admins
@@ -102,6 +108,7 @@ library IntegrationConstants {
     address constant AVAX_DEJAAA_USDC_VAULT = 0x498B6394b778A75eD9b0148e379778070B4621d2;
 
     address constant PLUME_SYNC_DEPOSIT_VAULT = 0x374Bc3D556fBc9feC0b9537c259DCB7935f7E5bf;
+    address constant AVAX_JAAA_USDC_VAULT = 0x1121F4e21eD8B9BC1BB9A2952cDD8639aC897784;
 
     // Share token addresses
     address constant ETH_JAAA_SHARE_TOKEN = 0x5a0F93D040De44e78F251b03c43be9CF317Dcf64;
@@ -147,10 +154,12 @@ library IntegrationConstants {
     string constant AVAX_AXELAR_ID = "Avalanche";
     string constant BNB_AXELAR_ID = "binance";
 
-    // ======== RPC Endpoints ========
+    // ======== RPC Endpoints (may have rate limits, no archive nodes, use for testing only) ========
     string constant RPC_ETHEREUM = "https://ethereum-rpc.publicnode.com";
     string constant RPC_BASE = "https://base-rpc.publicnode.com";
+    string constant RPC_ARBITRUM = "https://arbitrum-one-rpc.publicnode.com";
     string constant RPC_AVALANCHE = "https://avalanche-c-chain-rpc.publicnode.com";
+    string constant RPC_BNB = "https://bsc-rpc.publicnode.com";
     string constant RPC_PLUME = "https://rpc.plume.org";
 
     // ======== Misc Constants ========

--- a/test/integration/utils/IntegrationConstants.sol
+++ b/test/integration/utils/IntegrationConstants.sol
@@ -118,6 +118,11 @@ library IntegrationConstants {
     address constant AVAX_JTRSY_SHARE_TOKEN = 0xa5d465251fBCc907f5Dd6bB2145488DFC6a2627b;
     address constant AVAX_JAAA_SHARE_TOKEN = 0x58F93d6b1EF2F44eC379Cb975657C132CBeD3B6b;
 
+    // ======== CFG Token Contracts ========
+    address constant CFG = 0xcccCCCcCCC33D538DBC2EE4fEab0a7A1FF4e8A94;
+    address constant WCFG = 0xc221b7E65FfC80DE234bbB6667aBDd46593D34F0;
+    address constant IOU_CFG = 0xACF3c07BeBd65d5f7d86bc0bc716026A0C523069;
+
     // ======== V2 Constants (Legacy) ========
     address constant V2_ROOT = 0x0C1fDfd6a1331a875EA013F3897fc8a76ada5DfC;
     address constant V2_GUARDIAN = 0x09ab10a9c3E6Eac1d18270a2322B6113F4C7f5E8;
@@ -127,7 +132,6 @@ library IntegrationConstants {
     address constant V2_JTRSY_VAULT = 0x36036fFd9B1C6966ab23209E073c68Eb9A992f50;
     address constant V2_JAAA_VAULT = 0xE9d1f733F406D4bbbDFac6D4CfCD2e13A6ee1d01;
     uint256 constant V2_REQUEST_ID = 0;
-    uint128 constant V2_USDC_ASSET_ID = 242333941209166991950178742833476896417;
 
     // ======== Cross-Chain Adapter IDs ========
 

--- a/test/integration/utils/IntegrationConstants.sol
+++ b/test/integration/utils/IntegrationConstants.sol
@@ -81,7 +81,7 @@ library IntegrationConstants {
     address constant ETH_USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
     address constant BASE_USDC = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
     address constant ARBITRUM_USDC = 0xaf88d065e77c8cC2239327C5EDb3A432268e5831;
-    address constant AVA_USDC = 0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E;
+    address constant AVAX_USDC = 0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E;
     address constant BNB_USDC = 0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d;
     address constant PLUME_PUSD = 0xdddD73F5Df1F0DC31373357beAC77545dC5A6f3F;
 

--- a/test/integration/utils/VMLabeling.sol
+++ b/test/integration/utils/VMLabeling.sol
@@ -75,7 +75,7 @@ abstract contract VMLabeling is Test {
 
         // Token addresses
         vm.label(IntegrationConstants.ETH_USDC, "EthUSDC");
-        vm.label(IntegrationConstants.AVA_USDC, "AvaUSDC");
+        vm.label(IntegrationConstants.AVAX_USDC, "AvaxUSDC");
         vm.label(IntegrationConstants.PLUME_PUSD, "PlumePUSD");
 
         // Pool admin addresses

--- a/test/integration/utils/VMLabeling.sol
+++ b/test/integration/utils/VMLabeling.sol
@@ -86,6 +86,11 @@ abstract contract VMLabeling is Test {
         vm.label(IntegrationConstants.JTRSY_POOL_ESCROW, "JTRSYPoolEscrow");
         vm.label(IntegrationConstants.JAAA_POOL_ESCROW, "JAAAPoolEscrow");
 
+        // CFG Governance contracts
+        vm.label(IntegrationConstants.CFG, "CFG");
+        vm.label(IntegrationConstants.WCFG, "WCFG");
+        vm.label(IntegrationConstants.IOU_CFG, "IouCFG");
+
         // V2 Legacy contracts
         vm.label(IntegrationConstants.V2_ROOT, "V2Root");
         vm.label(IntegrationConstants.V2_GUARDIAN, "V2Guardian");

--- a/test/integration/utils/VMLabeling.sol
+++ b/test/integration/utils/VMLabeling.sol
@@ -46,7 +46,10 @@ abstract contract VMLabeling is Test {
         vm.label(IntegrationConstants.POOL_ESCROW_FACTORY, "PoolEscrowFactory");
         vm.label(IntegrationConstants.ETH_ADMIN_SAFE, "EthAdminSafe");
         vm.label(IntegrationConstants.BASE_ADMIN_SAFE, "BaseAdminSafe");
+        vm.label(IntegrationConstants.ARBITRUM_ADMIN_SAFE, "ArbitrumAdminSafe");
         vm.label(IntegrationConstants.AVAX_ADMIN_SAFE, "AvaxAdminSafe");
+        vm.label(IntegrationConstants.BNB_ADMIN_SAFE, "BnbAdminSafe");
+        vm.label(IntegrationConstants.PLUME_ADMIN_SAFE, "PlumeAdminSafe");
 
         // Vault addresses
         vm.label(IntegrationConstants.ETH_JAAA_VAULT, "EthJAAAVault");
@@ -59,6 +62,7 @@ abstract contract VMLabeling is Test {
         vm.label(IntegrationConstants.AVAX_DEJTRSY_USDC_VAULT, "AvaxDeJTRSYUsdcVault");
         vm.label(IntegrationConstants.BASE_DEJAAA_USDC_VAULT, "BaseDeJAAAUsdcVault");
         vm.label(IntegrationConstants.AVAX_DEJAAA_USDC_VAULT, "AvaxDeJAAAUsdcVault");
+        vm.label(IntegrationConstants.AVAX_JAAA_USDC_VAULT, "AvaxJAAAUsdcVault");
         vm.label(IntegrationConstants.PLUME_SYNC_DEPOSIT_VAULT, "PlumeSyncDepositVault");
 
         // Share token addresses


### PR DESCRIPTION
Adds missing networks Arbitrum, Binance and Plume for multichain validation.
* Adds CI job to run multichain validation once per week on Monday 7 am CET
  * Can also be triggered manually on Github
* Reduces non-blocking CI fork tests in PRs against main from all fork tests to just investment flows (v2 and v3 until v2 deprecation)