### PR TITLE
Feat: recovery adapters support

### DIFF
--- a/script/WireAdapters.s.sol
+++ b/script/WireAdapters.s.sol
@@ -67,7 +67,7 @@ contract WireAdapters is Script {
 
             // Register ALL adapters for this destination chain
             IGuardian guardian = IGuardian(vm.parseJsonAddress(localConfig, "$.contracts.guardian"));
-            guardian.setAdapters(remoteCentrifugeId, adapters, uint8(adapters.length));
+            guardian.setAdapters(remoteCentrifugeId, adapters, uint8(adapters.length), uint8(adapters.length));
             console.log("Registered MultiAdapter(", localNetwork, ") for", remoteNetwork);
 
             // Wire WormholeAdapter

--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
-  "fulfillDepositRequest": "788507",
-  "requestDeposit": "667908"
+  "fulfillDepositRequest": "789775",
+  "requestDeposit": "667930"
 }

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -1,7 +1,7 @@
 {
-  "claimDeposit": "954003",
+  "claimDeposit": "955271",
   "enable": "60931",
   "lockDepositRequest": "95582",
-  "requestDeposit": "707288",
-  "requestRedeem": "2140874"
+  "requestDeposit": "707310",
+  "requestRedeem": "2142186"
 }

--- a/src/common/Guardian.sol
+++ b/src/common/Guardian.sol
@@ -106,8 +106,11 @@ contract Guardian is IGuardian {
     }
 
     /// @inheritdoc IGuardian
