### PR TITLE
Fix gas service values taking into account EIP-150

### DIFF
--- a/script/utils/update_gas_service_values.py
+++ b/script/utils/update_gas_service_values.py
@@ -10,8 +10,13 @@ def main(json_path, sol_path):
     missing = []
     for k, v in data.items():
         if k == "BENCHMARKING_RUN_ID": continue
-        pat = re.compile(rf'^(\s*{re.escape(k)}\s*=\s*BASE_COST\s*\+\s*)([0-9_]+)(\s*;)([^\n]*)?', re.M)
-        new_src, n = pat.subn(rf'\g<1>{int(v)}\3\4', src, count=1)
+        pat = re.compile(
+            rf'^(\s*{re.escape(k)}\s*=\s*)'          # indent + "<name> = "
+            rf'_gasValue\(\s*([0-9_]+)\s*\)'         # _gasValue(<number>)
+            rf'(\s*;)([^\n]*)?',                     # semicolon + trailing comment
+            re.M,
+        )
+        new_src, n = pat.subn(rf'\1_gasValue({int(v)})\3\4', src, count=1)
         if n == 0:
             missing.append((k, v))
         else:

--- a/snapshots/MessageGasLimits.json
+++ b/snapshots/MessageGasLimits.json
@@ -1,8 +1,8 @@
 {
-  "BENCHMARKING_RUN_ID": 1759748861,
+  "BENCHMARKING_RUN_ID": 1759831058,
   "scheduleUpgrade": 93833,
   "cancelUpgrade": 74240,
-  "recoverTokens": 151060,
+  "recoverTokens": 151038,
   "registerAsset": 103955,
   "setPoolAdapters": 481579,
   "request": 220587,
@@ -26,6 +26,6 @@
   "updateShares": 201531,
   "maxAssetPriceAge": 110238,
   "maxSharePriceAge": 107124,
-  "updateGatewayManager": 88442,
+  "updateGatewayManager": 88420,
   "untrustedContractUpdate": 83807
 }

--- a/src/core/Gateway.sol
+++ b/src/core/Gateway.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.28;
 
 import {PoolId} from "./types/PoolId.sol";
 import {IAdapter} from "./interfaces/IAdapter.sol";
-import {IGateway} from "./interfaces/IGateway.sol";
+import {IGateway, GAS_FAIL_MESSAGE_STORAGE} from "./interfaces/IGateway.sol";
 import {IMessageLimits} from "./interfaces/IMessageLimits.sol";
 import {IMessageHandler} from "./interfaces/IMessageHandler.sol";
 import {IProtocolPauser} from "./interfaces/IProtocolPauser.sol";
