### PR TITLE
Test CCIPAdapter in sepolia

### DIFF
--- a/script/poc/CCIPTestScript.s.sol
+++ b/script/poc/CCIPTestScript.s.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import "forge-std/Script.sol";
+
+import {IMessageHandler} from "src/core/messaging/interfaces/IMessageHandler.sol";
+import {IAdapter} from "src/core/messaging/interfaces/IAdapter.sol";
+import {CCIPAdapter} from "src/adapters/CCIPAdapter.sol";
+
+import {CreateXScript} from "../utils/CreateXScript.sol";
+
+bytes constant MESSAGE = "abc";
+uint128 constant GAS_LIMIT = 500_000;
+
+uint64 constant CCIP_SEPOLIA_BASE_ID = 10344971235874465080;
+address constant CCIP_SEPOLIA_BASE_ROUTER = 0xD3b06cEbF099CE7DA4AcCf578aaebFDBd6e88a93;
+
+uint64 constant CCIP_SEPOLIA_ETHEREUM_ID = 16015286601757825753;
+address constant CCIP_SEPOLIA_ETHEREUM_ROUTER = 0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59;
+
+contract MockEntrypoint is IMessageHandler {
+    event MsgReceived(bytes);
+
+    function handle(uint16, bytes memory message) external {
+        emit MsgReceived(message);
+    }
+}
+
+contract CCIPEthTestScript is Script, CreateXScript {
+    function run() public {
+        vm.startBroadcast();
+
+        setUpCreateXFactory();
+
+        MockEntrypoint entrypoint = MockEntrypoint(
+            create3(keccak256("centrifuge-MockEntrypoint"), abi.encodePacked(type(MockEntrypoint).creationCode))
+        );
+
+        CCIPAdapter ccip = CCIPAdapter(
+            create3(
+                keccak256("centrifuge-CCIPAdapter"),
+                abi.encodePacked(
+                    type(CCIPAdapter).creationCode, abi.encode(entrypoint, CCIP_SEPOLIA_ETHEREUM_ROUTER, msg.sender)
+                )
+            )
+        );
+
+        ccip.wire(0, abi.encode(CCIP_SEPOLIA_BASE_ID, address(ccip)));
+        ccip.send{value: ccip.estimate(0, MESSAGE, GAS_LIMIT)}(0, MESSAGE, GAS_LIMIT, address(0));
+
+        vm.stopBroadcast();
+
+        console.log("entrypoint: ", address(entrypoint));
+        console.log("CCIPAdapter: ", address(ccip));
+    }
+}
+
+contract CCIPBaseTestScript is Script, CreateXScript {
+    function run() public {
+        vm.startBroadcast();
+
+        setUpCreateXFactory();
+
+        MockEntrypoint entrypoint = MockEntrypoint(
+            create3(keccak256("centrifuge-MockEntrypoint"), abi.encodePacked(type(MockEntrypoint).creationCode))
+        );
+
+        CCIPAdapter ccip = CCIPAdapter(
+            create3(
+                keccak256("centrifuge-CCIPAdapter"),
+                abi.encodePacked(
+                    type(CCIPAdapter).creationCode, abi.encode(entrypoint, CCIP_SEPOLIA_BASE_ROUTER, msg.sender)
+                )
+            )
+        );
+
+        ccip.wire(0, abi.encode(CCIP_SEPOLIA_ETHEREUM_ID, address(ccip)));
+
+        vm.stopBroadcast();
+
+        console.log("entrypoint: ", address(entrypoint));
+        console.log("CCIPAdapter: ", address(ccip));
+    }
+}

--- a/script/poc/CCIPTestScript.s.sol
+++ b/script/poc/CCIPTestScript.s.sol
@@ -18,6 +18,9 @@ address constant CCIP_SEPOLIA_BASE_ROUTER = 0xD3b06cEbF099CE7DA4AcCf578aaebFDBd6
 uint64 constant CCIP_SEPOLIA_ETHEREUM_ID = 16015286601757825753;
 address constant CCIP_SEPOLIA_ETHEREUM_ROUTER = 0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59;
 
+bytes constant ENTRYPOINT_NAME = "centrifuge-MockEntrypoint-4";
+bytes constant CCIP_ADAPTER_NAME = "centrifuge-CCIPAdapter-4";
+
 contract MockEntrypoint is IMessageHandler {
     event MsgReceived(bytes);
 
@@ -26,19 +29,18 @@ contract MockEntrypoint is IMessageHandler {
     }
 }
 
