### PR TITLE
Polish lockCallback behavior

### DIFF
--- a/src/core/messaging/Gateway.sol
+++ b/src/core/messaging/Gateway.sol
@@ -288,10 +288,9 @@ contract Gateway is Auth, Recoverable, IGateway {
     }
 
     /// @inheritdoc IGateway
-    function lockCallback() external returns (address caller) {
+    function lockCallback() external {
         require(_batcher != address(0), CallbackIsLocked());
         require(msg.sender == _batcher, CallbackWasNotFromSender());
-        caller = _batcher;
         _batcher = address(0);
     }
 

--- a/src/core/messaging/interfaces/IGateway.sol
+++ b/src/core/messaging/interfaces/IGateway.sol
@@ -165,8 +165,8 @@ interface IGateway is IMessageHandler, IRecoverable {
     ///             }
     ///
     ///             function callback(PoolId poolId) external {
-    ///                 // Avoid direct reentrancy to the callback and ensure it's called from withBatch in the same contract:
-    ///                 address msgSender = gateway.lockCallback();
+    ///                 // Avoid reentrancy to the callback and ensure it's called from withBatch in the same contract:
+    ///                 gateway.lockCallback();
     ///
     ///                 // Call several hub, balance sheet, or spoke methods that trigger cross-chain transactions
     ///             }
@@ -178,13 +178,12 @@ interface IGateway is IMessageHandler, IRecoverable {
     /// @param refund Address to refund excess payment
     function withBatch(bytes memory callbackData, address refund) external payable;
 
-    /// @notice Returns the current caller used to call withBatch and block any reentrancy.
+    /// @notice Ensures the callback is called by withBatch in the same contract.
     /// @dev calling this at the very beginning inside the multicall means:
     ///         - The callback is called from the gateway under `withBatch`.
     ///         - The callback is called from the same contract, because withBatch uses `msg.sender` as target for the callback
-    ///         - The callback that uses this can only be called once inside withBatch scope.
-    /// @return The locked callback sender
-    function lockCallback() external returns (address);
+    ///         - The callback that uses this can only be called once inside withBatch scope. No reentrancy.
+    function lockCallback() external;
 
     //----------------------------------------------------------------------------------------------
     // View methods


### PR DESCRIPTION
A very minor PR that polishes the lockCallback behavior.

Previously, it was returning the `batcher`, when it's not needed, because the batcher **is always** `address(this)` from the caller perspective. 

It created confusion, giving the false sense that it was the `msg.sender` to the method that later calls `withBatch`