### PR TITLE
Feat: Threshold support in adapters

### DIFF
--- a/script/WireAdapters.s.sol
+++ b/script/WireAdapters.s.sol
@@ -67,7 +67,7 @@ contract WireAdapters is Script {
 
             // Register ALL adapters for this destination chain
             IGuardian guardian = IGuardian(vm.parseJsonAddress(localConfig, "$.contracts.guardian"));
-            guardian.setAdapters(remoteCentrifugeId, adapters);
+            guardian.setAdapters(remoteCentrifugeId, adapters, uint8(adapters.length));
             console.log("Registered MultiAdapter(", localNetwork, ") for", remoteNetwork);
 
             // Wire WormholeAdapter

--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "795130",
-  "requestDeposit": "667952"
+  "fulfillDepositRequest": "788507",
+  "requestDeposit": "667908"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "960626",
+  "claimDeposit": "954003",
   "enable": "60931",
   "lockDepositRequest": "95582",
-  "requestDeposit": "707332",
-  "requestRedeem": "2147585"
+  "requestDeposit": "707288",
+  "requestRedeem": "2140874"
 }

--- a/src/common/Guardian.sol
+++ b/src/common/Guardian.sol
@@ -106,8 +106,8 @@ contract Guardian is IGuardian {
     }
 
     /// @inheritdoc IGuardian
-    function setAdapters(uint16 centrifugeId, IAdapter[] calldata adapters) external onlySafe {
-        multiAdapter.setAdapters(centrifugeId, PoolId.wrap(0), adapters);
+    function setAdapters(uint16 centrifugeId, IAdapter[] calldata adapters, uint8 threshold) external onlySafe {
+        multiAdapter.setAdapters(centrifugeId, PoolId.wrap(0), adapters, threshold);
     }
 
     /// @inheritdoc IGuardian

--- a/src/common/MessageDispatcher.sol
+++ b/src/common/MessageDispatcher.sol
@@ -537,12 +537,16 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
     }
 
     /// @inheritdoc IHubMessageSender
