### PR TITLE
ref: require registered asset for pool currency update

### DIFF
--- a/src/core/hub/HubRegistry.sol
+++ b/src/core/hub/HubRegistry.sol
@@ -87,6 +87,7 @@ contract HubRegistry is Auth, IHubRegistry {
     function updateCurrency(PoolId poolId_, AssetId currency_) external auth {
         require(exists(poolId_), NonExistingPool(poolId_));
         require(!currency_.isNull(), EmptyCurrency());
+        require(isRegistered(currency_), AssetNotFound());
 
         currency[poolId_] = currency_;
 

--- a/test/vaults/unit/BatchRequestManager.t.sol
+++ b/test/vaults/unit/BatchRequestManager.t.sol
@@ -432,7 +432,7 @@ contract BatchRequestManagerSimpleTest is BatchRequestManagerBaseTest {
         assertEq(batchRequestManager.maxRedeemClaims(poolId, scId, investor, USDC), 0, "Should be 0 after request");
 
         // After approve but before revoke, maxRedeemClaims should return 0 (uses revoke epoch, not redeem)
-        batchRequestManager.approveRedeems{value: COST}(
+        batchRequestManager.approveRedeems(
             poolId, scId, USDC, _nowRedeem(USDC), MIN_REQUEST_AMOUNT_SHARES, _pricePoolPerAsset(USDC)
         );
         assertEq(
@@ -471,7 +471,7 @@ contract BatchRequestManagerSimpleTest is BatchRequestManagerBaseTest {
         batchRequestManager.requestRedeem(poolId, scId, MIN_REQUEST_AMOUNT_SHARES * epochs, investor, USDC);
 
         for (uint256 i = 0; i < epochs; i++) {
-            batchRequestManager.approveRedeems{value: COST}(
+            batchRequestManager.approveRedeems(
                 poolId, scId, USDC, _nowRedeem(USDC), MIN_REQUEST_AMOUNT_SHARES, _pricePoolPerAsset(USDC)
             );
             batchRequestManager.revokeShares{value: COST}(


### PR DESCRIPTION
### Product requirements

* Fixes https://github.com/electisec/centrifuge-v31-report/issues/7
* Address informational audit finding by validating currency registration in `HubRegistry.updateCurrency`

### Design notes

* `HubRegistry.updateCurrency` now requires the new currency asset to be registered via `isRegistered()` check before allowing pool currency updates