-    function setAdapters(uint16 centrifugeId, IAdapter[] calldata adapters, uint8 threshold) external onlySafe {
-        multiAdapter.setAdapters(centrifugeId, PoolId.wrap(0), adapters, threshold);
+    function setAdapters(uint16 centrifugeId, IAdapter[] calldata adapters, uint8 threshold, uint8 recoveryIndex)
+        external
+        onlySafe
+    {
+        multiAdapter.setAdapters(centrifugeId, PoolId.wrap(0), adapters, threshold, recoveryIndex);
     }
 
     /// @inheritdoc IGuardian

--- a/src/common/MessageDispatcher.sol
+++ b/src/common/MessageDispatcher.sol
@@ -537,16 +537,24 @@ contract MessageDispatcher is Auth, IMessageDispatcher {
     }
 
     /// @inheritdoc IHubMessageSender
-    function sendSetPoolAdapters(uint16 centrifugeId, PoolId poolId, bytes32[] memory adapters, uint8 threshold)
-        external
-    {
+    function sendSetPoolAdapters(
+        uint16 centrifugeId,
+        PoolId poolId,
+        bytes32[] memory adapters,
+        uint8 threshold,
+        uint8 recoveryIndex
+    ) external {
         if (centrifugeId == localCentrifugeId) {
             revert CannotBeSentLocally();
         } else {
             gateway.send(
                 centrifugeId,
-                MessageLib.SetPoolAdapters({poolId: poolId.raw(), threshold: threshold, adapterList: adapters})
-                    .serialize()
+                MessageLib.SetPoolAdapters({
+                    poolId: poolId.raw(),
+                    threshold: threshold,
+                    recoveryIndex: recoveryIndex,
+                    adapterList: adapters
+                }).serialize()
             );
         }
     }

--- a/src/common/MessageProcessor.sol
+++ b/src/common/MessageProcessor.sol
@@ -92,7 +92,7 @@ contract MessageProcessor is Auth, IMessageProcessor {
             for (uint256 i; i < adapters.length; i++) {
                 adapters[i] = IAdapter(m.adapterList[i].toAddress());
             }
-            multiAdapter.setAdapters(centrifugeId, PoolId.wrap(m.poolId), adapters, m.threshold);
+            multiAdapter.setAdapters(centrifugeId, PoolId.wrap(m.poolId), adapters, m.threshold, m.recoveryIndex);
         } else if (kind == MessageType.SetPoolAdaptersManager) {
             MessageLib.SetPoolAdaptersManager memory m = message.deserializeSetPoolAdaptersManager();
             multiAdapter.setManager(PoolId.wrap(m.poolId), m.manager.toAddress());

--- a/src/common/MultiAdapter.sol
+++ b/src/common/MultiAdapter.sol
@@ -57,14 +57,18 @@ contract MultiAdapter is Auth, IMultiAdapter {
     }
 
     /// @inheritdoc IMultiAdapter
-    function setAdapters(uint16 centrifugeId, PoolId poolId, IAdapter[] calldata addresses, uint8 threshold_)
-        external
-        auth
-    {
+    function setAdapters(
+        uint16 centrifugeId,
+        PoolId poolId,
+        IAdapter[] calldata addresses,
+        uint8 threshold_,
+        uint8 recoveryIndex_
+    ) external auth {
         uint8 quorum_ = addresses.length.toUint8();
         require(quorum_ != 0, EmptyAdapterSet());
         require(quorum_ <= MAX_ADAPTER_COUNT, ExceedsMax());
         require(threshold_ <= quorum_, ThresholdHigherThanQuorum());
+        require(recoveryIndex_ <= quorum_, RecoveryIndexHigherThanQuorum());
 
         // Increment session id to reset pending votes
         uint256 numAdapters = adapters[centrifugeId][poolId].length;
@@ -82,11 +86,12 @@ contract MultiAdapter is Auth, IMultiAdapter {
             require(_adapterDetails[centrifugeId][poolId][addresses[j]].id == 0, NoDuplicatesAllowed());
 
             // Ids are assigned sequentially starting at 1
-            _adapterDetails[centrifugeId][poolId][addresses[j]] = Adapter(j + 1, quorum_, threshold_, sessionId);
+            _adapterDetails[centrifugeId][poolId][addresses[j]] =
+                Adapter(j + 1, quorum_, threshold_, recoveryIndex_, sessionId);
         }
 
         adapters[centrifugeId][poolId] = addresses;
-        emit SetAdapters(centrifugeId, poolId, addresses, threshold_);
+        emit SetAdapters(centrifugeId, poolId, addresses, threshold_, recoveryIndex_);
     }
 
     /// @inheritdoc IMultiAdapter
@@ -138,7 +143,7 @@ contract MultiAdapter is Auth, IMultiAdapter {
 
         if (state.votes.countPositiveValues(adapter.quorum) >= adapter.threshold) {
             // Reduce votes by quorum
-            state.votes.decreaseFirstNValues(adapter.quorum);
+            state.votes.decreaseFirstNValues(adapter.quorum, adapter.recoveryIndex);
 
             gateway.handle(centrifugeId, payload);
         }
@@ -220,6 +225,12 @@ contract MultiAdapter is Auth, IMultiAdapter {
     function threshold(uint16 centrifugeId, PoolId poolId) external view returns (uint8) {
         IAdapter adapter = adapters[centrifugeId][poolId][0];
         return _adapterDetails[centrifugeId][poolId][adapter].threshold;
+    }
+
+    /// @inheritdoc IMultiAdapter
+    function recoveryIndex(uint16 centrifugeId, PoolId poolId) external view returns (uint8) {
+        IAdapter adapter = adapters[centrifugeId][poolId][0];
+        return _adapterDetails[centrifugeId][poolId][adapter].recoveryIndex;
     }
 
     /// @inheritdoc IMultiAdapter

--- a/src/common/interfaces/IGatewaySenders.sol
+++ b/src/common/interfaces/IGatewaySenders.sol
@@ -132,8 +132,13 @@ interface IHubMessageSender is ILocalCentrifugeId {
     ) external;
 
     /// @notice Creates and send the message
-    function sendSetPoolAdapters(uint16 centrifugeId, PoolId poolId, bytes32[] memory adapters, uint8 threshold)
-        external;
+    function sendSetPoolAdapters(
+        uint16 centrifugeId,
+        PoolId poolId,
+        bytes32[] memory adapters,
+        uint8 threshold,
+        uint8 recoveryIndex
+    ) external;
 
     /// @notice Creates and send the message
     function sendSetPoolAdaptersManager(uint16 centrifugeId, PoolId poolId, bytes32 manager) external;

--- a/src/common/interfaces/IGuardian.sol
+++ b/src/common/interfaces/IGuardian.sol
@@ -67,12 +67,9 @@ interface IGuardian {
         uint256 amount
     ) external;
 
-    /// @notice Set adapters into MultiAdapter.
-    /// @dev The adapters must be previously deployed and wired.
-    /// @param centrifugeId The destination chain ID to wire adapters for
-    /// @param adapters Array of adapter addresses to register with MultiAdapter
-    /// @param  threshold Minimum number of adapters required to process the messages
-    function setAdapters(uint16 centrifugeId, IAdapter[] calldata adapters, uint8 threshold) external;
+    /// @notice Set adapters into MultiAdapter. Check IMultiAdapter docs
+    function setAdapters(uint16 centrifugeId, IAdapter[] calldata adapters, uint8 threshold, uint8 recoveryIndex)
+        external;
 
     /// @notice Set an adapters manager for the global adaters.
     /// @param manager address able to recover messages in the `centrifugeId` chain or pause sending messages

--- a/src/common/libraries/MessageLib.sol
+++ b/src/common/libraries/MessageLib.sol
@@ -73,7 +73,7 @@ library MessageLib {
         (33  << uint8(MessageType.CancelUpgrade) * 8) +
         (161 << uint8(MessageType.RecoverTokens) * 8) +
         (18  << uint8(MessageType.RegisterAsset) * 8) +
-        (12  << uint8(MessageType.SetPoolAdapters) * 8) +
+        (13  << uint8(MessageType.SetPoolAdapters) * 8) +
         (41  << uint8(MessageType.SetPoolAdaptersManager) * 8) +
         (0   << uint8(MessageType._Placeholder7) * 8) +
         (0   << uint8(MessageType._Placeholder8) * 8) +
@@ -133,7 +133,7 @@ library MessageLib {
         } else if (kind == uint8(MessageType.RequestCallback)) {
             length += 2 + message.toUint16(length); //payloadLength
         } else if (kind == uint8(MessageType.SetPoolAdapters)) {
-            length += message.toUint16(10) * 32; // message with variable length
+            length += message.toUint16(11) * 32; // message with variable length
         }
     }
 
@@ -266,24 +266,35 @@ library MessageLib {
     struct SetPoolAdapters {
         uint64 poolId;
         uint8 threshold;
+        uint8 recoveryIndex;
         bytes32[] adapterList;
     }
 
     function deserializeSetPoolAdapters(bytes memory data) internal pure returns (SetPoolAdapters memory) {
         require(messageType(data) == MessageType.SetPoolAdapters, UnknownMessageType());
 
-        uint16 length = data.toUint16(10);
+        uint16 length = data.toUint16(11);
         bytes32[] memory adapterList = new bytes32[](length);
         for (uint256 i; i < length; i++) {
-            adapterList[i] = data.toBytes32(12 + i * 32);
+            adapterList[i] = data.toBytes32(13 + i * 32);
         }
 
-        return SetPoolAdapters({poolId: data.toUint64(1), threshold: data.toUint8(9), adapterList: adapterList});
+        return SetPoolAdapters({
+            poolId: data.toUint64(1),
+            threshold: data.toUint8(9),
+            recoveryIndex: data.toUint8(10),
+            adapterList: adapterList
+        });
     }
 
     function serialize(SetPoolAdapters memory t) internal pure returns (bytes memory) {
         return abi.encodePacked(
-            MessageType.SetPoolAdapters, t.poolId, t.threshold, t.adapterList.length.toUint16(), t.adapterList
+            MessageType.SetPoolAdapters,
+            t.poolId,
+            t.threshold,
+            t.recoveryIndex,
+            t.adapterList.length.toUint16(),
+            t.adapterList
         );
     }
 

--- a/src/hub/Hub.sol
+++ b/src/hub/Hub.sol
@@ -659,13 +659,14 @@ contract Hub is Multicall, Auth, Recoverable, IHub, IHubGatewayHandler, IHubGuar
         PoolId poolId,
         IAdapter[] memory localAdapters,
         bytes32[] memory remoteAdapters,
-        uint8 threshold
+        uint8 threshold,
+        uint8 recoveryIndex
     ) external payable payTransaction {
         _isManager(poolId);
 
-        multiAdapter.setAdapters(centrifugeId, poolId, localAdapters, threshold);
+        multiAdapter.setAdapters(centrifugeId, poolId, localAdapters, threshold, recoveryIndex);
 
-        sender.sendSetPoolAdapters(centrifugeId, poolId, remoteAdapters, threshold);
+        sender.sendSetPoolAdapters(centrifugeId, poolId, remoteAdapters, threshold, recoveryIndex);
     }
 
     /// @inheritdoc IHub

--- a/src/hub/interfaces/IHub.sol
+++ b/src/hub/interfaces/IHub.sol
@@ -367,17 +367,21 @@ interface IHub {
 
     /// @notice Set adapters for a pool in another chain. Pool related message will go by these adapters.
     ///         The adapters should already be deployed and wired.
-    /// @param centrifugeId chain where to perform the adapter configuration.
-    /// @param poolId pool associated to this configuration.
-    /// @param localAdapters Adapter addresses in this chain.
-    /// @param remoteAdapters Adapter addresses in the remote chain.
-    /// @param threshold Minimum number of adapters required to process the messages
+    /// @param  centrifugeId chain where to perform the adapter configuration.
+    /// @param  poolId pool associated to this configuration.
+    /// @param  localAdapters Adapter addresses in this chain.
+    /// @param  remoteAdapters Adapter addresses in the remote chain.
+    /// @param  threshold Minimum number of adapters required to process the messages
+    ///         If not wanted a threshold set `adapters.length` value
+    /// @param  recoveryIndex Index in adapters array from where consider the adapter as recovery adapter.
+    ///         If not wanted a recoveryIndex set `adapters.length` value
     function setAdapters(
         uint16 centrifugeId,
         PoolId poolId,
         IAdapter[] memory localAdapters,
         bytes32[] memory remoteAdapters,
-        uint8 threshold
+        uint8 threshold,
+        uint8 recoveryIndex
     ) external payable;
 
     /// @notice Set an adapters manager for a pool. The manager can modify adapter-related things in the remote chain.

--- a/src/misc/libraries/ArrayLib.sol
+++ b/src/misc/libraries/ArrayLib.sol
@@ -9,8 +9,9 @@ library ArrayLib {
         }
     }
 
-    function decreaseFirstNValues(int16[8] storage arr, uint8 numValues) internal {
+    function decreaseFirstNValues(int16[8] storage arr, uint8 numValues, uint8 numValuesLowerZero) internal {
         for (uint256 i; i < numValues; i++) {
+            if (i >= numValuesLowerZero && arr[i] <= 0) break;
             arr[i] -= 1;
         }
     }

--- a/test/common/unit/Guardian.t.sol
+++ b/test/common/unit/Guardian.t.sol
@@ -243,12 +243,12 @@ contract GuardianTestSetAdapters is GuardianTest {
 
         vm.mockCall(
             address(multiAdapter),
-            abi.encodeWithSelector(IMultiAdapter.setAdapters.selector, CENTRIFUGE_ID, POOL_0, adapters, 1),
+            abi.encodeWithSelector(IMultiAdapter.setAdapters.selector, CENTRIFUGE_ID, POOL_0, adapters, 1, 2),
             abi.encode()
         );
 
         vm.prank(address(SAFE));
-        guardian.setAdapters(CENTRIFUGE_ID, adapters, 1);
+        guardian.setAdapters(CENTRIFUGE_ID, adapters, 1, 2);
     }
 
     function testSetAdaptersOnlySafe() public {
@@ -257,7 +257,7 @@ contract GuardianTestSetAdapters is GuardianTest {
 
         vm.prank(UNAUTHORIZED);
         vm.expectRevert(IGuardian.NotTheAuthorizedSafe.selector);
-        guardian.setAdapters(CENTRIFUGE_ID, adapters, 1);
+        guardian.setAdapters(CENTRIFUGE_ID, adapters, 1, 2);
     }
 }
 

--- a/test/common/unit/MultiAdapter.t.sol
+++ b/test/common/unit/MultiAdapter.t.sol
@@ -172,23 +172,30 @@ contract MultiAdapterTestSetAdapters is MultiAdapterTest {
     function testErrNotAuthorized() public {
         vm.prank(ANY);
         vm.expectRevert(IAuth.NotAuthorized.selector);
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, new IAdapter[](0), 0);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, new IAdapter[](0), 0, 0);
     }
 
     function testErrEmptyAdapterFile() public {
         vm.expectRevert(IMultiAdapter.EmptyAdapterSet.selector);
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, new IAdapter[](0), 0);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, new IAdapter[](0), 0, 0);
     }
 
     function testErrExceedsMax() public {
         IAdapter[] memory tooMuchAdapters = new IAdapter[](MAX_ADAPTER_COUNT + 1);
         vm.expectRevert(IMultiAdapter.ExceedsMax.selector);
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, tooMuchAdapters, uint8(tooMuchAdapters.length));
+        multiAdapter.setAdapters(
+            REMOTE_CENT_ID, POOL_A, tooMuchAdapters, uint8(tooMuchAdapters.length), uint8(tooMuchAdapters.length)
+        );
     }
 
     function testErrThresholdHigherThanQuorum() public {
         vm.expectRevert(IMultiAdapter.ThresholdHigherThanQuorum.selector);
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, uint8(threeAdapters.length + 1));
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, uint8(threeAdapters.length + 1), 0);
+    }
+
+    function testErrRecoveryIndexHigherThanQuorum() public {
+        vm.expectRevert(IMultiAdapter.RecoveryIndexHigherThanQuorum.selector);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 0, uint8(threeAdapters.length + 1));
     }
 
     function testErrNoDuplicatedAllowed() public {
@@ -197,16 +204,18 @@ contract MultiAdapterTestSetAdapters is MultiAdapterTest {
         duplicatedAdapters[1] = IAdapter(address(10));
 
         vm.expectRevert(IMultiAdapter.NoDuplicatesAllowed.selector);
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, duplicatedAdapters, uint8(duplicatedAdapters.length));
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, duplicatedAdapters, 0, 0);
     }
 
     function testMultiAdapterSetAdapters() public {
         vm.expectEmit();
-        emit IMultiAdapter.SetAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, uint8(threeAdapters.length));
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, uint8(threeAdapters.length));
+        emit IMultiAdapter.SetAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 1, 2);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 1, 2);
 
         assertEq(multiAdapter.activeSessionId(REMOTE_CENT_ID, POOL_A), 0);
         assertEq(multiAdapter.quorum(REMOTE_CENT_ID, POOL_A), threeAdapters.length);