@@ -31,7 +31,6 @@ contract Gateway is Auth, Recoverable, IGateway {
     using BytesLib for bytes;
     using TransientStorageLib for bytes32;
 
-    uint256 public constant GAS_FAIL_MESSAGE_STORAGE = 40_000; // check testMessageFailBenchmark
     bytes32 public constant BATCH_LOCATORS_SLOT = bytes32(uint256(keccak256("Centrifuge/batch-locators")) - 1);
 
     uint16 public immutable localCentrifugeId;

--- a/src/core/Gateway.sol
+++ b/src/core/Gateway.sol
@@ -3,11 +3,11 @@ pragma solidity 0.8.28;
 
 import {PoolId} from "./types/PoolId.sol";
 import {IAdapter} from "./interfaces/IAdapter.sol";
-import {IGateway, GAS_FAIL_MESSAGE_STORAGE} from "./interfaces/IGateway.sol";
 import {IMessageLimits} from "./interfaces/IMessageLimits.sol";
 import {IMessageHandler} from "./interfaces/IMessageHandler.sol";
 import {IProtocolPauser} from "./interfaces/IProtocolPauser.sol";
 import {IMessageProperties} from "./interfaces/IMessageProperties.sol";
+import {IGateway, GAS_FAIL_MESSAGE_STORAGE} from "./interfaces/IGateway.sol";
 
 import {Auth} from "../misc/Auth.sol";
 import {Recoverable} from "../misc/Recoverable.sol";

--- a/src/core/interfaces/IGateway.sol
+++ b/src/core/interfaces/IGateway.sol
@@ -7,6 +7,8 @@ import {IRecoverable} from "../../misc/interfaces/IRecoverable.sol";
 
 import {PoolId} from "../types/PoolId.sol";
 
+uint256 constant GAS_FAIL_MESSAGE_STORAGE = 40_000; // check testMessageFailBenchmark
+
 /// @notice Interface for dispatch-only gateway
 interface IGateway is IMessageHandler, IRecoverable {
     //----------------------------------------------------------------------------------------------

--- a/src/core/messaging/GasService.sol
+++ b/src/core/messaging/GasService.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {IGasService} from "./interfaces/IGasService.sol";
+import {GAS_FAIL_MESSAGE_STORAGE} from "../interfaces/IGateway.sol";
 import {MessageLib, MessageType, VaultUpdateKind} from "./libraries/MessageLib.sol";
 
 import {IMessageLimits} from "../interfaces/IMessageLimits.sol";
@@ -13,8 +14,9 @@ import {IMessageLimits} from "../interfaces/IMessageLimits.sol";
 contract GasService is IGasService {
     using MessageLib for *;
 
-    /// @dev Takes into account Adapter + Gateway processing + some mismatch happened regarding the input values
-    uint128 public constant BASE_COST = 50_000;
+    /// @dev Takes into account diverge computation from the base menchmarked value.
+    /// Also takens into account
+    uint128 public constant BASE_COST = 20_000;
 
     uint128 public immutable scheduleUpgrade;
     uint128 public immutable cancelUpgrade;
@@ -47,34 +49,34 @@ contract GasService is IGasService {
 
     constructor() {
         // NOTE: Below values should be updated using script/utils/benchmark.sh
-        scheduleUpgrade = BASE_COST + 93833;
-        cancelUpgrade = BASE_COST + 74240;
-        recoverTokens = BASE_COST + 151060;
-        registerAsset = BASE_COST + 103955;
-        setPoolAdapters = BASE_COST + 481579; // using MAX_ADAPTER_COUNT
-        request = BASE_COST + 220587;
-        notifyPool = BASE_COST + 1150798; // create escrow case
-        notifyShareClass = BASE_COST + 1853009;
-        notifyPricePoolPerShare = BASE_COST + 107070;
-        notifyPricePoolPerAsset = BASE_COST + 111076;
-        notifyShareMetadata = BASE_COST + 121478;
-        updateShareHook = BASE_COST + 96407;
-        initiateTransferShares = BASE_COST + 286613;
-        executeTransferShares = BASE_COST + 177494;
-        updateRestriction = BASE_COST + 114441;
-        trustedContractUpdate = BASE_COST + 142247;
-        requestCallback = BASE_COST + 258482; // approve deposit case
-        updateVaultDeployAndLink = BASE_COST + 2853046;
-        updateVaultLink = BASE_COST + 185355;
-        updateVaultUnlink = BASE_COST + 134073;
-        setRequestManager = BASE_COST + 100900;
-        updateBalanceSheetManager = BASE_COST + 104175;
-        updateHoldingAmount = BASE_COST + 304319;
-        updateShares = BASE_COST + 201531;
-        maxAssetPriceAge = BASE_COST + 110238;
-        maxSharePriceAge = BASE_COST + 107124;
-        updateGatewayManager = BASE_COST + 88442;
-        untrustedContractUpdate = BASE_COST + 83807;
+        scheduleUpgrade = _gasValue(93833);
+        cancelUpgrade = _gasValue(74240);
+        recoverTokens = _gasValue(151038);
+        registerAsset = _gasValue(103955);
+        setPoolAdapters = _gasValue(481579); // using MAX_ADAPTER_COUNT
+        request = _gasValue(220587);
+        notifyPool = _gasValue(1150798); // create escrow case
+        notifyShareClass = _gasValue(1853009);
+        notifyPricePoolPerShare = _gasValue(107070);
+        notifyPricePoolPerAsset = _gasValue(111076);
+        notifyShareMetadata = _gasValue(121478);
+        updateShareHook = _gasValue(96407);
+        initiateTransferShares = _gasValue(286613);
+        executeTransferShares = _gasValue(177494);
+        updateRestriction = _gasValue(114441);
+        trustedContractUpdate = _gasValue(142247);
+        requestCallback = _gasValue(258482); // approve deposit case
+        updateVaultDeployAndLink = _gasValue(2853046);
+        updateVaultLink = _gasValue(185355);
+        updateVaultUnlink = _gasValue(134073);
+        setRequestManager = _gasValue(100900);
+        updateBalanceSheetManager = _gasValue(104175);
+        updateHoldingAmount = _gasValue(304319);
+        updateShares = _gasValue(201531);
+        maxAssetPriceAge = _gasValue(110238);
+        maxSharePriceAge = _gasValue(107124);
+        updateGatewayManager = _gasValue(88420);
+        untrustedContractUpdate = _gasValue(83807);
     }
 
     /// @inheritdoc IMessageLimits
@@ -114,5 +116,9 @@ contract GasService is IGasService {
         if (kind == MessageType.UpdateGatewayManager) return updateGatewayManager;
         if (kind == MessageType.UntrustedContractUpdate) return untrustedContractUpdate;
         revert InvalidMessageType(); // Unreachable
+    }
+
+    function _gasValue(uint128 value) internal pure returns (uint128) {
+        return BASE_COST + uint128(GAS_FAIL_MESSAGE_STORAGE) + 64 * value / 63;
     }
 }

--- a/src/core/messaging/GasService.sol
+++ b/src/core/messaging/GasService.sol
@@ -118,6 +118,10 @@ contract GasService is IGasService {
         revert InvalidMessageType(); // Unreachable
     }
 
+    /// @dev - BASE_COST adds some offset to the benchmarked message
+    ///      - GAS_FAIL_MESSAGE_STORAGE is an extra required to process a possible message failure
+    ///      - Multiply by 64/63 is because EIP-150 pass 63/64 gas to each method call,
+    ///        so we add here the adapter call required gas.
     function _gasValue(uint128 value) internal pure returns (uint128) {
         return BASE_COST + uint128(GAS_FAIL_MESSAGE_STORAGE) + 64 * value / 63;
     }

--- a/src/core/messaging/GasService.sol
+++ b/src/core/messaging/GasService.sol
@@ -2,10 +2,10 @@
 pragma solidity 0.8.28;
 
 import {IGasService} from "./interfaces/IGasService.sol";
-import {GAS_FAIL_MESSAGE_STORAGE} from "../interfaces/IGateway.sol";
 import {MessageLib, MessageType, VaultUpdateKind} from "./libraries/MessageLib.sol";
 
 import {IMessageLimits} from "../interfaces/IMessageLimits.sol";
+import {GAS_FAIL_MESSAGE_STORAGE} from "../interfaces/IGateway.sol";
 
 /// @title  GasService
 /// @notice This contract stores the gas limits (in gas units) for cross-chain message execution.

--- a/test/core/unit/Gateway.t.sol
+++ b/test/core/unit/Gateway.t.sol
@@ -8,7 +8,7 @@ import {TransientBytesLib} from "../../../src/misc/libraries/TransientBytesLib.s
 import {TransientStorageLib} from "../../../src/misc/libraries/TransientStorageLib.sol";
 
 import {PoolId} from "../../../src/core/types/PoolId.sol";
-import {Gateway, IGateway} from "../../../src/core/Gateway.sol";
+import {Gateway, IGateway, GAS_FAIL_MESSAGE_STORAGE} from "../../../src/core/Gateway.sol";
 import {IAdapter} from "../../../src/core/interfaces/IAdapter.sol";
 import {IMessageLimits} from "../../../src/core/interfaces/IMessageLimits.sol";
 import {IProtocolPauser} from "../../../src/core/interfaces/IProtocolPauser.sol";
@@ -247,7 +247,7 @@ contract GatewayTestHandle is GatewayTest {
 
     function testErrNotEnoughGasToProcess() public {
         bytes memory batch = MessageKind.WithPool0.asBytes();
-        uint256 notEnough = gateway.GAS_FAIL_MESSAGE_STORAGE();
+        uint256 notEnough = GAS_FAIL_MESSAGE_STORAGE;
 
         vm.expectRevert(IGateway.NotEnoughGasToProcess.selector);
 

--- a/test/core/unit/Gateway.t.sol
+++ b/test/core/unit/Gateway.t.sol
@@ -8,11 +8,11 @@ import {TransientBytesLib} from "../../../src/misc/libraries/TransientBytesLib.s
 import {TransientStorageLib} from "../../../src/misc/libraries/TransientStorageLib.sol";
 
 import {PoolId} from "../../../src/core/types/PoolId.sol";
-import {Gateway, IGateway, GAS_FAIL_MESSAGE_STORAGE} from "../../../src/core/Gateway.sol";
 import {IAdapter} from "../../../src/core/interfaces/IAdapter.sol";
 import {IMessageLimits} from "../../../src/core/interfaces/IMessageLimits.sol";
 import {IProtocolPauser} from "../../../src/core/interfaces/IProtocolPauser.sol";
 import {IMessageProperties} from "../../../src/core/interfaces/IMessageProperties.sol";
+import {Gateway, IGateway, GAS_FAIL_MESSAGE_STORAGE} from "../../../src/core/Gateway.sol";
 
 import {IRoot} from "../../../src/admin/interfaces/IRoot.sol";
 


### PR DESCRIPTION
### Product requirements

* Gas values benchmarked in `GasService`, are taken into account from a hypothetical adapter calling to `MultiAdapter`. Nevertheless, the gas paid by some executor to the adapter is not taken into account EIP-150, which only forwards 63/64 of the total gas to the adapter. This PR fixes this taken into account the extra required gas

### Design notes

* Updated python script to the new format
