### PR TITLE
Minor move: VaultDetails to VaultRegistry

### DIFF
--- a/env/spell/003_base_0x21dbc1add7a52e47652e4a74dec4f28a77086bbd.sol
+++ b/env/spell/003_base_0x21dbc1add7a52e47652e4a74dec4f28a77086bbd.sol
@@ -13,7 +13,8 @@ import {ISpokeGatewayHandler} from "../../src/core/interfaces/IGatewayHandlers.s
 import {IBalanceSheetGatewayHandler} from "../../src/core/interfaces/IGatewayHandlers.sol";
 
 import {IBalanceSheet} from "../../src/core/spoke/interfaces/IBalanceSheet.sol";
-import {ISpoke, VaultDetails} from "../../src/core/spoke/interfaces/ISpoke.sol";
+import {ISpoke} from "../../src/core/spoke/interfaces/ISpoke.sol";
+import {VaultDetails} from "../../src/core/spoke/interfaces/IVaultRegistry.sol";
 
 import {BaseVault} from "../../src/vaults/BaseVaults.sol";
 import {IBaseVault} from "../../src/vaults/interfaces/IBaseVault.sol";

--- a/env/spell/003_bnb-smart-chain_0x086046cc2193f0184e03c8b1419a06f1f989e75a.sol
+++ b/env/spell/003_bnb-smart-chain_0x086046cc2193f0184e03c8b1419a06f1f989e75a.sol
@@ -13,7 +13,8 @@ import {ISpokeGatewayHandler} from "../../src/core/interfaces/IGatewayHandlers.s
 import {IBalanceSheetGatewayHandler} from "../../src/core/interfaces/IGatewayHandlers.sol";
 
 import {IBalanceSheet} from "../../src/core/spoke/interfaces/IBalanceSheet.sol";
-import {ISpoke, VaultDetails} from "../../src/core/spoke/interfaces/ISpoke.sol";
+import {ISpoke} from "../../src/core/spoke/interfaces/ISpoke.sol";
+import {VaultDetails} from "../../src/core/spoke/interfaces/IVaultRegistry.sol";
 
 import {BaseVault} from "../../src/vaults/BaseVaults.sol";
 import {IBaseVault} from "../../src/vaults/interfaces/IBaseVault.sol";

--- a/env/spell/003_ethereum_0x21dbc1add7a52e47652e4a74dec4f28a77086bbd.sol
+++ b/env/spell/003_ethereum_0x21dbc1add7a52e47652e4a74dec4f28a77086bbd.sol
@@ -13,7 +13,8 @@ import {ISpokeGatewayHandler} from "../../src/core/interfaces/IGatewayHandlers.s
 import {IBalanceSheetGatewayHandler} from "../../src/core/interfaces/IGatewayHandlers.sol";
 
 import {IBalanceSheet} from "../../src/core/spoke/interfaces/IBalanceSheet.sol";
-import {ISpoke, VaultDetails} from "../../src/core/spoke/interfaces/ISpoke.sol";
+import {ISpoke} from "../../src/core/spoke/interfaces/ISpoke.sol";
+import {VaultDetails} from "../../src/core/spoke/interfaces/IVaultRegistry.sol";
 
 import {BaseVault} from "../../src/vaults/BaseVaults.sol";
 import {IBaseVault} from "../../src/vaults/interfaces/IBaseVault.sol";

--- a/env/spell/004_avalanche_0x37271f54911a22156b39ab08e9f9738cc9bf55e4.sol
+++ b/env/spell/004_avalanche_0x37271f54911a22156b39ab08e9f9738cc9bf55e4.sol
@@ -94,7 +94,7 @@ import {VaultUpdateKind} from "../../src/core/messaging/libraries/MessageLib.sol
 import {ISpokeGatewayHandler} from "../../src/core/interfaces/IGatewayHandlers.sol";
 
 import {IVault} from "../../src/core/spoke/interfaces/IVault.sol";