+        assertEq(multiAdapter.threshold(REMOTE_CENT_ID, POOL_A), 1);
+        assertEq(multiAdapter.recoveryIndex(REMOTE_CENT_ID, POOL_A), 2);
 
         for (uint256 i; i < threeAdapters.length; i++) {
             IMultiAdapter.Adapter memory adapter = multiAdapter.adapterDetails(REMOTE_CENT_ID, POOL_A, threeAdapters[i]);
@@ -219,14 +228,14 @@ contract MultiAdapterTestSetAdapters is MultiAdapterTest {
     }
 
     function testMultiAdapterSetAdaptersAdvanceSession() public {
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3, 3);
         assertEq(multiAdapter.activeSessionId(REMOTE_CENT_ID, POOL_A), 0);
 
         // Using another chain uses a different active session counter
-        multiAdapter.setAdapters(LOCAL_CENT_ID, POOL_A, threeAdapters, 3);
+        multiAdapter.setAdapters(LOCAL_CENT_ID, POOL_A, threeAdapters, 3, 3);
         assertEq(multiAdapter.activeSessionId(LOCAL_CENT_ID, POOL_A), 0);
 
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3, 3);
         assertEq(multiAdapter.activeSessionId(REMOTE_CENT_ID, POOL_A), 1);
     }
 }
