### PR TITLE
Fix nested multicall

### DIFF
--- a/src/core/utils/BatchedMulticall.sol
+++ b/src/core/utils/BatchedMulticall.sol
@@ -36,7 +36,7 @@ abstract contract BatchedMulticall is Multicall, IBatchedMulticall {
         super.multicall(data);
     }
 
-    /// @dev Integrators MUST use msgSender() instead of msg.sender, since this is replaced
+    /// @dev Integrators MUST use msgSender() instead of msg.sender, since msg.sender is replaced
     ///      by the gateway address inside the multicall.
     function msgSender() internal view virtual returns (address) {
         return _sender != address(0) ? _sender : msg.sender;

--- a/src/core/utils/BatchedMulticall.sol
+++ b/src/core/utils/BatchedMulticall.sol
@@ -24,6 +24,10 @@ abstract contract BatchedMulticall is Multicall, IBatchedMulticall {
     /// @notice     With extra support for batching
     function multicall(bytes[] calldata data) public payable override {
         bool isNested = _sender != address(0);
+        // Prevent reentrancy attacks: if we're in a nested call (_sender is set),
+        // only allow the gateway to call multicall (legitimate nested multicalls)
+        require(!isNested || msg.sender == address(gateway), "BatchedMulticall/invalid-nested-caller");
+
         if (!isNested) _sender = msg.sender;
         gateway.withBatch{
             value: msg.value

--- a/src/core/utils/BatchedMulticall.sol
+++ b/src/core/utils/BatchedMulticall.sol
@@ -23,11 +23,12 @@ abstract contract BatchedMulticall is Multicall, IBatchedMulticall {
     /// @inheritdoc IMulticall
     /// @notice     With extra support for batching
     function multicall(bytes[] calldata data) public payable override {
-        _sender = msg.sender;
+        bool isNested = _sender != address(0);
+        if (!isNested) _sender = msg.sender;
         gateway.withBatch{
             value: msg.value
         }(abi.encodeWithSelector(BatchedMulticall.executeMulticall.selector, data), msg.sender);
-        _sender = address(0);
+        if (!isNested) _sender = address(0);
     }
 
     function executeMulticall(bytes[] calldata data) external payable protected {

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -1122,19 +1122,12 @@ contract EndToEndUseCases is EndToEndFlows, VMLabeling {
 
         // Create inner multicall: updateHubManager (requires manager permission)
         bytes[] memory innerCalls = new bytes[](1);
-        innerCalls[0] = abi.encodeWithSelector(
-            h.hub.updateHubManager.selector,
-            POOL_A,
-            makeAddr("AnotherManager"),
-            true
-        );
+        innerCalls[0] =
+            abi.encodeWithSelector(h.hub.updateHubManager.selector, POOL_A, makeAddr("AnotherManager"), true);
 
         // Create outer multicall: contains a nested multicall
         bytes[] memory outerCalls = new bytes[](1);
-        outerCalls[0] = abi.encodeWithSelector(
-            h.hub.multicall.selector,
-            innerCalls
-        );
+        outerCalls[0] = abi.encodeWithSelector(h.hub.multicall.selector, innerCalls);
 
         vm.startPrank(MANAGER);
         vm.deal(MANAGER, GAS);


### PR DESCRIPTION
## Problem

When `BatchedMulticall.multicall()` was called from within a batched multicall (nested call), the `msgSender()` function would incorrectly return the gateway address instead of the original caller. This occurred because the nested `multicall()` would unconditionally overwrite the transient `_sender` variable with `msg.sender`.

## Solution

The fix adds a check to detect nested calls before modifying `_sender`:

```solidity
bool isNested = _sender != address(0);
if (!isNested) _sender = msg.sender;
gateway.withBatch{value: msg.value}(...);
if (!isNested) _sender = address(0);
```