### PR TITLE
Revert on estimate if destination is not setup

### DIFF
--- a/src/adapters/AxelarAdapter.sol
+++ b/src/adapters/AxelarAdapter.sol
@@ -111,6 +111,8 @@ contract AxelarAdapter is Auth, IAxelarAdapter {
     /// @inheritdoc IAdapter
     function estimate(uint16 centrifugeId, bytes calldata payload, uint256 gasLimit) external view returns (uint256) {
         AxelarDestination memory destination = destinations[centrifugeId];
+        require(bytes(destination.axelarId).length != 0, UnknownChainId());
+
         return axelarGasService.estimateGasFee(
             destination.axelarId, destination.addr, payload, gasLimit + RECEIVE_COST, bytes("")
         );

--- a/src/adapters/LayerZeroAdapter.sol
+++ b/src/adapters/LayerZeroAdapter.sol
@@ -121,6 +121,8 @@ contract LayerZeroAdapter is Auth, ILayerZeroAdapter {
     /// @inheritdoc IAdapter
     function estimate(uint16 centrifugeId, bytes calldata payload, uint256 gasLimit) external view returns (uint256) {
         LayerZeroDestination memory destination = destinations[centrifugeId];
+        require(destination.layerZeroEid != 0, UnknownChainId());
+
         MessagingFee memory fee = endpoint.quote(_params(destination, payload, gasLimit + RECEIVE_COST), address(this));
         return fee.nativeFee;
     }

--- a/src/adapters/WormholeAdapter.sol
+++ b/src/adapters/WormholeAdapter.sol
@@ -104,7 +104,9 @@ contract WormholeAdapter is Auth, IWormholeAdapter {
         view
         returns (uint256 nativePriceQuote)
     {
-        (nativePriceQuote,) =
-            relayer.quoteEVMDeliveryPrice(destinations[centrifugeId].wormholeId, 0, gasLimit + RECEIVE_COST);
+        WormholeDestination memory destination = destinations[centrifugeId];
+        require(destination.wormholeId != 0, UnknownChainId());
+
+        (nativePriceQuote,) = relayer.quoteEVMDeliveryPrice(destination.wormholeId, 0, gasLimit + RECEIVE_COST);
     }
 }

--- a/test/adapters/unit/AxelarAdapter.t.sol
+++ b/test/adapters/unit/AxelarAdapter.t.sol
@@ -116,6 +116,8 @@ contract AxelarAdapterTest is AxelarAdapterTestBase {
         vm.assume(gasLimit > 0);
         vm.assume(gasLimit < adapter.RECEIVE_COST());
 
+        adapter.wire(CENTRIFUGE_CHAIN_ID, abi.encode(AXELAR_CHAIN_ID, REMOTE_AXELAR_ADDR));
+
         bytes memory payload = "irrelevant";
 
         axelarGasService.setReturn("estimateGasFee", gasLimit - 1);

--- a/test/adapters/unit/LayerZeroAdapter.t.sol
+++ b/test/adapters/unit/LayerZeroAdapter.t.sol
@@ -141,7 +141,9 @@ contract LayerZeroAdapterTest is LayerZeroAdapterTestBase {
         assertEq(adapter.wards(address(this)), 1);
     }
 
-    function testEstimate(uint64 gasLimit) public view {
+    function testEstimate(uint64 gasLimit) public {
+        adapter.wire(CENTRIFUGE_ID, abi.encode(LAYERZERO_ID, REMOTE_LAYERZERO_ADDR));
+
         bytes memory payload = "irrelevant";
         assertEq(adapter.estimate(CENTRIFUGE_ID, payload, gasLimit), 200_000);
     }

--- a/test/adapters/unit/WormholeAdapter.t.sol
+++ b/test/adapters/unit/WormholeAdapter.t.sol
@@ -105,7 +105,9 @@ contract WormholeAdapterTest is WormholeAdapterTestBase {
         assertEq(adapter.wards(address(this)), 1);
     }
 
-    function testEstimate(uint64 gasLimit) public view {
+    function testEstimate(uint64 gasLimit) public {
+        adapter.wire(CENTRIFUGE_CHAIN_ID, abi.encode(WORMHOLE_CHAIN_ID, REMOTE_WORMHOLE_ADDR));
+
         bytes memory payload = "irrelevant";
         assertEq(
             adapter.estimate(CENTRIFUGE_CHAIN_ID, payload, gasLimit), uint128(gasLimit + adapter.RECEIVE_COST()) * 2


### PR DESCRIPTION
### Product requirements

* If no destination is set up, then the `estimate` method of adapters should revert