@@ -255,7 +264,7 @@ contract MultiAdapterTestHandle is MultiAdapterTest {
 
     function testMessageWithOneAdapterButPoolANoConfigured() public {
         // POOL_A is not configured, and MESSAGE_1 comes from POOL_A, but it works because POOL_0 is the default
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_0, oneAdapter, 1);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_0, oneAdapter, 1, 1);
 
         vm.prank(address(adapter1));
         multiAdapter.handle(REMOTE_CENT_ID, MESSAGE_1);
@@ -264,7 +273,7 @@ contract MultiAdapterTestHandle is MultiAdapterTest {
     }
 
     function testMessageWithSeveralAdapters() public {
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3, 3);
 
         bytes32 payloadId = keccak256(abi.encodePacked(REMOTE_CENT_ID, LOCAL_CENT_ID, keccak256(MESSAGE_1)));
 
@@ -292,7 +301,7 @@ contract MultiAdapterTestHandle is MultiAdapterTest {
     }
 
     function testSameMessageAgainWithSeveralAdapters() public {
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3, 3);
 
         vm.prank(address(adapter1));
         multiAdapter.handle(REMOTE_CENT_ID, MESSAGE_1);
@@ -319,7 +328,7 @@ contract MultiAdapterTestHandle is MultiAdapterTest {
     }
 
     function testOtherMessageWithSeveralAdapters() public {
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3, 3);
 
         vm.prank(address(adapter1));
         multiAdapter.handle(REMOTE_CENT_ID, MESSAGE_1);
