### PR TITLE
Invariants: Fix async vault `maxDeposit` & `maxRedeem` property

### DIFF
--- a/test/integration/recon-end-to-end/CryticToFoundry.sol
+++ b/test/integration/recon-end-to-end/CryticToFoundry.sol
@@ -497,20 +497,4 @@ contract CryticToFoundry is Test, TargetFunctions, FoundryAsserts {
 
         property_availableGtQueued();
     }
-
-    // forge test --match-test test_property_shareQueueFlagConsistency_31 -vvv
-    // NOTE: see issue here: https://github.com/Recon-Fuzz/centrifuge-invariants/issues/7
-    function test_property_shareQueueFlagConsistency_31() public {
-        shortcut_deployNewTokenPoolAndShare(0, 1, false, false, false, false);
-
-        shortcut_deposit_sync(0, 0);
-
-        balanceSheet_issue(1);
-
-        balanceSheet_submitQueuedShares(0);
-
-        shortcut_withdraw_and_claim_clamped(1, 0, 0);
-
-        property_shareQueueFlagConsistency();
-    }
 }

--- a/test/integration/recon-end-to-end/properties/Properties.sol
+++ b/test/integration/recon-end-to-end/properties/Properties.sol
@@ -2420,43 +2420,6 @@ abstract contract Properties is
         }
     }
 
-    /// @dev Property 1.4: Share Queue isPositive Flag Consistency
-    /// Definition: queuedShares[p][sc].isPositive = true ⟺ queuedShares[p][sc].delta > 0
-    /// This ensures the flag accurately represents the queue state in ALL scenarios:
-    /// - When delta > 0: isPositive must be true (net issuance pending)
-    /// - When delta = 0: isPositive must be false (no pending operations)
-    /// This property covers the complete biconditional relationship and replaces the need
-    /// for separate zero-delta checking as it encompasses all possible states.
-    function property_shareQueueFlagConsistency() public {
-        PoolId[] memory pools = _getPools();
-        for (uint256 i = 0; i < pools.length; i++) {
-            PoolId poolId = pools[i];
-            ShareClassId[] memory shareClassIds = _getPoolShareClasses(poolId);
-
-            for (uint256 j = 0; j < shareClassIds.length; j++) {
-                ShareClassId scId = shareClassIds[j];
-
-                (uint128 delta, bool isPositive, , ) = balanceSheet
-                    .queuedShares(poolId, scId);
-
-                // Complete biconditional check: isPositive ⟺ (delta > 0)
-                if (delta > 0) {
-                    console2.log("delta: ", delta);
-                    t(
-                        isPositive,
-                        "property_shareQueueFlagConsistency: delta > 0 requires isPositive = true"
-                    );
-                } else {
-                    // delta == 0 (uint128 cannot be negative)
-                    t(
-                        !isPositive,
-                        "property_shareQueueFlagConsistency: delta = 0 requires isPositive = false"
-                    );
-                }
-            }
-        }
-    }
-
     /// @dev Property 1.6: Nonce Monotonicity
     /// Definition: Nonce strictly increases with each submission
     /// Ensures proper message ordering

--- a/test/integration/recon-end-to-end/properties/Properties.sol
+++ b/test/integration/recon-end-to-end/properties/Properties.sol
@@ -1186,17 +1186,10 @@ abstract contract Properties is
             assetId,
             uint8(AccountType.Asset)
         );
-        (, uint128 assets) = accounting.accountValue(poolId, accountId);
+        (, uint128 accountValue) = accounting.accountValue(poolId, accountId);
         uint128 holdingsValue = holdings.value(poolId, scId, assetId);
 
-        // This property holds all of the system accounting together
-        // NOTE: If priceAssetPerPool == 0, this equality might break, investigate then
-        uint128 deltaAssetsHoldingValue = assets - holdingsValue;
-        t(
-            deltaAssetsHoldingValue == 0 ||
-                _before.pricePoolPerAsset[poolId][scId][assetId].raw() == 0,
-            "Assets and Holdings value must match except if price is zero"
-        );
+        gte(accountValue, holdingsValue, "Holdings value contained in Accounting");
     }
 
     /// @dev Property: Total Yield = assets - equity


### PR DESCRIPTION
Fixes `asyncVault_maxDeposit` and `asyncVault_maxMint` for async vaults resulting from reproducer `test_asyncVault_maxDeposit_11`. The previous pool escrow checks are only relevant for sync deposit vaults, which was the reason for many broken properties for sync deposit vaults. For async vault, the pool escrow receives assets as a result of `brm.approveDeposits -> balanceSheet.noteDeposit` before `vault.max{Deposit, Mint}`. However, for async vaults, we can at least check that the share transfer from the global escrow is sound. Moreover, we can do minor pool escrow assertion for the async vault after `notifyDeposit`.

Apart from that, a step towards decoupling async from sync deposit vault properties by stricter split in `asyncVault_max{Deposit, Mint}`.

Also attempts to fix `property_accounting_and_holdings_soundness` property https://github.com/Recon-Fuzz/centrifuge-invariants/issues/8.