-import {VaultDetails} from "../../src/core/spoke/interfaces/ISpoke.sol";
+import {VaultDetails} from "../../src/core/spoke/interfaces/IVaultRegistry.sol";
 
 import {IBaseVault} from "../../src/vaults/interfaces/IBaseVault.sol";
 

--- a/env/spell/004_base_0x37271f54911a22156b39ab08e9f9738cc9bf55e4.sol
+++ b/env/spell/004_base_0x37271f54911a22156b39ab08e9f9738cc9bf55e4.sol
@@ -94,7 +94,7 @@ import {VaultUpdateKind} from "../../src/core/messaging/libraries/MessageLib.sol
 import {ISpokeGatewayHandler} from "../../src/core/interfaces/IGatewayHandlers.sol";
 
 import {IVault} from "../../src/core/spoke/interfaces/IVault.sol";
-import {VaultDetails} from "../../src/core/spoke/interfaces/ISpoke.sol";
+import {VaultDetails} from "../../src/core/spoke/interfaces/IVaultRegistry.sol";
 
 import {IBaseVault} from "../../src/vaults/interfaces/IBaseVault.sol";
 

--- a/env/spell/004_ethereum_0x37271f54911a22156b39ab08e9f9738cc9bf55e4.sol
+++ b/env/spell/004_ethereum_0x37271f54911a22156b39ab08e9f9738cc9bf55e4.sol
@@ -94,7 +94,7 @@ import {VaultUpdateKind} from "../../src/core/messaging/libraries/MessageLib.sol
 import {ISpokeGatewayHandler} from "../../src/core/interfaces/IGatewayHandlers.sol";
 
 import {IVault} from "../../src/core/spoke/interfaces/IVault.sol";
-import {VaultDetails} from "../../src/core/spoke/interfaces/ISpoke.sol";
+import {VaultDetails} from "../../src/core/spoke/interfaces/IVaultRegistry.sol";
 
 import {IBaseVault} from "../../src/vaults/interfaces/IBaseVault.sol";
 