@@ -346,7 +355,7 @@ contract MultiAdapterTestHandle is MultiAdapterTest {
     }
 
     function testOneFasterAdapter() public {
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3, 3);
 
         vm.prank(address(adapter1));
         multiAdapter.handle(REMOTE_CENT_ID, MESSAGE_1);
@@ -377,14 +386,14 @@ contract MultiAdapterTestHandle is MultiAdapterTest {
     }
 
     function testVotesAfterNewSession() public {
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3, 3);
 
         vm.prank(address(adapter1));
         multiAdapter.handle(REMOTE_CENT_ID, MESSAGE_1);
         vm.prank(address(adapter2));
         multiAdapter.handle(REMOTE_CENT_ID, MESSAGE_1);
 
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3, 3);
 
         vm.prank(address(adapter3));
         multiAdapter.handle(REMOTE_CENT_ID, MESSAGE_1);
@@ -393,7 +402,7 @@ contract MultiAdapterTestHandle is MultiAdapterTest {
     }
 
     function testMessageWithThreshold2() public {
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 2);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 2, 3);
 
         vm.prank(address(adapter1));
         multiAdapter.handle(REMOTE_CENT_ID, MESSAGE_1);
@@ -412,7 +421,7 @@ contract MultiAdapterTestHandle is MultiAdapterTest {
     }
 
     function testSameMessageWithThreshold2() public {
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 2);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 2, 3);
 
         vm.prank(address(adapter1));
         multiAdapter.handle(REMOTE_CENT_ID, MESSAGE_1);