-contract CCIPEthTestScript is Script, CreateXScript {
+contract CCIPEthereumTestScript is Script, CreateXScript {
     function run() public {
         vm.startBroadcast();
 
         setUpCreateXFactory();
 
-        MockEntrypoint entrypoint = MockEntrypoint(
-            create3(keccak256("centrifuge-MockEntrypoint"), abi.encodePacked(type(MockEntrypoint).creationCode))
-        );
+        MockEntrypoint entrypoint =
+            MockEntrypoint(create3(keccak256(ENTRYPOINT_NAME), abi.encodePacked(type(MockEntrypoint).creationCode)));
 
         CCIPAdapter ccip = CCIPAdapter(
             create3(
-                keccak256("centrifuge-CCIPAdapter"),
+                keccak256(CCIP_ADAPTER_NAME),
                 abi.encodePacked(
                     type(CCIPAdapter).creationCode, abi.encode(entrypoint, CCIP_SEPOLIA_ETHEREUM_ROUTER, msg.sender)
                 )
@@ -61,13 +63,12 @@ contract CCIPBaseTestScript is Script, CreateXScript {
 
         setUpCreateXFactory();
 
-        MockEntrypoint entrypoint = MockEntrypoint(
-            create3(keccak256("centrifuge-MockEntrypoint"), abi.encodePacked(type(MockEntrypoint).creationCode))
-        );
+        MockEntrypoint entrypoint =
+            MockEntrypoint(create3(keccak256(ENTRYPOINT_NAME), abi.encodePacked(type(MockEntrypoint).creationCode)));
 
         CCIPAdapter ccip = CCIPAdapter(
             create3(
-                keccak256("centrifuge-CCIPAdapter"),
+                keccak256(CCIP_ADAPTER_NAME),
                 abi.encodePacked(
                     type(CCIPAdapter).creationCode, abi.encode(entrypoint, CCIP_SEPOLIA_BASE_ROUTER, msg.sender)
                 )

--- a/script/poc/CCIPTestScript.s.sol
+++ b/script/poc/CCIPTestScript.s.sol
@@ -18,11 +18,10 @@ address constant CCIP_SEPOLIA_BASE_ROUTER = 0xD3b06cEbF099CE7DA4AcCf578aaebFDBd6
 uint64 constant CCIP_SEPOLIA_ETHEREUM_ID = 16015286601757825753;
 address constant CCIP_SEPOLIA_ETHEREUM_ROUTER = 0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59;
 
-bytes constant ENTRYPOINT_NAME = "MockEntrypoint-cfg"; // 0x6bB60C397FDD8a274E1cb8E098F10d4f9499b784
+bytes constant ENTRYPOINT_NAME = "MockEntrypoint-cfg"; //0xbd3873aEd2dB4680a6D84586c9F3F691B54462cb
 bytes constant CCIP_ADAPTER_NAME = "CCIPAdapter-cfg"; //0x6bB60C397FDD8a274E1cb8E098F10d4f9499b784
 
 contract MockEntrypoint is IMessageHandler {
-    // Check event in https://sepolia.basescan.org/address/0xbd3873aEd2dB4680a6D84586c9F3F691B54462cb#events
     event MsgReceived(bytes);
 
     function handle(uint16, bytes memory message) external {

--- a/script/poc/CCIPTestScript.s.sol
+++ b/script/poc/CCIPTestScript.s.sol
@@ -18,14 +18,19 @@ address constant CCIP_SEPOLIA_BASE_ROUTER = 0xD3b06cEbF099CE7DA4AcCf578aaebFDBd6
 uint64 constant CCIP_SEPOLIA_ETHEREUM_ID = 16015286601757825753;
 address constant CCIP_SEPOLIA_ETHEREUM_ROUTER = 0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59;
 
-bytes constant ENTRYPOINT_NAME = "centrifuge-MockEntrypoint-4";
-bytes constant CCIP_ADAPTER_NAME = "centrifuge-CCIPAdapter-4";
+bytes constant ENTRYPOINT_NAME = "MockEntrypoint-cfg"; // 0x6bB60C397FDD8a274E1cb8E098F10d4f9499b784
+bytes constant CCIP_ADAPTER_NAME = "CCIPAdapter-cfg"; //0x6bB60C397FDD8a274E1cb8E098F10d4f9499b784
 
 contract MockEntrypoint is IMessageHandler {
+    // Check event in https://sepolia.basescan.org/address/0xbd3873aEd2dB4680a6D84586c9F3F691B54462cb#events
     event MsgReceived(bytes);
 
     function handle(uint16, bytes memory message) external {
         emit MsgReceived(message);
+    }
+
+    function send(IAdapter adapter) external payable {
+        adapter.send{value: msg.value}(0, MESSAGE, GAS_LIMIT, address(0));
     }
 }
 
@@ -48,7 +53,7 @@ contract CCIPEthereumTestScript is Script, CreateXScript {
         );
 
         ccip.wire(0, abi.encode(CCIP_SEPOLIA_BASE_ID, address(ccip)));
-        ccip.send{value: ccip.estimate(0, MESSAGE, GAS_LIMIT)}(0, MESSAGE, GAS_LIMIT, address(0));
+        entrypoint.send{value: ccip.estimate(0, MESSAGE, GAS_LIMIT)}(ccip);
 
         vm.stopBroadcast();
 

--- a/script/poc/CCIPTestScript.s.sol
+++ b/script/poc/CCIPTestScript.s.sol
@@ -5,7 +5,7 @@ import "forge-std/Script.sol";
 
 import {IMessageHandler} from "src/core/messaging/interfaces/IMessageHandler.sol";
 import {IAdapter} from "src/core/messaging/interfaces/IAdapter.sol";
-import {CCIPAdapter} from "src/adapters/CCIPAdapter.sol";
+import {ChainlinkAdapter} from "src/adapters/ChainlinkAdapter.sol";
 
 import {CreateXScript} from "../utils/CreateXScript.sol";
 
@@ -18,8 +18,8 @@ address constant CCIP_SEPOLIA_BASE_ROUTER = 0xD3b06cEbF099CE7DA4AcCf578aaebFDBd6
 uint64 constant CCIP_SEPOLIA_ETHEREUM_ID = 16015286601757825753;
 address constant CCIP_SEPOLIA_ETHEREUM_ROUTER = 0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59;
 
-bytes constant ENTRYPOINT_NAME = "MockEntrypoint-cfg"; //0xbd3873aEd2dB4680a6D84586c9F3F691B54462cb
-bytes constant CCIP_ADAPTER_NAME = "CCIPAdapter-cfg"; //0x6bB60C397FDD8a274E1cb8E098F10d4f9499b784
+bytes constant ENTRYPOINT_NAME = "MockEntrypoint-cfg-2"; // 0x6c9CF1aB69fF9deb6FD361F67738b7d35bAa69Ed
+bytes constant CCIP_ADAPTER_NAME = "ChainlinkAdapter-cfg-2"; // 0x56955946BB95544627c2F02fD3CfcAB48DbC997d
 
 contract MockEntrypoint is IMessageHandler {
     event MsgReceived(bytes);
@@ -42,11 +42,12 @@ contract CCIPEthereumTestScript is Script, CreateXScript {
         MockEntrypoint entrypoint =
             MockEntrypoint(create3(keccak256(ENTRYPOINT_NAME), abi.encodePacked(type(MockEntrypoint).creationCode)));
 
-        CCIPAdapter ccip = CCIPAdapter(
+        ChainlinkAdapter ccip = ChainlinkAdapter(
             create3(
                 keccak256(CCIP_ADAPTER_NAME),
                 abi.encodePacked(
-                    type(CCIPAdapter).creationCode, abi.encode(entrypoint, CCIP_SEPOLIA_ETHEREUM_ROUTER, msg.sender)
+                    type(ChainlinkAdapter).creationCode,
+                    abi.encode(entrypoint, CCIP_SEPOLIA_ETHEREUM_ROUTER, msg.sender)
                 )
             )
         );
@@ -57,7 +58,7 @@ contract CCIPEthereumTestScript is Script, CreateXScript {
         vm.stopBroadcast();
 
         console.log("entrypoint: ", address(entrypoint));
-        console.log("CCIPAdapter: ", address(ccip));
+        console.log("ChainlinkAdapter: ", address(ccip));
     }
 }
 
@@ -70,11 +71,11 @@ contract CCIPBaseTestScript is Script, CreateXScript {
         MockEntrypoint entrypoint =
             MockEntrypoint(create3(keccak256(ENTRYPOINT_NAME), abi.encodePacked(type(MockEntrypoint).creationCode)));
 
-        CCIPAdapter ccip = CCIPAdapter(
+        ChainlinkAdapter ccip = ChainlinkAdapter(
             create3(
                 keccak256(CCIP_ADAPTER_NAME),
                 abi.encodePacked(
-                    type(CCIPAdapter).creationCode, abi.encode(entrypoint, CCIP_SEPOLIA_BASE_ROUTER, msg.sender)
+                    type(ChainlinkAdapter).creationCode, abi.encode(entrypoint, CCIP_SEPOLIA_BASE_ROUTER, msg.sender)
                 )
             )
         );
@@ -84,6 +85,6 @@ contract CCIPBaseTestScript is Script, CreateXScript {
         vm.stopBroadcast();
 
         console.log("entrypoint: ", address(entrypoint));
-        console.log("CCIPAdapter: ", address(ccip));
+        console.log("ChainlinkAdapter: ", address(ccip));
     }
 }


### PR DESCRIPTION
Test CCIPAdapter works fine in Sepolia.

Seems CCIP doesn't allow sending to the same chain, so we need to deploy in two different chains.

### Testing process:
1. First deploy `CCIPBaseTestScript` script in Base
2. Second deploy `CCIPEthereumTestScript` in Ethereum which also sends a message to the base adapter
3. Check https://sepolia.basescan.org/address/0xbd3873aEd2dB4680a6D84586c9F3F691B54462cb#events in base for message received.

### For reference, deploy commands here:
- For Base:
  ```sh
  forge script script/poc/CCIPTestScript.s.sol:CCIPBaseTestScript --optimize --fork-url $BASE_RPC_URL --private-key $PRIVATE_KEY --verify --broadcast --chain-id 84532 --etherscan-api-key $BASESCAN_KEY
  ```
- For Ethereum:
  ```
  forge script script/poc/CCIPTestScript.s.sol:CCIPEthereumTestScript --optimize --fork-url $ETHEREUM_RPC_URL --private-key $PRIVATE_KEY --verify --broadcast --chain-id 11155111 --etherscan-api-key $ETHERSCAN_KEY
  ```