### PR TITLE
fix: maxDepositClaims

### DIFF
--- a/src/vaults/BatchRequestManager.sol
+++ b/src/vaults/BatchRequestManager.sol
@@ -700,7 +700,7 @@ contract BatchRequestManager is Auth, ReentrancyProtection, IBatchRequestManager
         returns (uint32)
     {
         return _maxClaims(
-            depositRequest[poolId][scId_][depositAssetId][investor], epochId[poolId][scId_][depositAssetId].deposit
+            depositRequest[poolId][scId_][depositAssetId][investor], epochId[poolId][scId_][depositAssetId].issue
         );
     }
 


### PR DESCRIPTION
### Product requirements

* Fix maxDepositClaims calculation to use issue epoch instead of deposit epoch for accurate claimable deposit tracking (alternative fix to Electisec v3.1 [issue 2](https://github.com/electisec/centrifuge-v31-report/issues/2))
* Ref discussion: https://kflabs.slack.com/archives/C07PG2EUR9C/p1759942672540799

### Design notes

* Changed BatchRequestManager.maxDepositClaims to check depositRequest against epochId.issue instead of epochId.deposit
* The issue epoch represents when shares are actually issued and claimable, while deposit epoch only represents when deposits are approved