@@ -441,7 +450,7 @@ contract MultiAdapterTestHandle is MultiAdapterTest {
     }
 
     function testSameMessageWithThreshold1() public {
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 1);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 1, 3);
 
         vm.prank(address(adapter1));
         multiAdapter.handle(REMOTE_CENT_ID, MESSAGE_1);
@@ -468,6 +477,30 @@ contract MultiAdapterTestHandle is MultiAdapterTest {
         assertEq(gateway.count(REMOTE_CENT_ID), 3);
         assertVotes(MESSAGE_1, -1, 0, -3);
     }
+
+    function testMessageWithThreshold2AndRecovery2() public {
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 2, 2);
+
+        vm.prank(address(adapter1));
+        multiAdapter.handle(REMOTE_CENT_ID, MESSAGE_1);
+        assertEq(gateway.count(REMOTE_CENT_ID), 0);
+        assertVotes(MESSAGE_1, 1, 0, 0);
+
+        vm.prank(address(adapter2));
+        multiAdapter.handle(REMOTE_CENT_ID, MESSAGE_1);
+        assertEq(gateway.count(REMOTE_CENT_ID), 1);
+        assertVotes(MESSAGE_1, 0, 0, 0); // <- vote from third adapter does not decrease below 0
+
+        vm.prank(address(adapter3));
+        multiAdapter.handle(REMOTE_CENT_ID, MESSAGE_1);
+        assertEq(gateway.count(REMOTE_CENT_ID), 1);
+        assertVotes(MESSAGE_1, 0, 0, 1);
+
+        vm.prank(address(adapter1));
+        multiAdapter.handle(REMOTE_CENT_ID, MESSAGE_1);
+        assertEq(gateway.count(REMOTE_CENT_ID), 2);
+        assertVotes(MESSAGE_1, 0, -1, 0);
+    }
 }
 
 contract MultiAdapterTestExecute is MultiAdapterTest {
@@ -478,7 +511,7 @@ contract MultiAdapterTestExecute is MultiAdapterTest {
     }
 
     function testExecute() public {
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, oneAdapter, 1);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, oneAdapter, 1, 1);
         multiAdapter.setManager(POOL_A, MANAGER);
 
         vm.prank(MANAGER);
@@ -489,7 +522,7 @@ contract MultiAdapterTestExecute is MultiAdapterTest {
     }
 
     function testExecuteWithSeveralAdapters() public {
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3, 3);
         multiAdapter.setManager(POOL_A, MANAGER);
 
         vm.startPrank(MANAGER);
@@ -519,7 +552,7 @@ contract MultiAdapterTestSend is MultiAdapterTest {
     }
 
     function testErrSendingBlocked() public {
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, oneAdapter, 1);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, oneAdapter, 1, 1);
         multiAdapter.setManager(POOL_A, MANAGER);
 
         vm.prank(MANAGER);
@@ -531,7 +564,7 @@ contract MultiAdapterTestSend is MultiAdapterTest {
     }
 
     function testSendMessage() public {
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3, 3);
 
         bytes32 payloadId = keccak256(abi.encodePacked(LOCAL_CENT_ID, REMOTE_CENT_ID, keccak256(MESSAGE_1)));
 
