### PR TITLE
ref: rm payable approveRedeems

### DIFF
--- a/src/vaults/BatchRequestManager.sol
+++ b/src/vaults/BatchRequestManager.sol
@@ -245,7 +245,7 @@ contract BatchRequestManager is Auth, ReentrancyProtection, IBatchRequestManager
         uint32 nowRedeemEpochId,
         uint128 approvedShareAmount,
         D18 pricePoolPerAsset
-    ) external payable authOrManager(poolId) {
+    ) external authOrManager(poolId) {
         require(
             nowRedeemEpochId == nowRedeemEpoch(poolId, scId_, payoutAssetId),
             EpochNotInSequence(nowRedeemEpochId, nowRedeemEpoch(poolId, scId_, payoutAssetId))

--- a/src/vaults/interfaces/IBatchRequestManager.sol
+++ b/src/vaults/interfaces/IBatchRequestManager.sol
@@ -275,7 +275,7 @@ interface IBatchRequestManager is IHubRequestManager, IHubRequestManagerNotifica
         uint32 nowRedeemEpochId,
         uint128 approvedShareAmount,
         D18 pricePoolPerAsset
-    ) external payable;
+    ) external;
 
     /// @notice Issue shares to investors based on approved deposits
     /// @dev This function mints shares for the approved deposit epoch using the provided share price


### PR DESCRIPTION
### Product requirements

* Fix https://github.com/electisec/centrifuge-v31-report/issues/1
* Remove unnecessary payable modifier from approveRedeems function to prevent accidental ETH transfers during redemption approval operations 

### Design notes

* Removed `payable` modifier from `approveRedeems` function in BatchRequestManager.sol and its interface
* Function does not handle native ETH and should not accept value transfers
* No breaking changes to function signature or parameters, only removes incorrect modifier