### PR TITLE
ref: rm redundant address(0) mgr check

### DIFF
--- a/src/core/hub/Hub.sol
+++ b/src/core/hub/Hub.sol
@@ -497,7 +497,6 @@ contract Hub is BatchedMulticall, Auth, Recoverable, IHub, IHubRequestManagerCal
         address refund
     ) external payable {
         IHubRequestManager manager = hubRegistry.hubRequestManager(poolId, assetId.centrifugeId());
-        require(address(manager) != address(0), InvalidRequestManager());
         require(msg.sender == address(manager), NotAuthorized());
 
         sender.sendRequestCallback{value: _payment()}(poolId, scId, assetId, payload, extraGasLimit, refund);

--- a/src/core/spoke/Spoke.sol
+++ b/src/core/spoke/Spoke.sol
@@ -328,7 +328,6 @@ contract Spoke is Auth, Recoverable, ReentrancyProtection, ISpoke, ISpokeGateway
         bool unpaid
     ) external payable {
         IRequestManager manager = requestManager[poolId];
-        require(address(manager) != address(0), InvalidRequestManager());
         require(msg.sender == address(manager), NotAuthorized());
 
         gateway.setUnpaidMode(unpaid);

--- a/test/core/spoke/unit/Spoke.t.sol
+++ b/test/core/spoke/unit/Spoke.t.sol
@@ -441,7 +441,7 @@ contract SpokeTestRegisterAsset is SpokeTest {
 contract SpokeTestRequest is SpokeTest {
     function testErrInvalidRequestManager() public {
         vm.prank(AUTH);
-        vm.expectRevert(ISpoke.InvalidRequestManager.selector);
+        vm.expectRevert(IAuth.NotAuthorized.selector);
         spoke.request{value: COST}(POOL_A, SC_1, ASSET_ID_20, PAYLOAD, REFUND, false);
     }
 


### PR DESCRIPTION
### Product requirements

* Fixes https://github.com/electisec/centrifuge-v31-report/issues/11
* Remove redundant `address(0)` validation checks in request manager authorization paths to reduce gas consumption per call

### Design notes

* Removed first require statement in `Hub.requestCallback()` and `Spoke.request()` that checked `address(manager) != address(0)` since the subsequent `msg.sender == address(manager)` check makes it redundant (msg.sender cannot be address(0) in EVM)