-    function sendSetPoolAdapters(uint16 centrifugeId, PoolId poolId, bytes32[] memory adapters) external {
+    function sendSetPoolAdapters(uint16 centrifugeId, PoolId poolId, bytes32[] memory adapters, uint8 threshold)
+        external
+    {
         if (centrifugeId == localCentrifugeId) {
             revert CannotBeSentLocally();
         } else {
             gateway.send(
-                centrifugeId, MessageLib.SetPoolAdapters({poolId: poolId.raw(), adapterList: adapters}).serialize()
+                centrifugeId,
+                MessageLib.SetPoolAdapters({poolId: poolId.raw(), threshold: threshold, adapterList: adapters})
+                    .serialize()
             );
         }
     }

--- a/src/common/MessageProcessor.sol
+++ b/src/common/MessageProcessor.sol
@@ -92,7 +92,7 @@ contract MessageProcessor is Auth, IMessageProcessor {
             for (uint256 i; i < adapters.length; i++) {
                 adapters[i] = IAdapter(m.adapterList[i].toAddress());
             }
-            multiAdapter.setAdapters(centrifugeId, PoolId.wrap(m.poolId), adapters);
+            multiAdapter.setAdapters(centrifugeId, PoolId.wrap(m.poolId), adapters, m.threshold);
         } else if (kind == MessageType.SetPoolAdaptersManager) {
             MessageLib.SetPoolAdaptersManager memory m = message.deserializeSetPoolAdaptersManager();
             multiAdapter.setManager(PoolId.wrap(m.poolId), m.manager.toAddress());

--- a/src/common/interfaces/IGatewaySenders.sol
+++ b/src/common/interfaces/IGatewaySenders.sol
@@ -132,7 +132,8 @@ interface IHubMessageSender is ILocalCentrifugeId {
     ) external;
 
     /// @notice Creates and send the message
-    function sendSetPoolAdapters(uint16 centrifugeId, PoolId poolId, bytes32[] memory adapters) external;
+    function sendSetPoolAdapters(uint16 centrifugeId, PoolId poolId, bytes32[] memory adapters, uint8 threshold)
+        external;
 
     /// @notice Creates and send the message
     function sendSetPoolAdaptersManager(uint16 centrifugeId, PoolId poolId, bytes32 manager) external;

--- a/src/common/interfaces/IGuardian.sol
+++ b/src/common/interfaces/IGuardian.sol
@@ -68,11 +68,11 @@ interface IGuardian {
     ) external;
 
     /// @notice Set adapters into MultiAdapter.
-    /// @dev Only registers adapters with MultiAdapter and does not configure individual adapters.
-    /// @dev For bidirectional communication, perform this setup on the remote MultiAdapter.
+    /// @dev The adapters must be previously deployed and wired.
     /// @param centrifugeId The destination chain ID to wire adapters for
     /// @param adapters Array of adapter addresses to register with MultiAdapter
-    function setAdapters(uint16 centrifugeId, IAdapter[] calldata adapters) external;
+    /// @param  threshold Minimum number of adapters required to process the messages
+    function setAdapters(uint16 centrifugeId, IAdapter[] calldata adapters, uint8 threshold) external;
 
     /// @notice Set an adapters manager for the global adaters.
     /// @param manager address able to recover messages in the `centrifugeId` chain or pause sending messages

--- a/src/common/interfaces/IMultiAdapter.sol
+++ b/src/common/interfaces/IMultiAdapter.sol
@@ -56,7 +56,7 @@ interface IMultiAdapter is IAdapterBlockSendingExt, IMessageHandler {
     /// @notice Dispatched when the contract is configured with an empty adapter set.
     error EmptyAdapterSet();
 
-    /// @notice Dispatched when the threshold number is higher than the number of configued adapters (aka quorum).
+    /// @notice Dispatched when the threshold number is higher than the number of configured adapters (aka quorum).
     error ThresholdHigherThanQuorum();
 
     /// @notice Dispatched when the contract is configured with a number of adapter exceeding the maximum.

--- a/src/common/libraries/MessageLib.sol
+++ b/src/common/libraries/MessageLib.sol
@@ -73,7 +73,7 @@ library MessageLib {
         (33  << uint8(MessageType.CancelUpgrade) * 8) +
         (161 << uint8(MessageType.RecoverTokens) * 8) +
         (18  << uint8(MessageType.RegisterAsset) * 8) +
-        (11  << uint8(MessageType.SetPoolAdapters) * 8) +
+        (12  << uint8(MessageType.SetPoolAdapters) * 8) +
         (41  << uint8(MessageType.SetPoolAdaptersManager) * 8) +
         (0   << uint8(MessageType._Placeholder7) * 8) +
         (0   << uint8(MessageType._Placeholder8) * 8) +
@@ -133,7 +133,7 @@ library MessageLib {
         } else if (kind == uint8(MessageType.RequestCallback)) {
             length += 2 + message.toUint16(length); //payloadLength
         } else if (kind == uint8(MessageType.SetPoolAdapters)) {
-            length += message.toUint16(9) * 32; // message with variable length
+            length += message.toUint16(10) * 32; // message with variable length
         }
     }
 
@@ -265,23 +265,26 @@ library MessageLib {
 
     struct SetPoolAdapters {
         uint64 poolId;
+        uint8 threshold;
         bytes32[] adapterList;
     }
 
     function deserializeSetPoolAdapters(bytes memory data) internal pure returns (SetPoolAdapters memory) {
         require(messageType(data) == MessageType.SetPoolAdapters, UnknownMessageType());
 
-        uint16 length = data.toUint16(9);
+        uint16 length = data.toUint16(10);
         bytes32[] memory adapterList = new bytes32[](length);
         for (uint256 i; i < length; i++) {
-            adapterList[i] = data.toBytes32(11 + i * 32);
+            adapterList[i] = data.toBytes32(12 + i * 32);
         }
 
-        return SetPoolAdapters({poolId: data.toUint64(1), adapterList: adapterList});
+        return SetPoolAdapters({poolId: data.toUint64(1), threshold: data.toUint8(9), adapterList: adapterList});
     }
 
     function serialize(SetPoolAdapters memory t) internal pure returns (bytes memory) {
-        return abi.encodePacked(MessageType.SetPoolAdapters, t.poolId, t.adapterList.length.toUint16(), t.adapterList);
+        return abi.encodePacked(
+            MessageType.SetPoolAdapters, t.poolId, t.threshold, t.adapterList.length.toUint16(), t.adapterList
+        );
     }
 
     //---------------------------------------

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -658,13 +658,14 @@ contract Hub is Multicall, Auth, Recoverable, IHub, IHubGatewayHandler, IHubGuar
         uint16 centrifugeId,
         PoolId poolId,
         IAdapter[] memory localAdapters,
-        bytes32[] memory remoteAdapters
+        bytes32[] memory remoteAdapters,
+        uint8 threshold
     ) external payable payTransaction {
         _isManager(poolId);
 
-        multiAdapter.setAdapters(centrifugeId, poolId, localAdapters);
+        multiAdapter.setAdapters(centrifugeId, poolId, localAdapters, threshold);
 
-        sender.sendSetPoolAdapters(centrifugeId, poolId, remoteAdapters);
+        sender.sendSetPoolAdapters(centrifugeId, poolId, remoteAdapters, threshold);
     }
 
     /// @inheritdoc IHub

--- a/src/hub/interfaces/IHub.sol
+++ b/src/hub/interfaces/IHub.sol
@@ -371,11 +371,13 @@ interface IHub {
     /// @param poolId pool associated to this configuration.
     /// @param localAdapters Adapter addresses in this chain.
     /// @param remoteAdapters Adapter addresses in the remote chain.
+    /// @param threshold Minimum number of adapters required to process the messages
     function setAdapters(
         uint16 centrifugeId,
         PoolId poolId,
         IAdapter[] memory localAdapters,
-        bytes32[] memory remoteAdapters
+        bytes32[] memory remoteAdapters,
+        uint8 threshold
     ) external payable;
 
     /// @notice Set an adapters manager for a pool. The manager can modify adapter-related things in the remote chain.

--- a/src/misc/libraries/ArrayLib.sol
+++ b/src/misc/libraries/ArrayLib.sol
@@ -3,34 +3,15 @@ pragma solidity 0.8.28;
 
 /// @title  ArrayLib
 library ArrayLib {
-    error InvalidValues();
-
-    function countNonZeroValues(uint16[8] memory arr) internal pure returns (uint8 count) {
-        uint256 elementsCount = arr.length;
-        for (uint256 i; i < elementsCount; i++) {
-            if (arr[i] != 0) ++count;
+    function countPositiveValues(int16[8] memory arr, uint8 numValues) internal pure returns (uint8 count) {
+        for (uint256 i; i < numValues; i++) {
+            if (arr[i] > 0) ++count;
         }
     }
 
-    function decreaseFirstNValues(uint16[8] storage arr, uint8 numValues) internal {
-        uint256 elementsCount = arr.length;
-        for (uint256 i; i < elementsCount; i++) {
-            if (numValues == 0) return;
-
-            if (arr[i] != 0) {
-                arr[i] -= 1;
-                numValues--;
-            }
+    function decreaseFirstNValues(int16[8] storage arr, uint8 numValues) internal {
+        for (uint256 i; i < numValues; i++) {
+            arr[i] -= 1;
         }
-
-        require(numValues == 0, InvalidValues());
-    }
-
-    function isEmpty(uint16[8] memory arr) internal pure returns (bool) {
-        uint256 elementsCount = arr.length;
-        for (uint256 i; i < elementsCount; i++) {
-            if (arr[i] != 0) return false;
-        }
-        return true;
     }
 }

--- a/test/common/unit/Guardian.t.sol
+++ b/test/common/unit/Guardian.t.sol
@@ -243,12 +243,12 @@ contract GuardianTestSetAdapters is GuardianTest {
 
         vm.mockCall(
             address(multiAdapter),
-            abi.encodeWithSelector(IMultiAdapter.setAdapters.selector, CENTRIFUGE_ID, POOL_0, adapters),
+            abi.encodeWithSelector(IMultiAdapter.setAdapters.selector, CENTRIFUGE_ID, POOL_0, adapters, 1),
             abi.encode()
         );
 
         vm.prank(address(SAFE));
-        guardian.setAdapters(CENTRIFUGE_ID, adapters);
+        guardian.setAdapters(CENTRIFUGE_ID, adapters, 1);
     }
 
     function testSetAdaptersOnlySafe() public {
@@ -257,7 +257,7 @@ contract GuardianTestSetAdapters is GuardianTest {
 
         vm.prank(UNAUTHORIZED);
         vm.expectRevert(IGuardian.NotTheAuthorizedSafe.selector);
-        guardian.setAdapters(CENTRIFUGE_ID, adapters);
+        guardian.setAdapters(CENTRIFUGE_ID, adapters, 1);
     }
 }
 

--- a/test/common/unit/libraries/MessageLib.t.sol
+++ b/test/common/unit/libraries/MessageLib.t.sol
@@ -211,13 +211,15 @@ contract TestMessageLibIdentities is Test {
         assertEq(a.serialize().messageSourceCentrifugeId(), AssetId.wrap(assetId).centrifugeId());
     }
 
-    function testSetPoolAdapters(uint64 poolId, bytes32[] memory adapterList) public pure {
+    function testSetPoolAdapters(uint64 poolId, uint8 threshold, bytes32[] memory adapterList) public pure {
         vm.assume(adapterList.length <= 20);
 
-        MessageLib.SetPoolAdapters memory a = MessageLib.SetPoolAdapters({poolId: poolId, adapterList: adapterList});
+        MessageLib.SetPoolAdapters memory a =
+            MessageLib.SetPoolAdapters({poolId: poolId, threshold: threshold, adapterList: adapterList});
         MessageLib.SetPoolAdapters memory b = MessageLib.deserializeSetPoolAdapters(a.serialize());
 
         assertEq(a.poolId, b.poolId);
+        assertEq(a.threshold, b.threshold);
         assertEq(a.adapterList, b.adapterList);
 
         assertEq(bytes(a.serialize()).length, a.serialize().messageLength());

--- a/test/hub/integration/BaseTest.sol
+++ b/test/hub/integration/BaseTest.sol
@@ -61,7 +61,7 @@ contract BaseTest is HubDeployer, Test {
         cv = new MockVaults(CHAIN_CV, multiAdapter);
         IAdapter[] memory adapters = new IAdapter[](1);
         adapters[0] = cv;
-        multiAdapter.setAdapters(CHAIN_CV, PoolId.wrap(0), adapters);
+        multiAdapter.setAdapters(CHAIN_CV, PoolId.wrap(0), adapters, uint8(adapters.length));
 
         valuation = new MockValuation(hubRegistry);
 

--- a/test/hub/unit/Hub.t.sol
+++ b/test/hub/unit/Hub.t.sol
@@ -203,7 +203,7 @@ contract TestMainMethodsChecks is TestCommon {
         hub.updateJournal(POOL_A, EMPTY, EMPTY);
 
         vm.expectRevert(IHub.NotManager.selector);
-        hub.setAdapters(0, POOL_A, new IAdapter[](0), new bytes32[](0));
+        hub.setAdapters(0, POOL_A, new IAdapter[](0), new bytes32[](0), 0);
 
         vm.expectRevert(IHub.NotManager.selector);
         hub.setAdaptersManager(0, POOL_A, bytes32(0));

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -226,7 +226,7 @@ contract EndToEndDeployment is Test {
         vm.startPrank(address(deploy.guardian().safe()));
         IAdapter[] memory adapters = new IAdapter[](1);
         adapters[0] = adapter;
-        deploy.guardian().setAdapters(remoteCentrifugeId, adapters);
+        deploy.guardian().setAdapters(remoteCentrifugeId, adapters, uint8(adapters.length));
         deploy.guardian().setAdaptersManager(MULTI_ADAPTER_MANAGER);
         vm.stopPrank();
     }
@@ -499,7 +499,7 @@ contract EndToEndFlows is EndToEndUtils {
         remoteAdapters[0] = address(poolAdapterBToA).toBytes32();
 
         vm.startPrank(FM);
-        h.hub.setAdapters{value: GAS}(s.centrifugeId, POOL_A, localAdapters, remoteAdapters);
+        h.hub.setAdapters{value: GAS}(s.centrifugeId, POOL_A, localAdapters, remoteAdapters, 1);
         h.hub.setAdaptersManager{value: GAS}(h.centrifugeId, POOL_A, MULTI_ADAPTER_MANAGER.toBytes32());
         h.hub.setAdaptersManager{value: GAS}(s.centrifugeId, POOL_A, MULTI_ADAPTER_MANAGER.toBytes32());
     }
@@ -1383,6 +1383,6 @@ contract EndToEndUseCases is EndToEndFlows, VMLabeling {
         }
 
         vm.startPrank(FM);
-        h.hub.setAdapters{value: GAS}(s.centrifugeId, POOL_A, localAdapters, remoteAdapters);
+        h.hub.setAdapters{value: GAS}(s.centrifugeId, POOL_A, localAdapters, remoteAdapters, 1);
     }
 }

--- a/test/misc/unit/libraries/ArrayLib.t.sol
+++ b/test/misc/unit/libraries/ArrayLib.t.sol
@@ -6,62 +6,35 @@ import {ArrayLib} from "../../../../src/misc/libraries/ArrayLib.sol";
 import "forge-std/Test.sol";
 
 contract ArrayLibTest is Test {
-    // Used for testDecreaseFirstNValues (which requires storage pointers)
-    uint16[8] initialArray;
-    uint16[8] decreasedArray;
+    using ArrayLib for *;
 
-    function testCountNonZeroValues(uint8 numNonZeroes) public view {
-        numNonZeroes = uint8(bound(numNonZeroes, 0, 8));
-        uint16[8] memory arr = _randomArray(numNonZeroes);
+    int16[8] storedArray;
 
-        assertEq(ArrayLib.countNonZeroValues(arr), numNonZeroes);
-    }
+    function testCountPositiveValues(int16[8] memory array, uint8 valuesToCheck) public pure {
+        vm.assume(valuesToCheck <= 8);
 
-    function testDecreaseFirstNValues(uint8 numValuesToDecrease) public {
-        numValuesToDecrease = uint8(bound(numValuesToDecrease, 0, 8));
-
-        initialArray = _randomArray(8);
-        decreasedArray = initialArray;
-        uint8 numNonZeroes = ArrayLib.countNonZeroValues(initialArray);
-
-        // Decreasing by 1 should reduce by min(numNonZeroes, numValuesToDecrease) since zero values cannot be decreased
-        ArrayLib.decreaseFirstNValues(decreasedArray, numValuesToDecrease);
-        assertEq(_count(initialArray) - _count(decreasedArray), _min(numNonZeroes, numValuesToDecrease));
-    }
-
-    function testIsEmpty(uint8 numNonZeroes) public view {
-        numNonZeroes = uint8(bound(numNonZeroes, 0, 8));
-        uint16[8] memory arr = _randomArray(numNonZeroes);
-
-        // Array is only empty if there are no zeros
-        assertEq(ArrayLib.isEmpty(arr), numNonZeroes == 0);
-    }
-
-    function _randomArray(uint8 numNonZeroes) internal view returns (uint16[8] memory arr) {
-        for (uint256 i; i < numNonZeroes; i++) {
-            arr[i] = _randomUint16(1, type(uint16).max);
+        uint8 negativeOrZero;
+        for (uint256 i; i < valuesToCheck; i++) {
+            if (array[i] <= 0) negativeOrZero++;
         }
+
+        assertEq(array.countPositiveValues(valuesToCheck), valuesToCheck - negativeOrZero);
     }
 
-    function _min(uint256 a, uint256 b) internal pure returns (uint256) {
-        return a > b ? b : a;
+    function testDecreaseFirstNValues(int16[8] memory initialArray, uint8 valuesToDecrease) public {
+        vm.assume(valuesToDecrease <= 8);
+        for (uint256 i; i < valuesToDecrease; i++) {
+            vm.assume(initialArray[i] > type(int16).min);
+        }
+        storedArray = initialArray;
+        storedArray.decreaseFirstNValues(valuesToDecrease);
+
+        assertEq(uint8(int8(_sum(initialArray) - _sum(storedArray))), valuesToDecrease);
     }
 
-    function _count(uint16[8] memory arr) internal pure returns (uint256 count) {
+    function _sum(int16[8] memory arr) internal pure returns (int256 count) {
         for (uint256 i; i < arr.length; i++) {
-            count += uint8(arr[i]);
+            count += int256(arr[i]);
         }
-    }
-
-    function _randomUint16(uint16 minValue, uint16 maxValue) internal view returns (uint16) {
-        uint256 nonce = 1;
-
-        if (maxValue == 1) {
-            return 1;
-        }
-
-        uint16 value =
-            uint16(uint256(keccak256(abi.encodePacked(block.timestamp, address(this), nonce))) % (maxValue - minValue));
-        return value + minValue;
     }
 }

--- a/test/spoke/integration/BaseTest.sol
+++ b/test/spoke/integration/BaseTest.sol
@@ -103,7 +103,7 @@ contract BaseTest is ExtendedSpokeDeployer, Test, ExtendedSpokeActionBatcher {
         erc20 = _newErc20("X's Dollar", "USDX", 6);
         erc6909 = new MockERC6909();
 
-        multiAdapter.setAdapters(OTHER_CHAIN_ID, PoolId.wrap(0), testAdapters);
+        multiAdapter.setAdapters(OTHER_CHAIN_ID, PoolId.wrap(0), testAdapters, uint8(testAdapters.length));
 
         // We should not use the block ChainID
         vm.chainId(BLOCK_CHAIN_ID);


### PR DESCRIPTION
Thread: https://kflabs.slack.com/archives/C07PG2EUR9C/p1756461367469699?thread_ts=1756404586.718779&cid=C07PG2EUR9C

The recovery removal in favor of recovery adapters and moving the `blockOutgoing` feature to the `Gateway` will go in future PRs.