### PR TITLE
Fix: adapter multiplier with ETH instead of GasLimit

### DIFF
--- a/script/WireAdapters.s.sol
+++ b/script/WireAdapters.s.sol
@@ -13,7 +13,7 @@ import "forge-std/Script.sol";
 ///
 ///      Intended for testnet use only.
 contract WireAdapters is Script {
-    uint8 constant GAS_MULTIPLIER = 10; // 10%
+    uint16 constant GAS_MULTIPLIER = 10; // 10%
     IAdapter[] adapters; // Storage array for adapter instances
 
     function fetchConfig(string memory network) internal view returns (string memory) {

--- a/src/adapters/AxelarAdapter.sol
+++ b/src/adapters/AxelarAdapter.sol
@@ -51,7 +51,7 @@ contract AxelarAdapter is Auth, IAxelarAdapter {
     ///        Measured as % over the message cost. i.e: `10` means added a 10%
     function wire(uint16 centrifugeId, bytes memory data) external auth {
         (uint16 gasBufferPercentage, string memory axelarId, string memory adapter) =
-            abi.decode(data, (uint8, string, string));
+            abi.decode(data, (uint16, string, string));
         sources[axelarId] = AxelarSource(centrifugeId, keccak256(bytes(adapter)));
         destinations[centrifugeId] = AxelarDestination(gasBufferPercentage, axelarId, adapter);
         emit Wire(centrifugeId, axelarId, adapter);

--- a/src/adapters/AxelarAdapter.sol
+++ b/src/adapters/AxelarAdapter.sol
@@ -48,9 +48,9 @@ contract AxelarAdapter is Auth, IAxelarAdapter {
 
     /// @inheritdoc IAdapterWiring
     /// @dev   First encoded param is a payment overhead to ensure the message is computed despite price fluctuations.
-    ///        Measured as % over the given gasLimit. i.e: `10` means added a 10% over gasLimit
+    ///        Measured as % over the message cost. i.e: `10` means added a 10%
     function wire(uint16 centrifugeId, bytes memory data) external auth {
-        (uint8 gasBufferPercentage, string memory axelarId, string memory adapter) =
+        (uint16 gasBufferPercentage, string memory axelarId, string memory adapter) =
             abi.decode(data, (uint8, string, string));
         sources[axelarId] = AxelarSource(centrifugeId, keccak256(bytes(adapter)));
         destinations[centrifugeId] = AxelarDestination(gasBufferPercentage, axelarId, adapter);
@@ -121,11 +121,7 @@ contract AxelarAdapter is Auth, IAxelarAdapter {
         require(bytes(destination.axelarId).length != 0, UnknownChainId());
 
         return axelarGasService.estimateGasFee(
-            destination.axelarId,
-            destination.addr,
-            payload,
-            (gasLimit + RECEIVE_COST) * (100 + destination.gasBufferPercentage) / 100,
-            bytes("")
-        );
+            destination.axelarId, destination.addr, payload, gasLimit + RECEIVE_COST, bytes("")
+        ) * (100 + destination.gasBufferPercentage) / 100;
     }
 }

--- a/src/adapters/LayerZeroAdapter.sol
+++ b/src/adapters/LayerZeroAdapter.sol
@@ -57,7 +57,7 @@ contract LayerZeroAdapter is Auth, ILayerZeroAdapter {
     /// @dev   First encoded param is a payment overhead to ensure the message is computed despite price fluctuations.
     ///        Measured as % over the message cost. i.e: `10` means added a 10%
     function wire(uint16 centrifugeId, bytes memory data) external auth {
-        (uint16 gasBufferPercentage, uint32 layerZeroEid, address adapter) = abi.decode(data, (uint8, uint32, address));
+        (uint16 gasBufferPercentage, uint32 layerZeroEid, address adapter) = abi.decode(data, (uint16, uint32, address));
         sources[layerZeroEid] = LayerZeroSource(centrifugeId, adapter);
         destinations[centrifugeId] = LayerZeroDestination(gasBufferPercentage, layerZeroEid, adapter);
         emit Wire(centrifugeId, layerZeroEid, adapter);

--- a/src/adapters/interfaces/IAxelarAdapter.sol
+++ b/src/adapters/interfaces/IAxelarAdapter.sol
@@ -76,7 +76,7 @@ struct AxelarSource {
 }
 
 struct AxelarDestination {
-    uint8 gasBufferPercentage;
+    uint16 gasBufferPercentage;
     string axelarId;
     string addr;
 }
@@ -103,11 +103,11 @@ interface IAxelarAdapter is IAdapter, IAdapterWiring, IAxelarExecutable {
 
     /// @notice Returns the destination configuration for a given chain id
     /// @param centrifugeId The remote chain id
-    /// @return gasBufferPercentage multiplier applied to the gas estimation
+    /// @return gasBufferPercentage multiplier applied to the message cost
     /// @return axelarId The Axelar ID of the remote chain
     /// @return addr The address of the remote axelar adapter
     function destinations(uint16 centrifugeId)
         external
         view
-        returns (uint8 gasBufferPercentage, string memory axelarId, string memory addr);
+        returns (uint16 gasBufferPercentage, string memory axelarId, string memory addr);
 }

--- a/src/adapters/interfaces/ILayerZeroAdapter.sol
+++ b/src/adapters/interfaces/ILayerZeroAdapter.sol
@@ -83,7 +83,7 @@ struct LayerZeroSource {
 }
 
 struct LayerZeroDestination {
-    uint8 gasBufferPercentage;
+    uint16 gasBufferPercentage;
     uint32 layerZeroEid;
     address addr;
 }
@@ -118,11 +118,11 @@ interface ILayerZeroAdapter is IAdapter, IAdapterWiring, ILayerZeroReceiver {
 
     /// @notice Returns the destination configuration for a given chain id
     /// @param centrifugeId The remote chain id
-    /// @return gasBufferPercentage multiplier applied to the gas estimation
+    /// @return gasBufferPercentage multiplier applied to the message cost
     /// @return layerZeroEid The remote LayerZero Endpoint ID
     /// @return addr The address of the remote layerzero adapter
     function destinations(uint16 centrifugeId)
         external
         view
-        returns (uint8 gasBufferPercentage, uint32 layerZeroEid, address addr);
+        returns (uint16 gasBufferPercentage, uint32 layerZeroEid, address addr);
 }

--- a/src/adapters/interfaces/IWormholeAdapter.sol
+++ b/src/adapters/interfaces/IWormholeAdapter.sol
@@ -131,6 +131,7 @@ struct WormholeSource {
 }
 
 struct WormholeDestination {
+    uint16 gasBufferPercentage;
     uint16 wormholeId;
     address addr;
 }
@@ -164,7 +165,11 @@ interface IWormholeAdapter is IAdapter, IAdapterWiring, IWormholeReceiver {
 
     /// @notice Returns the destination configuration for a given chain id
     /// @param centrifugeId The remote chain id
+    /// @return gasBufferPercentage multiplier applied to the message cost
     /// @return wormholeId The remote wormhole id
     /// @return addr The address of the remote wormhole adapter
-    function destinations(uint16 centrifugeId) external view returns (uint16 wormholeId, address addr);
+    function destinations(uint16 centrifugeId)
+        external
+        view
+        returns (uint16 gasBufferPercentage, uint16 wormholeId, address addr);
 }

--- a/test/adapters/unit/AxelarAdapter.t.sol
+++ b/test/adapters/unit/AxelarAdapter.t.sol
@@ -61,7 +61,7 @@ contract AxelarAdapterTestBase is Test {
     uint16 constant CENTRIFUGE_CHAIN_ID = 1;
     string constant AXELAR_CHAIN_ID = "mainnet";
     string constant REMOTE_AXELAR_ADDR = "remoteAddress";
-    uint8 constant GAS_MULTIPLIER = 10; // 10%
+    uint16 constant GAS_MULTIPLIER = 10; // 10%
 
     MockAxelarGateway axelarGateway;
     MockAxelarGasService axelarGasService;
@@ -88,7 +88,7 @@ contract AxelarAdapterTestWire is AxelarAdapterTestBase {
         bytes memory data = abi.encode(GAS_MULTIPLIER, AXELAR_CHAIN_ID, REMOTE_AXELAR_ADDR);
         adapter.wire(CENTRIFUGE_CHAIN_ID, data);
 
-        (uint8 gasBufferPercentage, string memory axelarId, string memory remoteAddress) =
+        (uint16 gasBufferPercentage, string memory axelarId, string memory remoteAddress) =
             adapter.destinations(CENTRIFUGE_CHAIN_ID);
         assertEq(axelarId, AXELAR_CHAIN_ID);
         assertEq(remoteAddress, REMOTE_AXELAR_ADDR);
@@ -131,7 +131,7 @@ contract AxelarAdapterTest is AxelarAdapterTestBase {
         axelarGasService.setReturn("estimateGasFee", gasLimit - 1);
 
         uint256 estimation = adapter.estimate(CENTRIFUGE_CHAIN_ID, payload, gasLimit);
-        assertEq(estimation, gasLimit - 1);
+        assertEq(estimation, (gasLimit - 1) * (100 + GAS_MULTIPLIER) / 100);
     }
 
     function testIncomingCalls(

--- a/test/adapters/unit/LayerZeroAdapter.t.sol
+++ b/test/adapters/unit/LayerZeroAdapter.t.sol
@@ -59,7 +59,7 @@ contract LayerZeroAdapterTestBase is Test {
     uint32 constant LAYERZERO_ID = 2;
     address immutable DELEGATE = makeAddr("delegate");
     address immutable REMOTE_LAYERZERO_ADDR = makeAddr("remoteAddress");
-    uint8 constant GAS_MULTIPLIER = 10; // 10%
+    uint16 constant GAS_MULTIPLIER = 10; // 10%
 
     IMessageHandler constant GATEWAY = IMessageHandler(address(1));
 
@@ -95,7 +95,8 @@ contract LayerZeroAdapterTestWire is LayerZeroAdapterTestBase {
             adapter.allowInitializePath(Origin(LAYERZERO_ID, REMOTE_LAYERZERO_ADDR.toBytes32LeftPadded(), 0)), true
         );
 
-        (uint8 gasBufferPercentage, uint32 layerZeroid, address remoteDestAddress) = adapter.destinations(CENTRIFUGE_ID);
+        (uint16 gasBufferPercentage, uint32 layerZeroid, address remoteDestAddress) =
+            adapter.destinations(CENTRIFUGE_ID);
         assertEq(layerZeroid, LAYERZERO_ID);
         assertEq(remoteDestAddress, REMOTE_LAYERZERO_ADDR);
         assertEq(gasBufferPercentage, GAS_MULTIPLIER);
@@ -147,7 +148,7 @@ contract LayerZeroAdapterTest is LayerZeroAdapterTestBase {
         adapter.wire(CENTRIFUGE_ID, abi.encode(GAS_MULTIPLIER, LAYERZERO_ID, REMOTE_LAYERZERO_ADDR));
 
         bytes memory payload = "irrelevant";
-        assertEq(adapter.estimate(CENTRIFUGE_ID, payload, gasLimit), 200_000);
+        assertEq(adapter.estimate(CENTRIFUGE_ID, payload, gasLimit), 200_000 * (100 + uint128(GAS_MULTIPLIER)) / 100);
     }
 
     function testIncomingCalls(
@@ -230,7 +231,7 @@ contract LayerZeroAdapterTest is LayerZeroAdapterTestBase {
             uint8(1), // WORKER_ID
             uint16(17), // uint128 gasLimit byte length + 1
             uint8(1), // OPTION_TYPE_LZ
-            uint128((gasLimit + adapter.RECEIVE_COST()) * (100 + GAS_MULTIPLIER) / 100)
+            uint128(gasLimit + adapter.RECEIVE_COST())
         );
         assertEq(endpoint.values_bytes("params.options"), expectedOptions);
         assertEq(endpoint.values_bool("params.payInLzToken"), false);


### PR DESCRIPTION
### Product requirements

* https://kflabs.slack.com/archives/C07PG2EUR9C/p1760544909344319

### Design notes

* Multiply after the estimation, to multiply the eth not the gasLimit
* Use uint16, given uint8 only allows to multiply x2.5, and it seems some escenarios with x5 exists.
* Add gasBuffer to wormhole