### PR TITLE
fix: decouple refund escrow creation from controller

### DIFF
--- a/snapshots/AsyncVault.json
+++ b/snapshots/AsyncVault.json
@@ -1,4 +1,4 @@
 {
   "fulfillDepositRequest": "860778",
-  "requestDeposit": "727974"
+  "requestDeposit": "725215"
 }

--- a/snapshots/MessageGasLimits.json
+++ b/snapshots/MessageGasLimits.json
@@ -1,5 +1,5 @@
 {
-  "BENCHMARKING_RUN_ID": 1759748228,
+  "BENCHMARKING_RUN_ID": 1759748861,
   "scheduleUpgrade": 93833,
   "cancelUpgrade": 74240,
   "recoverTokens": 151060,

--- a/snapshots/MessageGasLimits.json
+++ b/snapshots/MessageGasLimits.json
@@ -1,5 +1,5 @@
 {
-  "BENCHMARKING_RUN_ID": 1759694277,
+  "BENCHMARKING_RUN_ID": 1759748228,
   "scheduleUpgrade": 93833,
   "cancelUpgrade": 74240,
   "recoverTokens": 151060,
@@ -15,7 +15,7 @@
   "initiateTransferShares": 286613,
   "executeTransferShares": 177494,
   "updateRestriction": 114441,
-  "trustedContractUpdate": 145006,
+  "trustedContractUpdate": 142247,
   "requestCallback": 258482,
   "updateVaultDeployAndLink": 2853046,
   "updateVaultLink": 185355,

--- a/snapshots/VaultRouter.json
+++ b/snapshots/VaultRouter.json
@@ -2,6 +2,6 @@
   "claimDeposit": "1020323",
   "enable": "60953",
   "lockDepositRequest": "95521",
-  "requestDeposit": "737338",
-  "requestRedeem": "2243320"
+  "requestDeposit": "734579",
+  "requestRedeem": "2237802"
 }

--- a/src/core/messaging/GasService.sol
+++ b/src/core/messaging/GasService.sol
@@ -62,7 +62,7 @@ contract GasService is IGasService {
         initiateTransferShares = BASE_COST + 286613;
         executeTransferShares = BASE_COST + 177494;
         updateRestriction = BASE_COST + 114441;
-        trustedContractUpdate = BASE_COST + 145006;
+        trustedContractUpdate = BASE_COST + 142247;
         requestCallback = BASE_COST + 258482; // approve deposit case
         updateVaultDeployAndLink = BASE_COST + 2853046;
         updateVaultLink = BASE_COST + 185355;

--- a/src/vaults/RefundEscrow.sol
+++ b/src/vaults/RefundEscrow.sol
@@ -10,7 +10,7 @@ import {Auth} from "../misc/Auth.sol";
 ///         messaging costs, allowing authorized parties to deposit funds and withdraw them to specified
 ///         addresses for managing transaction gas refunds.
 contract RefundEscrow is Auth, IRefundEscrow {
-    constructor(address owner) Auth(owner) {}
+    constructor() Auth(msg.sender) {}
 
     receive() external payable {}
 

--- a/src/vaults/factories/RefundEscrowFactory.sol
+++ b/src/vaults/factories/RefundEscrowFactory.sol
@@ -12,12 +12,14 @@ import {RefundEscrow, IRefundEscrow} from "../RefundEscrow.sol";
 
 contract RefundEscrowFactory is Auth, IRefundEscrowFactory {
     address public controller;
+    address public root;
 
     constructor(address deployer) Auth(deployer) {}
 
     /// @inheritdoc IRefundEscrowFactory
     function file(bytes32 what, address data) external auth {
         if (what == "controller") controller = data;
+        else if (what == "root") root = data;
         else revert FileUnrecognizedParam();
         emit File(what, data);
     }
@@ -25,6 +27,7 @@ contract RefundEscrowFactory is Auth, IRefundEscrowFactory {
     /// @inheritdoc IRefundEscrowFactory
     function newEscrow(PoolId poolId) external auth returns (IRefundEscrow escrow) {
         escrow = new RefundEscrow{salt: bytes32(uint256(poolId.raw()))}();
+        IAuth(address(escrow)).rely(root);
         IAuth(address(escrow)).rely(controller);
         IAuth(address(escrow)).deny(address(this));
         emit DeployRefundEscrow(poolId, address(escrow));

--- a/test/vaults/unit/RefundEscrow.t.sol
+++ b/test/vaults/unit/RefundEscrow.t.sol
@@ -15,9 +15,13 @@ contract RefundEscrowTest is Test {
     address immutable RECEIVER = makeAddr("receiver");
     address immutable NO_RECEIVER = address(new NoReceivable());
 
-    RefundEscrow escrow = new RefundEscrow(AUTH);
+    RefundEscrow escrow;
 
     function setUp() external {
+        escrow = new RefundEscrow();
+        IAuth(address(escrow)).rely(AUTH); // Mimic controller behavior
+        IAuth(address(escrow)).deny(address(this)); // Mimic factory behavior
+
         vm.deal(ANY, 1 ether);
         vm.deal(AUTH, 1 ether);
     }

--- a/test/vaults/unit/RefundEscrowFactory.t.sol
+++ b/test/vaults/unit/RefundEscrowFactory.t.sol
@@ -14,6 +14,7 @@ contract RefundEscrowFactoryTest is Test {
     address immutable ANY = makeAddr("any");
     address immutable AUTH = makeAddr("auth");
     address immutable CONTROLLER = makeAddr("receiver");
+    address immutable ROOT = makeAddr("root");
 
     PoolId constant POOL_A = PoolId.wrap(1);
 
@@ -53,11 +54,15 @@ contract RefundEscrowFactoryTestNewEscrow is RefundEscrowFactoryTest {
         factory.file("controller", CONTROLLER);
 
         vm.prank(AUTH);
+        factory.file("root", ROOT);
+
+        vm.prank(AUTH);
         IRefundEscrow escrow = factory.newEscrow(POOL_A);
 
         assertEq(address(escrow), address(factory.get(POOL_A)));
-        assertEq(IAuth(address(escrow)).wards(CONTROLLER), 1);
-        assertEq(IAuth(address(escrow)).wards(address(factory)), 0); // Factory revoked itself
+        assertEq(IAuth(address(escrow)).wards(CONTROLLER), 1, "Controller should have ward");
+        assertEq(IAuth(address(escrow)).wards(ROOT), 1, "Root should have ward");
+        assertEq(IAuth(address(escrow)).wards(address(factory)), 0, "Factory should not have ward");
     }
 
     function testCannotDeployTwiceForSamePool() external {


### PR DESCRIPTION
### Product requirements

* Updating the controller of `RefundEscrowFactory` must not create to a new `RefundEscrow`

### Design notes

* Removed controller address parameter from RefundEscrow constructor, making CREATE2 address calculation dependent only on immutable bytecode
* Factory now grants initial ward permissions to itself during deployment, then transfers control to configured controller via rely/deny pattern
* CREATE2 hash now excludes constructor arguments, ensuring escrow addresses remain stable across controller migrations