@@ -552,7 +585,7 @@ contract MultiAdapterTestSend is MultiAdapterTest {
 
     function testSendMessageButPoolANotConfigured() public {
         // POOL_A is not configured, and MESSAGE_1 is send from POOL_A, but it works because POOL_0 is the default
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_0, oneAdapter, 1);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_0, oneAdapter, 1, 1);
 
         _mockAdapter(adapter1, MESSAGE_1, ADAPTER_ESTIMATE_1, ADAPTER_DATA_1);
 
@@ -567,7 +600,7 @@ contract MultiAdapterTestEstimate is MultiAdapterTest {
     }
 
     function testEstimate() public {
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_A, threeAdapters, 3, 3);
 
         _mockAdapter(adapter1, MESSAGE_1, ADAPTER_ESTIMATE_1, ADAPTER_DATA_1);
         _mockAdapter(adapter2, MESSAGE_1, ADAPTER_ESTIMATE_2, ADAPTER_DATA_2);
@@ -580,7 +613,7 @@ contract MultiAdapterTestEstimate is MultiAdapterTest {
 
     function testEstimateButPoolANotConfigured() public {
         // POOL_A is not configured, and MESSAGE_1 is from POOL_A, but it works because POOL_0 is the default
-        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_0, threeAdapters, 3);
+        multiAdapter.setAdapters(REMOTE_CENT_ID, POOL_0, threeAdapters, 3, 3);
 
         _mockAdapter(adapter1, MESSAGE_1, ADAPTER_ESTIMATE_1, ADAPTER_DATA_1);
         _mockAdapter(adapter2, MESSAGE_1, ADAPTER_ESTIMATE_2, ADAPTER_DATA_2);

--- a/test/common/unit/libraries/MessageLib.t.sol
+++ b/test/common/unit/libraries/MessageLib.t.sol
@@ -211,15 +211,23 @@ contract TestMessageLibIdentities is Test {
         assertEq(a.serialize().messageSourceCentrifugeId(), AssetId.wrap(assetId).centrifugeId());
     }
 
-    function testSetPoolAdapters(uint64 poolId, uint8 threshold, bytes32[] memory adapterList) public pure {
+    function testSetPoolAdapters(uint64 poolId, uint8 threshold, uint8 recoveryIndex, bytes32[] memory adapterList)
+        public
+        pure
+    {
         vm.assume(adapterList.length <= 20);
 
-        MessageLib.SetPoolAdapters memory a =
-            MessageLib.SetPoolAdapters({poolId: poolId, threshold: threshold, adapterList: adapterList});
+        MessageLib.SetPoolAdapters memory a = MessageLib.SetPoolAdapters({
+            poolId: poolId,
+            threshold: threshold,
+            recoveryIndex: recoveryIndex,
+            adapterList: adapterList
+        });
         MessageLib.SetPoolAdapters memory b = MessageLib.deserializeSetPoolAdapters(a.serialize());
 
         assertEq(a.poolId, b.poolId);
         assertEq(a.threshold, b.threshold);
+        assertEq(a.recoveryIndex, b.recoveryIndex);
         assertEq(a.adapterList, b.adapterList);
 
         assertEq(bytes(a.serialize()).length, a.serialize().messageLength());

--- a/test/hub/integration/BaseTest.sol
+++ b/test/hub/integration/BaseTest.sol
@@ -61,7 +61,7 @@ contract BaseTest is HubDeployer, Test {
         cv = new MockVaults(CHAIN_CV, multiAdapter);
         IAdapter[] memory adapters = new IAdapter[](1);
         adapters[0] = cv;
-        multiAdapter.setAdapters(CHAIN_CV, PoolId.wrap(0), adapters, uint8(adapters.length));
+        multiAdapter.setAdapters(CHAIN_CV, PoolId.wrap(0), adapters, uint8(adapters.length), uint8(adapters.length));
 
         valuation = new MockValuation(hubRegistry);
 

--- a/test/hub/unit/Hub.t.sol
+++ b/test/hub/unit/Hub.t.sol
@@ -203,7 +203,7 @@ contract TestMainMethodsChecks is TestCommon {
         hub.updateJournal(POOL_A, EMPTY, EMPTY);
 
         vm.expectRevert(IHub.NotManager.selector);
-        hub.setAdapters(0, POOL_A, new IAdapter[](0), new bytes32[](0), 0);
+        hub.setAdapters(0, POOL_A, new IAdapter[](0), new bytes32[](0), 0, 0);
 
         vm.expectRevert(IHub.NotManager.selector);
         hub.setAdaptersManager(0, POOL_A, bytes32(0));

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -226,7 +226,7 @@ contract EndToEndDeployment is Test {
         vm.startPrank(address(deploy.guardian().safe()));
         IAdapter[] memory adapters = new IAdapter[](1);
         adapters[0] = adapter;
-        deploy.guardian().setAdapters(remoteCentrifugeId, adapters, uint8(adapters.length));
+        deploy.guardian().setAdapters(remoteCentrifugeId, adapters, uint8(adapters.length), uint8(adapters.length));
         deploy.guardian().setAdaptersManager(MULTI_ADAPTER_MANAGER);
         vm.stopPrank();
     }
@@ -499,7 +499,7 @@ contract EndToEndFlows is EndToEndUtils {
         remoteAdapters[0] = address(poolAdapterBToA).toBytes32();
 
         vm.startPrank(FM);
-        h.hub.setAdapters{value: GAS}(s.centrifugeId, POOL_A, localAdapters, remoteAdapters, 1);
+        h.hub.setAdapters{value: GAS}(s.centrifugeId, POOL_A, localAdapters, remoteAdapters, 1, 1);
         h.hub.setAdaptersManager{value: GAS}(h.centrifugeId, POOL_A, MULTI_ADAPTER_MANAGER.toBytes32());
         h.hub.setAdaptersManager{value: GAS}(s.centrifugeId, POOL_A, MULTI_ADAPTER_MANAGER.toBytes32());
     }
@@ -1383,6 +1383,6 @@ contract EndToEndUseCases is EndToEndFlows, VMLabeling {
         }
 
         vm.startPrank(FM);
-        h.hub.setAdapters{value: GAS}(s.centrifugeId, POOL_A, localAdapters, remoteAdapters, 1);
+        h.hub.setAdapters{value: GAS}(s.centrifugeId, POOL_A, localAdapters, remoteAdapters, 1, 1);
     }
 }

--- a/test/misc/unit/libraries/ArrayLib.t.sol
+++ b/test/misc/unit/libraries/ArrayLib.t.sol
@@ -27,9 +27,21 @@ contract ArrayLibTest is Test {
             vm.assume(initialArray[i] > type(int16).min);
         }
         storedArray = initialArray;
-        storedArray.decreaseFirstNValues(valuesToDecrease);
+        storedArray.decreaseFirstNValues(valuesToDecrease, valuesToDecrease);
 
         assertEq(uint8(int8(_sum(initialArray) - _sum(storedArray))), valuesToDecrease);
+    }
+
+    function testDecreaseFirstNValuesButNotBelowZeroAfterIndex(uint8 valuesToDecrease, uint8 numValuesLowerZeroIndex)
+        public
+    {
+        vm.assume(valuesToDecrease <= 8);
+        vm.assume(numValuesLowerZeroIndex <= valuesToDecrease);
+
+        int16[8] memory initialArray = storedArray;
+        storedArray.decreaseFirstNValues(valuesToDecrease, numValuesLowerZeroIndex);
+
+        assertEq(uint8(int8(_sum(initialArray) - _sum(storedArray))), numValuesLowerZeroIndex);
     }
 
     function _sum(int16[8] memory arr) internal pure returns (int256 count) {

--- a/test/spoke/integration/BaseTest.sol
+++ b/test/spoke/integration/BaseTest.sol
@@ -103,7 +103,9 @@ contract BaseTest is ExtendedSpokeDeployer, Test, ExtendedSpokeActionBatcher {
         erc20 = _newErc20("X's Dollar", "USDX", 6);
         erc6909 = new MockERC6909();
 
-        multiAdapter.setAdapters(OTHER_CHAIN_ID, PoolId.wrap(0), testAdapters, uint8(testAdapters.length));
+        multiAdapter.setAdapters(
+            OTHER_CHAIN_ID, PoolId.wrap(0), testAdapters, uint8(testAdapters.length), uint8(testAdapters.length)
+        );
 
         // We should not use the block ChainID
         vm.chainId(BLOCK_CHAIN_ID);


### PR DESCRIPTION
Added a new parameter `recoveryIndex` to `setAdapters`. From this index, all adapters are considered recovery adapters, which means that their votes will never decrease by 0.

Thread: https://kflabs.slack.com/archives/C07PG2EUR9C/p1757578243204429?thread_ts=1756404586.718779&cid=C07PG2EUR9C

Next PR: removing old recovery system with the manager and move blockOutbound method to Gateway