--- a/src/core/messaging/libraries/MessageLib.sol
+++ b/src/core/messaging/libraries/MessageLib.sol
@@ -642,7 +642,7 @@ library MessageLib {
         bytes16 scId;
         uint128 assetId;
         bytes32 vaultOrFactory;
-        uint8 kind;
+        uint8 kind; // VaultUpdateKind
     }
 
     function deserializeUpdateVault(bytes memory data) internal pure returns (UpdateVault memory) {

--- a/src/core/spoke/VaultRegistry.sol
+++ b/src/core/spoke/VaultRegistry.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
+import {ISpoke} from "./interfaces/ISpoke.sol";
 import {IShareToken} from "./interfaces/IShareToken.sol";
 import {IVault, VaultKind} from "./interfaces/IVault.sol";
-import {ISpoke} from "./interfaces/ISpoke.sol";
-import {VaultDetails, IVaultRegistry} from "./interfaces/IVaultRegistry.sol";
 import {IVaultFactory} from "./factories/interfaces/IVaultFactory.sol";
+import {VaultDetails, IVaultRegistry} from "./interfaces/IVaultRegistry.sol";
 
 import {Auth} from "../../misc/Auth.sol";
 import {Recoverable} from "../../misc/Recoverable.sol";

--- a/src/core/spoke/VaultRegistry.sol
+++ b/src/core/spoke/VaultRegistry.sol
@@ -3,8 +3,8 @@ pragma solidity 0.8.28;
 
 import {IShareToken} from "./interfaces/IShareToken.sol";
 import {IVault, VaultKind} from "./interfaces/IVault.sol";
-import {VaultDetails, ISpoke} from "./interfaces/ISpoke.sol";
-import {IVaultRegistry} from "./interfaces/IVaultRegistry.sol";
+import {ISpoke} from "./interfaces/ISpoke.sol";
+import {VaultDetails, IVaultRegistry} from "./interfaces/IVaultRegistry.sol";
 import {IVaultFactory} from "./factories/interfaces/IVaultFactory.sol";
 
 import {Auth} from "../../misc/Auth.sol";

--- a/src/core/spoke/interfaces/ISpoke.sol
+++ b/src/core/spoke/interfaces/ISpoke.sol
@@ -26,17 +26,6 @@ struct ShareClassDetails {
     Price pricePoolPerShare;
 }
 
-struct VaultDetails {
-    /// @dev AssetId of the asset
-    AssetId assetId;
-    /// @dev Address of the asset
-    address asset;
-    /// @dev TokenId of the asset - zero if asset is ERC20, non-zero if asset is ERC6909
-    uint256 tokenId;
-    /// @dev Whether the vault is linked to a share class atm
-    bool isLinked;
-}
-
 struct AssetIdKey {
     /// @dev The address of the asset
     address asset;

--- a/src/core/spoke/interfaces/IVaultRegistry.sol
+++ b/src/core/spoke/interfaces/IVaultRegistry.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {VaultDetails} from "./ISpoke.sol";
 import {IVault, VaultKind} from "./IVault.sol";
 
 import {PoolId} from "../../types/PoolId.sol";
@@ -9,6 +8,17 @@ import {AssetId} from "../../types/AssetId.sol";
 import {ShareClassId} from "../../types/ShareClassId.sol";
 import {IRequestManager} from "../../interfaces/IRequestManager.sol";
 import {IVaultFactory} from "../factories/interfaces/IVaultFactory.sol";
+
+struct VaultDetails {
+    /// @dev AssetId of the asset
+    AssetId assetId;
+    /// @dev Address of the asset
+    address asset;
+    /// @dev TokenId of the asset - zero if asset is ERC20, non-zero if asset is ERC6909
+    uint256 tokenId;
+    /// @dev Whether the vault is linked to a share class atm
+    bool isLinked;
+}
 
 interface IVaultRegistry {
     //----------------------------------------------------------------------------------------------

--- a/src/vaults/AsyncRequestManager.sol
+++ b/src/vaults/AsyncRequestManager.sol
@@ -29,9 +29,9 @@ import {IPoolEscrow} from "../core/spoke/interfaces/IPoolEscrow.sol";
 import {IShareToken} from "../core/spoke/interfaces/IShareToken.sol";
 import {IRequestManager} from "../core/interfaces/IRequestManager.sol";
 import {IBalanceSheet} from "../core/spoke/interfaces/IBalanceSheet.sol";
-import {ISpoke, VaultDetails} from "../core/spoke/interfaces/ISpoke.sol";
+import {ISpoke} from "../core/spoke/interfaces/ISpoke.sol";
 import {ESCROW_HOOK_ID} from "../core/spoke/interfaces/ITransferHook.sol";
-import {IVaultRegistry} from "../core/spoke/interfaces/IVaultRegistry.sol";
+import {VaultDetails, IVaultRegistry} from "../core/spoke/interfaces/IVaultRegistry.sol";
 import {ITrustedContractUpdate} from "../core/utils/interfaces/IContractUpdate.sol";
 
 /// @title  Async Request Manager

--- a/src/vaults/AsyncRequestManager.sol
+++ b/src/vaults/AsyncRequestManager.sol
@@ -22,6 +22,7 @@ import {BytesLib} from "../misc/libraries/BytesLib.sol";
 
 import {PoolId} from "../core/types/PoolId.sol";
 import {AssetId} from "../core/types/AssetId.sol";
+import {ISpoke} from "../core/spoke/interfaces/ISpoke.sol";
 import {IVault} from "../core/spoke/interfaces/IVault.sol";
 import {PricingLib} from "../core/libraries/PricingLib.sol";
 import {ShareClassId} from "../core/types/ShareClassId.sol";
@@ -29,10 +30,9 @@ import {IPoolEscrow} from "../core/spoke/interfaces/IPoolEscrow.sol";
 import {IShareToken} from "../core/spoke/interfaces/IShareToken.sol";
 import {IRequestManager} from "../core/interfaces/IRequestManager.sol";
 import {IBalanceSheet} from "../core/spoke/interfaces/IBalanceSheet.sol";
-import {ISpoke} from "../core/spoke/interfaces/ISpoke.sol";
 import {ESCROW_HOOK_ID} from "../core/spoke/interfaces/ITransferHook.sol";
-import {VaultDetails, IVaultRegistry} from "../core/spoke/interfaces/IVaultRegistry.sol";
 import {ITrustedContractUpdate} from "../core/utils/interfaces/IContractUpdate.sol";
+import {VaultDetails, IVaultRegistry} from "../core/spoke/interfaces/IVaultRegistry.sol";
 
 /// @title  Async Request Manager
 /// @notice This is the main contract vaults interact with for

--- a/src/vaults/SyncManager.sol
+++ b/src/vaults/SyncManager.sol
@@ -15,13 +15,13 @@ import {BytesLib} from "../misc/libraries/BytesLib.sol";
 
 import {PoolId} from "../core/types/PoolId.sol";
 import {AssetId} from "../core/types/AssetId.sol";
+import {ISpoke} from "../core/spoke/interfaces/ISpoke.sol";
 import {PricingLib} from "../core/libraries/PricingLib.sol";
 import {ShareClassId} from "../core/types/ShareClassId.sol";
 import {IShareToken} from "../core/spoke/interfaces/IShareToken.sol";
 import {IBalanceSheet} from "../core/spoke/interfaces/IBalanceSheet.sol";
-import {ISpoke} from "../core/spoke/interfaces/ISpoke.sol";
-import {VaultDetails, IVaultRegistry} from "../core/spoke/interfaces/IVaultRegistry.sol";
 import {ITrustedContractUpdate} from "../core/utils/interfaces/IContractUpdate.sol";
+import {VaultDetails, IVaultRegistry} from "../core/spoke/interfaces/IVaultRegistry.sol";
 
 /// @title  Sync Manager
 /// @notice This is the main contract for synchronous ERC-4626 deposits.

--- a/src/vaults/SyncManager.sol
+++ b/src/vaults/SyncManager.sol
@@ -19,8 +19,8 @@ import {PricingLib} from "../core/libraries/PricingLib.sol";
 import {ShareClassId} from "../core/types/ShareClassId.sol";
 import {IShareToken} from "../core/spoke/interfaces/IShareToken.sol";
 import {IBalanceSheet} from "../core/spoke/interfaces/IBalanceSheet.sol";
-import {ISpoke, VaultDetails} from "../core/spoke/interfaces/ISpoke.sol";
-import {IVaultRegistry} from "../core/spoke/interfaces/IVaultRegistry.sol";
+import {ISpoke} from "../core/spoke/interfaces/ISpoke.sol";
+import {VaultDetails, IVaultRegistry} from "../core/spoke/interfaces/IVaultRegistry.sol";
 import {ITrustedContractUpdate} from "../core/utils/interfaces/IContractUpdate.sol";
 
 /// @title  Sync Manager

--- a/src/vaults/VaultRouter.sol
+++ b/src/vaults/VaultRouter.sol
@@ -18,8 +18,8 @@ import {PoolId} from "../core/types/PoolId.sol";
 import {ShareClassId} from "../core/types/ShareClassId.sol";
 import {IGateway} from "../core/messaging/interfaces/IGateway.sol";
 import {BatchedMulticall} from "../core/utils/BatchedMulticall.sol";
-import {ISpoke, VaultDetails} from "../core/spoke/interfaces/ISpoke.sol";
-import {IVaultRegistry} from "../core/spoke/interfaces/IVaultRegistry.sol";
+import {ISpoke} from "../core/spoke/interfaces/ISpoke.sol";
+import {VaultDetails, IVaultRegistry} from "../core/spoke/interfaces/IVaultRegistry.sol";
 
 /// @title  VaultRouter
 /// @notice This is a helper contract, designed to be the entrypoint for EOAs.

--- a/src/vaults/VaultRouter.sol
+++ b/src/vaults/VaultRouter.sol
@@ -15,10 +15,10 @@ import {IERC20, IERC20Permit} from "../misc/interfaces/IERC20.sol";
 import {SafeTransferLib} from "../misc/libraries/SafeTransferLib.sol";
 
 import {PoolId} from "../core/types/PoolId.sol";
+import {ISpoke} from "../core/spoke/interfaces/ISpoke.sol";
 import {ShareClassId} from "../core/types/ShareClassId.sol";
 import {IGateway} from "../core/messaging/interfaces/IGateway.sol";
 import {BatchedMulticall} from "../core/utils/BatchedMulticall.sol";
-import {ISpoke} from "../core/spoke/interfaces/ISpoke.sol";
 import {VaultDetails, IVaultRegistry} from "../core/spoke/interfaces/IVaultRegistry.sol";
 
 /// @title  VaultRouter

--- a/test/core/spoke/integration/Spoke.t.sol
+++ b/test/core/spoke/integration/Spoke.t.sol
@@ -11,8 +11,8 @@ import {AssetId} from "../../../../src/core/types/AssetId.sol";
 import {ShareToken} from "../../../../src/core/spoke/ShareToken.sol";
 import {IVault} from "../../../../src/core/spoke/interfaces/IVault.sol";
 import {ShareClassId} from "../../../../src/core/types/ShareClassId.sol";
-import {VaultDetails} from "../../../../src/core/spoke/interfaces/IVaultRegistry.sol";
 import {MessageLib} from "../../../../src/core/messaging/libraries/MessageLib.sol";
+import {VaultDetails} from "../../../../src/core/spoke/interfaces/IVaultRegistry.sol";
 
 import {UpdateRestrictionMessageLib} from "../../../../src/hooks/libraries/UpdateRestrictionMessageLib.sol";
 

--- a/test/core/spoke/integration/Spoke.t.sol
+++ b/test/core/spoke/integration/Spoke.t.sol
@@ -11,7 +11,7 @@ import {AssetId} from "../../../../src/core/types/AssetId.sol";
 import {ShareToken} from "../../../../src/core/spoke/ShareToken.sol";
 import {IVault} from "../../../../src/core/spoke/interfaces/IVault.sol";
 import {ShareClassId} from "../../../../src/core/types/ShareClassId.sol";
-import {VaultDetails} from "../../../../src/core/spoke/interfaces/ISpoke.sol";
+import {VaultDetails} from "../../../../src/core/spoke/interfaces/IVaultRegistry.sol";
 import {MessageLib} from "../../../../src/core/messaging/libraries/MessageLib.sol";
 
 import {UpdateRestrictionMessageLib} from "../../../../src/hooks/libraries/UpdateRestrictionMessageLib.sol";

--- a/test/core/spoke/mocks/MockCentrifugeChain.sol
+++ b/test/core/spoke/mocks/MockCentrifugeChain.sol
@@ -7,8 +7,8 @@ import {CastLib} from "../../../../src/misc/libraries/CastLib.sol";
 import {Spoke} from "../../../../src/core/spoke/Spoke.sol";
 import {PoolId} from "../../../../src/core/types/PoolId.sol";
 import {VaultRegistry} from "../../../../src/core/spoke/VaultRegistry.sol";
-import {VaultDetails} from "../../../../src/core/spoke/interfaces/IVaultRegistry.sol";
 import {IAdapter} from "../../../../src/core/messaging/interfaces/IAdapter.sol";
+import {VaultDetails} from "../../../../src/core/spoke/interfaces/IVaultRegistry.sol";
 import {MessageLib, VaultUpdateKind} from "../../../../src/core/messaging/libraries/MessageLib.sol";
 
 import {UpdateRestrictionMessageLib} from "../../../../src/hooks/libraries/UpdateRestrictionMessageLib.sol";

--- a/test/core/spoke/mocks/MockCentrifugeChain.sol
+++ b/test/core/spoke/mocks/MockCentrifugeChain.sol
@@ -7,7 +7,7 @@ import {CastLib} from "../../../../src/misc/libraries/CastLib.sol";
 import {Spoke} from "../../../../src/core/spoke/Spoke.sol";
 import {PoolId} from "../../../../src/core/types/PoolId.sol";
 import {VaultRegistry} from "../../../../src/core/spoke/VaultRegistry.sol";
-import {VaultDetails} from "../../../../src/core/spoke/interfaces/ISpoke.sol";
+import {VaultDetails} from "../../../../src/core/spoke/interfaces/IVaultRegistry.sol";
 import {IAdapter} from "../../../../src/core/messaging/interfaces/IAdapter.sol";
 import {MessageLib, VaultUpdateKind} from "../../../../src/core/messaging/libraries/MessageLib.sol";
 

--- a/test/vaults/integration/SyncDeposit.t.sol
+++ b/test/vaults/integration/SyncDeposit.t.sol
@@ -15,7 +15,7 @@ import {PoolId} from "../../../src/core/types/PoolId.sol";
 import {AssetId} from "../../../src/core/types/AssetId.sol";
 import {IVault} from "../../../src/core/spoke/interfaces/IVault.sol";
 import {ShareClassId} from "../../../src/core/types/ShareClassId.sol";
-import {VaultDetails} from "../../../src/core/spoke/interfaces/ISpoke.sol";
+import {VaultDetails} from "../../../src/core/spoke/interfaces/IVaultRegistry.sol";
 import {MessageLib} from "../../../src/core/messaging/libraries/MessageLib.sol";
 import {IBalanceSheet} from "../../../src/core/spoke/interfaces/IBalanceSheet.sol";
 

--- a/test/vaults/integration/SyncDeposit.t.sol
+++ b/test/vaults/integration/SyncDeposit.t.sol
@@ -15,9 +15,9 @@ import {PoolId} from "../../../src/core/types/PoolId.sol";
 import {AssetId} from "../../../src/core/types/AssetId.sol";
 import {IVault} from "../../../src/core/spoke/interfaces/IVault.sol";
 import {ShareClassId} from "../../../src/core/types/ShareClassId.sol";
-import {VaultDetails} from "../../../src/core/spoke/interfaces/IVaultRegistry.sol";
 import {MessageLib} from "../../../src/core/messaging/libraries/MessageLib.sol";
 import {IBalanceSheet} from "../../../src/core/spoke/interfaces/IBalanceSheet.sol";
+import {VaultDetails} from "../../../src/core/spoke/interfaces/IVaultRegistry.sol";
 
 import {IBaseVault} from "../../../src/vaults/interfaces/IBaseVault.sol";
 import {SyncDepositVault} from "../../../src/vaults/SyncDepositVault.sol";

--- a/test/vaults/unit/AsyncRequestManager.t.sol
+++ b/test/vaults/unit/AsyncRequestManager.t.sol
@@ -9,6 +9,7 @@ import {IERC7575} from "../../../src/misc/interfaces/IERC7575.sol";
 import {IERC20Metadata} from "../../../src/misc/interfaces/IERC20.sol";
 
 import {PoolId} from "../../../src/core/types/PoolId.sol";
+import {ISpoke} from "../../../src/core/spoke/interfaces/ISpoke.sol";
 import {IVault} from "../../../src/core/spoke/interfaces/IVault.sol";
 import {PricingLib} from "../../../src/core/libraries/PricingLib.sol";
 import {ShareClassId} from "../../../src/core/types/ShareClassId.sol";
@@ -17,7 +18,6 @@ import {IGateway} from "../../../src/core/messaging/interfaces/IGateway.sol";
 import {IPoolEscrow} from "../../../src/core/spoke/interfaces/IPoolEscrow.sol";
 import {IShareToken} from "../../../src/core/spoke/interfaces/IShareToken.sol";
 import {IBalanceSheet} from "../../../src/core/spoke/interfaces/IBalanceSheet.sol";
-import {ISpoke} from "../../../src/core/spoke/interfaces/ISpoke.sol";
 import {VaultDetails, IVaultRegistry} from "../../../src/core/spoke/interfaces/IVaultRegistry.sol";
 
 import {IBaseVault} from "../../../src/vaults/interfaces/IBaseVault.sol";

--- a/test/vaults/unit/AsyncRequestManager.t.sol
+++ b/test/vaults/unit/AsyncRequestManager.t.sol
@@ -17,8 +17,8 @@ import {IGateway} from "../../../src/core/messaging/interfaces/IGateway.sol";
 import {IPoolEscrow} from "../../../src/core/spoke/interfaces/IPoolEscrow.sol";
 import {IShareToken} from "../../../src/core/spoke/interfaces/IShareToken.sol";
 import {IBalanceSheet} from "../../../src/core/spoke/interfaces/IBalanceSheet.sol";
-import {ISpoke, VaultDetails} from "../../../src/core/spoke/interfaces/ISpoke.sol";
-import {IVaultRegistry} from "../../../src/core/spoke/interfaces/IVaultRegistry.sol";
+import {ISpoke} from "../../../src/core/spoke/interfaces/ISpoke.sol";
+import {VaultDetails, IVaultRegistry} from "../../../src/core/spoke/interfaces/IVaultRegistry.sol";
 
 import {IBaseVault} from "../../../src/vaults/interfaces/IBaseVault.sol";
 import {IAsyncVault} from "../../../src/vaults/interfaces/IAsyncVault.sol";

--- a/test/vaults/unit/SyncManager.t.sol
+++ b/test/vaults/unit/SyncManager.t.sol
@@ -10,8 +10,8 @@ import {AssetId} from "../../../src/core/types/AssetId.sol";
 import {ShareClassId} from "../../../src/core/types/ShareClassId.sol";
 import {IShareToken} from "../../../src/core/spoke/interfaces/IShareToken.sol";
 import {IBalanceSheet} from "../../../src/core/spoke/interfaces/IBalanceSheet.sol";
-import {ISpoke, VaultDetails} from "../../../src/core/spoke/interfaces/ISpoke.sol";
-import {IVaultRegistry} from "../../../src/core/spoke/interfaces/IVaultRegistry.sol";
+import {ISpoke} from "../../../src/core/spoke/interfaces/ISpoke.sol";
+import {VaultDetails, IVaultRegistry} from "../../../src/core/spoke/interfaces/IVaultRegistry.sol";
 
 import {SyncManager} from "../../../src/vaults/SyncManager.sol";
 import {IBaseVault} from "../../../src/vaults/interfaces/IBaseVault.sol";

--- a/test/vaults/unit/SyncManager.t.sol
+++ b/test/vaults/unit/SyncManager.t.sol
@@ -7,10 +7,10 @@ import {IERC20Metadata} from "../../../src/misc/interfaces/IERC20.sol";
 
 import {PoolId} from "../../../src/core/types/PoolId.sol";
 import {AssetId} from "../../../src/core/types/AssetId.sol";
+import {ISpoke} from "../../../src/core/spoke/interfaces/ISpoke.sol";
 import {ShareClassId} from "../../../src/core/types/ShareClassId.sol";
 import {IShareToken} from "../../../src/core/spoke/interfaces/IShareToken.sol";
 import {IBalanceSheet} from "../../../src/core/spoke/interfaces/IBalanceSheet.sol";
-import {ISpoke} from "../../../src/core/spoke/interfaces/ISpoke.sol";
 import {VaultDetails, IVaultRegistry} from "../../../src/core/spoke/interfaces/IVaultRegistry.sol";
 
 import {SyncManager} from "../../../src/vaults/SyncManager.sol";


### PR DESCRIPTION
Minor change that just move the `VaultDetails` struct declaration to `IVaultRegistry` (the expected place) instead of `ISpoke`.

No "real" code touch, just an struct movement