### PR TITLE
Ref: LaunchDeployer using EnvConfig

### DIFF
--- a/script/FullDeployer.s.sol
+++ b/script/FullDeployer.s.sol
@@ -154,10 +154,7 @@ contract FullActionBatcher is CoreActionBatcher {
 
         report.batchRequestManager.rely(address(report.root));
 
-        if (address(report.layerZeroAdapter) != address(0)) report.layerZeroAdapter.rely(address(report.root));
-        if (address(report.wormholeAdapter) != address(0)) report.wormholeAdapter.rely(address(report.root));
-        if (address(report.axelarAdapter) != address(0)) report.axelarAdapter.rely(address(report.root));
-        if (address(report.chainlinkAdapter) != address(0)) report.chainlinkAdapter.rely(address(report.root));
+        _relyAdapters(report, address(report.root));
 
         // Rely spoke
         report.asyncRequestManager.rely(address(report.core.spoke));
@@ -181,25 +178,13 @@ contract FullActionBatcher is CoreActionBatcher {
         report.root.rely(address(report.protocolGuardian));
         report.tokenRecoverer.rely(address(report.protocolGuardian));
         // Permanent ward for ongoing adapter maintenance
-        if (address(report.layerZeroAdapter) != address(0)) {
-            report.layerZeroAdapter.rely(address(report.protocolGuardian));
-        }
-        if (address(report.wormholeAdapter) != address(0)) {
-            report.wormholeAdapter.rely(address(report.protocolGuardian));
-        }
-        if (address(report.axelarAdapter) != address(0)) report.axelarAdapter.rely(address(report.protocolGuardian));
-        if (address(report.chainlinkAdapter) != address(0)) {
-            report.chainlinkAdapter.rely(address(report.protocolGuardian));
-        }
+        _relyAdapters(report, address(report.protocolGuardian));
 
         // Rely opsGuardian
         report.core.multiAdapter.rely(address(report.opsGuardian));
         report.core.hub.rely(address(report.opsGuardian));
         // Temporal ward for initial adapter wiring
-        if (address(report.layerZeroAdapter) != address(0)) report.layerZeroAdapter.rely(address(report.opsGuardian));
-        if (address(report.wormholeAdapter) != address(0)) report.wormholeAdapter.rely(address(report.opsGuardian));
-        if (address(report.axelarAdapter) != address(0)) report.axelarAdapter.rely(address(report.opsGuardian));
-        if (address(report.chainlinkAdapter) != address(0)) report.chainlinkAdapter.rely(address(report.opsGuardian));
+        _relyAdapters(report, address(report.opsGuardian));
 
         // Rely tokenRecoverer
         report.root.rely(address(report.tokenRecoverer));
@@ -343,6 +328,13 @@ contract FullActionBatcher is CoreActionBatcher {
         if (address(report.axelarAdapter) != address(0)) report.axelarAdapter.deny(address(this));
         if (address(report.layerZeroAdapter) != address(0)) report.layerZeroAdapter.deny(address(this));
         if (address(report.chainlinkAdapter) != address(0)) report.chainlinkAdapter.deny(address(this));
+    }
+
+    function _relyAdapters(FullReport memory report, address ward) internal {
+        if (address(report.layerZeroAdapter) != address(0)) report.layerZeroAdapter.rely(ward);
+        if (address(report.wormholeAdapter) != address(0)) report.wormholeAdapter.rely(ward);
+        if (address(report.axelarAdapter) != address(0)) report.axelarAdapter.rely(ward);
+        if (address(report.chainlinkAdapter) != address(0)) report.chainlinkAdapter.rely(ward);
     }
 
     function _setLayerZeroUlnConfig(LayerZeroAdapter adapter, uint32 eid, SetConfigParam memory param) internal {

--- a/script/FullDeployer.s.sol
+++ b/script/FullDeployer.s.sol
@@ -625,6 +625,11 @@ contract FullDeployer is CoreDeployer {
             require(input.adapters.layerZero.endpoint != address(0), "LayerZero endpoint address cannot be zero");
             require(input.adapters.layerZero.endpoint.code.length > 0, "LayerZero endpoint must be a deployed contract");
             require(input.adapters.layerZero.delegate != address(0), "LayerZero delegate address cannot be zero");
+            require(
+                input.adapters.layerZero.configParams.length == 0
+                    || input.adapters.layerZero.configParams.length != input.adapters.connections.length,
+                "configParams must mimics connections"
+            );
 
             layerZeroAdapter = LayerZeroAdapter(
                 create3(

--- a/script/FullDeployer.s.sol
+++ b/script/FullDeployer.s.sol
@@ -627,7 +627,7 @@ contract FullDeployer is CoreDeployer {
             require(input.adapters.layerZero.delegate != address(0), "LayerZero delegate address cannot be zero");
             require(
                 input.adapters.layerZero.configParams.length == 0
-                    || input.adapters.layerZero.configParams.length != input.adapters.connections.length,
+                    || input.adapters.layerZero.configParams.length == input.adapters.connections.length,
                 "configParams must mimics connections"
             );
 

--- a/script/FullDeployer.s.sol
+++ b/script/FullDeployer.s.sol
@@ -90,7 +90,7 @@ struct AdaptersInput {
 }
 
 struct FullInput {
-    ISafe adminSafe;
+    ISafe protocolSafe;
     ISafe opsSafe;
     CoreInput core;
     AdaptersInput adapters;
@@ -231,10 +231,10 @@ contract FullActionBatcher is CoreActionBatcher {
         report.syncManager.rely(address(report.syncDepositVaultFactory));
         report.asyncRequestManager.rely(address(report.syncDepositVaultFactory));
 
-        // Rely adminSafe
+        // Rely protocolSafe
         if (address(report.layerZeroAdapter) != address(0)) {
             // Needed for setDelegate calls
-            report.layerZeroAdapter.rely(address(input.adminSafe));
+            report.layerZeroAdapter.rely(address(input.protocolSafe));
         }
 
         // File methods
@@ -243,7 +243,7 @@ contract FullActionBatcher is CoreActionBatcher {
 
         report.opsGuardian.file("opsSafe", address(input.opsSafe));
 
-        report.protocolGuardian.file("safe", address(input.adminSafe));
+        report.protocolGuardian.file("safe", address(input.protocolSafe));
 
         report.refundEscrowFactory.file(bytes32("controller"), address(report.subsidyManager));
 
@@ -368,7 +368,7 @@ contract FullActionBatcher is CoreActionBatcher {
 contract FullDeployer is CoreDeployer {
     uint256 public constant DELAY = 48 hours;
 
-    ISafe public adminSafe;
+    ISafe public protocolSafe;
     ISafe public opsSafe;
 
     Root public root;
@@ -411,7 +411,7 @@ contract FullDeployer is CoreDeployer {
     function deployFull(FullInput memory input, FullActionBatcher batcher) public {
         _init(input.core.version, batcher.deployer());
 
-        adminSafe = input.adminSafe;
+        protocolSafe = input.protocolSafe;
         opsSafe = input.opsSafe;
 
         root =

--- a/script/LaunchDeployer.s.sol
+++ b/script/LaunchDeployer.s.sol
@@ -73,7 +73,7 @@ contract LaunchDeployer is FullDeployer {
                     shouldDeploy: config.adapters.layerZero.deploy,
                     endpoint: config.adapters.layerZero.endpoint,
                     delegate: config.network.protocolAdmin,
-                    configParams: config.buildZeroConfigParams()
+                    configParams: config.buildLayerZeroConfigParams()
                 }),
                 wormhole: WormholeInput({
                     shouldDeploy: config.adapters.wormhole.deploy, relayer: config.adapters.wormhole.relayer

--- a/script/LaunchDeployer.s.sol
+++ b/script/LaunchDeployer.s.sol
@@ -53,7 +53,7 @@ contract LaunchDeployer is FullDeployer {
 
         // Hardcoded wards to double-check a correct mainnet deployment
         if (config.network.isMainnet()) {
-            require(address(input.adminSafe) == 0x9711730060C73Ee7Fcfe1890e8A0993858a7D225, "wrong safe admin");
+            require(address(input.protocolSafe) == 0x9711730060C73Ee7Fcfe1890e8A0993858a7D225, "wrong safe admin");
             require(address(input.opsSafe) == 0xd21413291444C5c104F1b5918cA0D2f6EC91Ad16, "wrong ops admin");
             require(msg.sender == 0x926702C7f1af679a8f99A40af8917DDd82fD6F6c, "wrong deployer");
         }
@@ -63,7 +63,7 @@ contract LaunchDeployer is FullDeployer {
 
     function _buildFullInput(EnvConfig memory config, bytes32 version) internal view returns (FullInput memory) {
         return FullInput({
-            adminSafe: ISafe(config.network.protocolAdmin),
+            protocolSafe: ISafe(config.network.protocolAdmin),
             opsSafe: ISafe(config.network.opsAdmin),
             core: CoreInput({
                 centrifugeId: config.network.centrifugeId, version: version, txLimits: config.network.buildBatchLimits()

--- a/script/LaunchDeployer.s.sol
+++ b/script/LaunchDeployer.s.sol
@@ -70,7 +70,8 @@ contract LaunchDeployer is FullDeployer {
                 layerZero: LayerZeroInput({
                     shouldDeploy: _parseJsonBoolOrDefault(config, "$.adapters.layerZero.deploy"),
                     endpoint: _parseJsonAddressOrDefault(config, "$.adapters.layerZero.endpoint"),
-                    delegate: protocolAdmin
+                    delegate: protocolAdmin,
+                    configParams: new SetConfigParam[](0)
                 }),
                 wormhole: WormholeInput({
                     shouldDeploy: _parseJsonBoolOrDefault(config, "$.adapters.wormhole.deploy"),
@@ -175,10 +176,10 @@ contract LaunchDeployer is FullDeployer {
                 chainlinkId: _parseJsonBoolOrDefault(remoteConfig, "$.adapters.chainlink.deploy")
                     ? uint64(_parseJsonUintOrDefault(remoteConfig, "$.adapters.chainlink.chainSelector"))
                     : 0,
-                threshold: uint8(_parseJsonUintOrDefault(remoteConfig, "$.adapters.threshold")),
-                layerZeroConfigParams: _getLayerZeroConfigParams(
+                threshold: uint8(_parseJsonUintOrDefault(remoteConfig, "$.adapters.threshold"))
+                /*layerZeroConfigParams: _getLayerZeroConfigParams(
                         layerZeroId, layerZeroBlockConfirmations, layerZeroDvns
-                    )
+                    )*/
             });
         }
     }

--- a/script/LaunchDeployer.s.sol
+++ b/script/LaunchDeployer.s.sol
@@ -2,7 +2,8 @@
 pragma solidity 0.8.28;
 
 import {CoreInput, makeSalt} from "./CoreDeployer.s.sol";
-import {UlnConfig, SetConfigParam} from "./utils/ILayerZeroEndpointV2Like.sol";
+import {SetConfigParam} from "./utils/ILayerZeroEndpointV2Like.sol";
+import {EnvConfig, Env, prettyEnvString} from "./utils/EnvConfig.s.sol";
 import {
     FullInput,
     FullActionBatcher,
@@ -12,12 +13,10 @@ import {
     AxelarInput,
     LayerZeroInput,
     ChainlinkInput,
-    AdapterConnections,
-    MAX_ADAPTER_COUNT
+    AdapterConnections
 } from "./FullDeployer.s.sol";
 
 import {CastLib} from "../src/misc/libraries/CastLib.sol";
-import {MathLib} from "../src/misc/libraries/MathLib.sol";
 
 import {ISafe} from "../src/admin/interfaces/ISafe.sol";
 
@@ -25,70 +24,17 @@ import "forge-std/Script.sol";
 
 contract LaunchDeployer is FullDeployer {
     using CastLib for *;
-    using MathLib for *;
 
     function run() public virtual {
         vm.startBroadcast();
         captureStartBlock();
 
-        string memory network;
-        string memory config;
-        try vm.envString("NETWORK") returns (string memory _network) {
-            network = _network;
-            string memory configFile = string.concat("env/", network, ".json");
-            config = vm.readFile(configFile);
-        } catch {
-            console.log("NETWORK environment variable is not set, this must be a mocked test");
-            revert("NETWORK environment variable is required");
-        }
-
-        uint16 centrifugeId = uint16(vm.parseJsonUint(config, "$.network.centrifugeId"));
-        string memory environment = vm.parseJsonString(config, "$.network.environment");
-        bool isTestnet = keccak256(bytes(environment)) == keccak256("testnet");
-
-        console.log("Network:", network);
-        console.log("Environment:", environment);
-
-        bytes32 version = vm.envOr("VERSION", string("")).toBytes32();
-        console.log("Version:", version.toString());
-        console.log("\n\n---------\n\nStarting deployment for chain ID: %s\n\n", vm.toString(block.chainid));
+        EnvConfig memory config = Env.load(prettyEnvString("NETWORK"));
+        bytes32 version = prettyEnvString("VERSION").toBytes32();
 
         startDeploymentOutput();
 
-        address[] memory layerZeroDVNs = _parseAndValidateLayerZeroConfig(config);
-        uint8 layerZeroBlockConfirmations = layerZeroDVNs.length > 0
-            ? uint8(_parseJsonUintOrDefault(config, "$.adapters.layerZero.blockConfirmations"))
-            : 0;
-
-        address protocolAdmin = vm.parseJsonAddress(config, "$.network.protocolAdmin");
-
-        FullInput memory input = FullInput({
-            adminSafe: ISafe(protocolAdmin),
-            opsSafe: ISafe(vm.parseJsonAddress(config, "$.network.opsAdmin")),
-            core: CoreInput({centrifugeId: centrifugeId, version: version, txLimits: _parseBatchLimits(config)}),
-            adapters: AdaptersInput({
-                layerZero: LayerZeroInput({
-                    shouldDeploy: _parseJsonBoolOrDefault(config, "$.adapters.layerZero.deploy"),
-                    endpoint: _parseJsonAddressOrDefault(config, "$.adapters.layerZero.endpoint"),
-                    delegate: protocolAdmin,
-                    configParams: new SetConfigParam[](0)
-                }),
-                wormhole: WormholeInput({
-                    shouldDeploy: _parseJsonBoolOrDefault(config, "$.adapters.wormhole.deploy"),
-                    relayer: _parseJsonAddressOrDefault(config, "$.adapters.wormhole.relayer")
-                }),
-                axelar: AxelarInput({
-                    shouldDeploy: _parseJsonBoolOrDefault(config, "$.adapters.axelar.deploy"),
-                    gateway: _parseJsonAddressOrDefault(config, "$.adapters.axelar.gateway"),
-                    gasService: _parseJsonAddressOrDefault(config, "$.adapters.axelar.gasService")
-                }),
-                chainlink: ChainlinkInput({
-                    shouldDeploy: _parseJsonBoolOrDefault(config, "$.adapters.chainlink.deploy"),
-                    ccipRouter: _parseJsonAddressOrDefault(config, "$.adapters.chainlink.ccipRouter")
-                }),
-                connections: _buildConnections(_parseConnections(config), layerZeroDVNs, layerZeroBlockConfirmations)
-            })
-        });
+        FullInput memory input = _buildFullInput(config, version);
 
         FullActionBatcher batcher = FullActionBatcher(
             create3(
@@ -106,7 +52,7 @@ contract LaunchDeployer is FullDeployer {
         saveDeploymentOutput();
 
         // Hardcoded wards to double-check a correct mainnet deployment
-        if (!isTestnet) {
+        if (config.network.isMainnet()) {
             require(address(input.adminSafe) == 0x9711730060C73Ee7Fcfe1890e8A0993858a7D225, "wrong safe admin");
             require(address(input.opsSafe) == 0xd21413291444C5c104F1b5918cA0D2f6EC91Ad16, "wrong ops admin");
             require(msg.sender == 0x926702C7f1af679a8f99A40af8917DDd82fD6F6c, "wrong deployer");
@@ -115,163 +61,55 @@ contract LaunchDeployer is FullDeployer {
         vm.stopBroadcast();
     }
 
-    function _parseJsonBoolOrDefault(string memory config, string memory path) private pure returns (bool) {
-        try vm.parseJsonBool(config, path) returns (bool value) {
-            return value;
-        } catch {
-            return false;
-        }
+    function _buildFullInput(EnvConfig memory config, bytes32 version) internal view returns (FullInput memory) {
+        return FullInput({
+            adminSafe: ISafe(config.network.protocolAdmin),
+            opsSafe: ISafe(config.network.opsAdmin),
+            core: CoreInput({
+                centrifugeId: config.network.centrifugeId, version: version, txLimits: config.network.buildBatchLimits()
+            }),
+            adapters: AdaptersInput({
+                layerZero: LayerZeroInput({
+                    shouldDeploy: config.adapters.layerZero.deploy,
+                    endpoint: config.adapters.layerZero.endpoint,
+                    delegate: config.network.protocolAdmin,
+                    configParams: config.buildZeroConfigParams()
+                }),
+                wormhole: WormholeInput({
+                    shouldDeploy: config.adapters.wormhole.deploy, relayer: config.adapters.wormhole.relayer
+                }),
+                axelar: AxelarInput({
+                    shouldDeploy: config.adapters.axelar.deploy,
+                    gateway: config.adapters.axelar.gateway,
+                    gasService: config.adapters.axelar.gasService
+                }),
+                chainlink: ChainlinkInput({
+                    shouldDeploy: config.adapters.chainlink.deploy, ccipRouter: config.adapters.chainlink.ccipRouter
+                }),
+                connections: _buildConnections(config)
+            })
+        });
     }
 
-    function _parseJsonAddressOrDefault(string memory config, string memory path) private pure returns (address) {
-        try vm.parseJsonAddress(config, path) returns (address value) {
-            return value;
-        } catch {
-            return address(0);
-        }
-    }
-
-    function _parseJsonUintOrDefault(string memory config, string memory path) private pure returns (uint256) {
-        try vm.parseJsonUint(config, path) returns (uint256 value) {
-            return value;
-        } catch {
-            return 0;
-        }
-    }
-
-    function _parseJsonStringOrDefault(string memory config, string memory path) private pure returns (string memory) {
-        try vm.parseJsonString(config, path) returns (string memory value) {
-            return value;
-        } catch {
-            return "";
-        }
-    }
-
-    function _buildConnections(
-        string[] memory connectsTo,
-        address[] memory layerZeroDvns,
-        uint8 layerZeroBlockConfirmations
-    ) private view returns (AdapterConnections[] memory connections) {
+    function _buildConnections(EnvConfig memory config)
+        internal
+        view
+        returns (AdapterConnections[] memory connections)
+    {
+        string[] memory connectsTo = config.network.connectsTo;
         connections = new AdapterConnections[](connectsTo.length);
 
         for (uint256 i; i < connectsTo.length; i++) {
-            string memory remoteConfigFile = string.concat("env/", connectsTo[i], ".json");
-            string memory remoteConfig = vm.readFile(remoteConfigFile);
-
-            _checkLayerZeroConfiguration(layerZeroDvns, layerZeroBlockConfirmations, remoteConfig);
-
-            uint32 layerZeroId = _parseJsonBoolOrDefault(remoteConfig, "$.adapters.layerZero.deploy")
-                ? uint32(_parseJsonUintOrDefault(remoteConfig, "$.adapters.layerZero.layerZeroEid"))
-                : 0;
+            EnvConfig memory remoteConfig = Env.load(connectsTo[i]);
 
             connections[i] = AdapterConnections({
-                centrifugeId: uint16(_parseJsonUintOrDefault(remoteConfig, "$.network.centrifugeId")),
-                layerZeroId: layerZeroId,
-                wormholeId: _parseJsonBoolOrDefault(remoteConfig, "$.adapters.wormhole.deploy")
-                    ? uint16(_parseJsonUintOrDefault(remoteConfig, "$.adapters.wormhole.wormholeId"))
-                    : 0,
-                axelarId: _parseJsonBoolOrDefault(remoteConfig, "$.adapters.axelar.deploy")
-                    ? _parseJsonStringOrDefault(remoteConfig, "$.adapters.axelar.axelarId")
-                    : "",
-                chainlinkId: _parseJsonBoolOrDefault(remoteConfig, "$.adapters.chainlink.deploy")
-                    ? uint64(_parseJsonUintOrDefault(remoteConfig, "$.adapters.chainlink.chainSelector"))
-                    : 0,
-                threshold: uint8(_parseJsonUintOrDefault(remoteConfig, "$.adapters.threshold"))
-                /*layerZeroConfigParams: _getLayerZeroConfigParams(
-                        layerZeroId, layerZeroBlockConfirmations, layerZeroDvns
-                    )*/
+                centrifugeId: remoteConfig.network.centrifugeId,
+                layerZeroId: remoteConfig.adapters.layerZero.layerZeroEid,
+                wormholeId: remoteConfig.adapters.wormhole.wormholeId,
+                axelarId: remoteConfig.adapters.axelar.axelarId,
+                chainlinkId: remoteConfig.adapters.chainlink.chainSelector,
+                threshold: remoteConfig.adapters.threshold
             });
         }
-    }
-
-    function _parseConnections(string memory config) internal pure returns (string[] memory connectsTo) {
-        try vm.parseJsonStringArray(config, "$.network.connectsTo") returns (string[] memory connectsTo_) {
-            return connectsTo_;
-        } catch {
-            return new string[](0);
-        }
-    }
-
-    function _checkLayerZeroConfiguration(
-        address[] memory layerZeroDvns,
-        uint8 layerZeroBlockConfirmations,
-        string memory remoteConfig
-    ) private pure {
-        if (layerZeroDvns.length == 0) return;
-
-        uint8 remoteBlockConfirmations =
-            uint8(_parseJsonUintOrDefault(remoteConfig, "$.adapters.layerZero.blockConfirmations"));
-        require(
-            remoteBlockConfirmations == layerZeroBlockConfirmations,
-            "blockConfirmations mismatch between local and remote config"
-        );
-    }
-
-    function _parseAndValidateLayerZeroConfig(string memory config) private pure returns (address[] memory) {
-        try vm.parseJsonStringArray(config, "$.adapters.layerZero.DVNs") returns (string[] memory dvns) {
-            address[] memory layerZeroDVNs = new address[](dvns.length);
-            for (uint256 i; i < dvns.length; i++) {
-                layerZeroDVNs[i] = vm.parseAddress(dvns[i]);
-            }
-            for (uint256 i = 1; i < layerZeroDVNs.length; i++) {
-                require(layerZeroDVNs[i - 1] < layerZeroDVNs[i], "DVNs must be sorted in ascending order");
-            }
-
-            return layerZeroDVNs;
-        } catch {
-            return new address[](0);
-        }
-    }
-
-    /// @notice Gets LayerZero SetConfigParam[] for a given connection
-    /// @param layerZeroId The LayerZero endpoint id for the remote chain
-    /// @param blockConfirmations block confirmations required
-    /// @param dvns Required DVN addresses
-    ///             Must be sorted alphabetically
-    ///             Must be the same DVNs everywhere, though addresses can differ per chain
-    function _getLayerZeroConfigParams(uint32 layerZeroId, uint8 blockConfirmations, address[] memory dvns)
-        internal
-        pure
-        returns (SetConfigParam[] memory params)
-    {
-        if (dvns.length == 0) {
-            return new SetConfigParam[](0);
-        }
-
-        uint32 ULN_CONFIG_TYPE = 2;
-
-        /// @notice UlnConfig controls verification threshold for incoming messages
-        /// @notice Receive config enforces these settings have been applied to the DVNs and Executor
-        /// @dev 0 values will be interpreted as defaults, so to apply NIL settings, use:
-        /// @dev uint8 internal constant NIL_DVN_COUNT = type(uint8).max;
-        /// @dev uint64 internal constant NIL_CONFIRMATIONS = type(uint64).max;
-        /// @dev confirmations must be the same on the source and destination chains
-        UlnConfig memory uln = UlnConfig({
-            confirmations: blockConfirmations,
-            requiredDVNCount: uint8(dvns.length),
-            optionalDVNCount: type(uint8).max,
-            optionalDVNThreshold: 0,
-            requiredDVNs: dvns,
-            optionalDVNs: new address[](0)
-        });
-
-        params = new SetConfigParam[](1);
-        params[0] = SetConfigParam(layerZeroId, ULN_CONFIG_TYPE, abi.encode(uln));
-    }
-
-    function _parseBatchLimits(string memory config) private view returns (uint8[32] memory batchLimits) {
-        try vm.parseJsonStringArray(config, "$.network.connectsTo") returns (string[] memory connectsTo) {
-            for (uint256 i; i < connectsTo.length; i++) {
-                string memory remoteConfigFile = string.concat("env/", connectsTo[i], ".json");
-                string memory remoteConfig = vm.readFile(remoteConfigFile);
-
-                uint16 centrifugeId = _parseJsonUintOrDefault(remoteConfig, "$.network.centrifugeId").toUint16();
-                if (centrifugeId <= 31) {
-                    batchLimits[centrifugeId] = _parseJsonUintOrDefault(remoteConfig, "$.network.batchLimit").toUint8();
-                } else {
-                    revert("loaded centrifugeId value higher than 31");
-                }
-            }
-        } catch {}
     }
 }

--- a/script/LaunchDeployer.s.sol
+++ b/script/LaunchDeployer.s.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.28;
 
 import {CoreInput, makeSalt} from "./CoreDeployer.s.sol";
-import {SetConfigParam} from "./utils/ILayerZeroEndpointV2Like.sol";
 import {EnvConfig, Env, prettyEnvString} from "./utils/EnvConfig.s.sol";
 import {
     FullInput,

--- a/script/deploy/lib/anvil.py
+++ b/script/deploy/lib/anvil.py
@@ -65,9 +65,9 @@ class AnvilManager:
                 "environment": "testnet",
                 "connectsTo": [],
                 "protocolAdmin": self.protocol_admin_address,
-                "opsAdmin": self.ops_admin_address
+                "opsAdmin": self.ops_admin_address,
+                "baseRpcUrl": "http://localhost:8545"
             },
-            "contracts": {},  # Will be populated after LaunchDeployer runs
             "adapters": {
                 "wormhole": {
                 "wormholeId": "10002",

--- a/script/utils/EnvConfig.s.sol
+++ b/script/utils/EnvConfig.s.sol
@@ -302,7 +302,7 @@ library EnvConfigLib {
     }
 
     function buildZeroConfigParams(EnvConfig memory config) internal view returns (SetConfigParam[] memory params) {
-        if (config.adapters.layerZero.deploy) return params;
+        if (!config.adapters.layerZero.deploy) return params;
 
         string[] memory connectsTo = config.network.connectsTo;
         params = new SetConfigParam[](connectsTo.length);

--- a/script/utils/EnvConfig.s.sol
+++ b/script/utils/EnvConfig.s.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import "./GraphQLConstants.sol";
+import {GraphQLConstants} from "./GraphQLConstants.sol";
 import {UlnConfig, SetConfigParam} from "./ILayerZeroEndpointV2Like.sol";
 
 import "forge-std/Vm.sol";
-import "forge-std/Console.sol";
+import "forge-std/Script.sol";
 
 Vm constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 

--- a/script/utils/EnvConfig.s.sol
+++ b/script/utils/EnvConfig.s.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import "./GraphQLConstants.sol";
+import {UlnConfig, SetConfigParam} from "./ILayerZeroEndpointV2Like.sol";
 
 import "forge-std/Vm.sol";
 
@@ -294,9 +295,75 @@ library Env {
     }
 }
 
+struct AdapterConnections {
+    uint16 centrifugeId;
+    uint32 layerZeroId;
+    uint16 wormholeId;
+    string axelarId;
+    uint64 chainlinkId;
+    uint8 threshold;
+}
+
 library EnvConfigLib {
     function etherscanApiKey(EnvConfig memory) internal view returns (string memory) {
         return _envString("ETHERSCAN_API_KEY");
+    }
+
+    function buildConnections(EnvConfig memory config) internal view returns (AdapterConnections[] memory connections) {
+        string[] memory connectsTo = config.network.connectsTo;
+        connections = new AdapterConnections[](connectsTo.length);
+
+        for (uint256 i; i < connectsTo.length; i++) {
+            EnvConfig memory remoteConfig = Env.load(connectsTo[i]);
+
+            connections[i] = AdapterConnections({
+                centrifugeId: remoteConfig.network.centrifugeId,
+                layerZeroId: remoteConfig.adapters.layerZero.layerZeroEid,
+                wormholeId: remoteConfig.adapters.wormhole.wormholeId,
+                axelarId: remoteConfig.adapters.axelar.axelarId,
+                chainlinkId: remoteConfig.adapters.chainlink.chainSelector,
+                threshold: remoteConfig.adapters.threshold
+            });
+        }
+    }
+
+    function buildZeroConfigParams(EnvConfig memory config) internal view returns (SetConfigParam[] memory params) {
+        string[] memory connectsTo = config.network.connectsTo;
+        params = new SetConfigParam[](connectsTo.length);
+
+        // UlnConfig is the same for all connections - only eid differs
+        uint32 ULN_CONFIG_TYPE = 2;
+        bytes memory encodedUln = abi.encode(
+            UlnConfig({
+                confirmations: config.adapters.layerZero.blockConfirmations,
+                requiredDVNCount: uint8(config.adapters.layerZero.dvns.length),
+                optionalDVNCount: type(uint8).max,
+                optionalDVNThreshold: 0,
+                requiredDVNs: config.adapters.layerZero.dvns,
+                optionalDVNs: new address[](0)
+            })
+        );
+
+        for (uint256 i; i < connectsTo.length; i++) {
+            EnvConfig memory remoteConfig = Env.load(connectsTo[i]);
+
+            require(
+                config.adapters.layerZero.dvns.length == remoteConfig.adapters.layerZero.dvns.length,
+                "DVNs count mismatch between local and remote config"
+            );
+            for (uint256 j; j < config.adapters.layerZero.dvns.length; j++) {
+                require(
+                    config.adapters.layerZero.dvns[j] == remoteConfig.adapters.layerZero.dvns[j],
+                    "DVNs mismatch between local and remote config"
+                );
+            }
+            require(
+                config.adapters.layerZero.blockConfirmations == remoteConfig.adapters.layerZero.blockConfirmations,
+                "blockConfirmations mismatch between local and remote config"
+            );
+
+            params[i] = SetConfigParam(remoteConfig.adapters.layerZero.layerZeroEid, ULN_CONFIG_TYPE, encodedUln);
+        }
     }
 }
 

--- a/script/utils/EnvConfig.s.sol
+++ b/script/utils/EnvConfig.s.sol
@@ -331,12 +331,6 @@ library EnvConfigLib {
                 config.adapters.layerZero.dvns.length == remoteConfig.adapters.layerZero.dvns.length,
                 "DVNs count mismatch between local and remote config"
             );
-            for (uint256 j; j < config.adapters.layerZero.dvns.length; j++) {
-                require(
-                    config.adapters.layerZero.dvns[j] == remoteConfig.adapters.layerZero.dvns[j],
-                    "DVNs mismatch between local and remote config"
-                );
-            }
             require(
                 config.adapters.layerZero.blockConfirmations == remoteConfig.adapters.layerZero.blockConfirmations,
                 "blockConfirmations mismatch between local and remote config"

--- a/script/utils/EnvConfig.s.sol
+++ b/script/utils/EnvConfig.s.sol
@@ -301,7 +301,11 @@ library EnvConfigLib {
         return prettyEnvString("ETHERSCAN_API_KEY");
     }
 
-    function buildZeroConfigParams(EnvConfig memory config) internal view returns (SetConfigParam[] memory params) {
+    function buildLayerZeroConfigParams(EnvConfig memory config)
+        internal
+        view
+        returns (SetConfigParam[] memory params)
+    {
         if (!config.adapters.layerZero.deploy) return params;
 
         string[] memory connectsTo = config.network.connectsTo;

--- a/script/utils/EnvConfig.s.sol
+++ b/script/utils/EnvConfig.s.sol
@@ -407,4 +407,3 @@ function prettyEnvString(string memory name) view returns (string memory value) 
     if (bytes(value).length == 0) revert(string.concat("Missing env var: ", name));
     else console.log(string.concat("Loaded env var: ", name));
 }
-

--- a/test/core/hub/integration/BaseTest.sol
+++ b/test/core/hub/integration/BaseTest.sol
@@ -35,7 +35,7 @@ contract BaseTest is FullDeployer, Test {
     bytes32 constant SC_HOOK = bytes32("ExampleHookData");
     bool constant IS_SNAPSHOT = true;
 
-    address immutable ADMIN = address(adminSafe);
+    address immutable ADMIN = address(protocolSafe);
     address immutable FM = makeAddr("FM");
     address immutable ANY = makeAddr("Anyone");
     bytes32 immutable INVESTOR = bytes32("Investor");
@@ -90,7 +90,7 @@ contract BaseTest is FullDeployer, Test {
         deployFull(
             FullInput({
                 core: CoreInput({centrifugeId: CHAIN_CP, version: bytes32(0), txLimits: defaultTxLimits()}),
-                adminSafe: adminSafe,
+                protocolSafe: protocolSafe,
                 opsSafe: opsSafe,
                 adapters: noAdaptersInput()
             }),

--- a/test/core/spoke/integration/BaseTest.sol
+++ b/test/core/spoke/integration/BaseTest.sol
@@ -52,7 +52,7 @@ contract BaseTest is FullDeployer, Test {
     address investor = makeAddr("investor");
     address nonMember = makeAddr("nonMember");
     address randomUser = makeAddr("randomUser");
-    address immutable ADMIN = address(adminSafe);
+    address immutable ADMIN = address(protocolSafe);
 
     uint128 constant MAX_UINT128 = type(uint128).max;
     uint64 constant MAX_UINT64 = type(uint64).max;
@@ -89,7 +89,7 @@ contract BaseTest is FullDeployer, Test {
         deployFull(
             FullInput({
                 core: CoreInput({centrifugeId: THIS_CHAIN_ID, version: bytes32(0), txLimits: defaultTxLimits()}),
-                adminSafe: ISafe(ADMIN),
+                protocolSafe: ISafe(ADMIN),
                 opsSafe: ISafe(ADMIN),
                 adapters: noAdaptersInput()
             }),

--- a/test/hooks/integration/BaseTransferHook.t.sol
+++ b/test/hooks/integration/BaseTransferHook.t.sol
@@ -29,7 +29,7 @@ contract MockPoolEscrow {
 
 contract BaseTransferHookIntegrationTest is FullDeployer, Test {
     uint16 constant LOCAL_CENTRIFUGE_ID = IntegrationConstants.LOCAL_CENTRIFUGE_ID;
-    address immutable ADMIN = address(adminSafe);
+    address immutable ADMIN = address(protocolSafe);
     uint256 constant GAS = IntegrationConstants.INTEGRATION_DEFAULT_SUBSIDY;
     address constant USER = address(0x1234);
     PoolId constant TEST_POOL_ID = PoolId.wrap(999);
@@ -43,8 +43,8 @@ contract BaseTransferHookIntegrationTest is FullDeployer, Test {
         super.deployFull(
             FullInput({
                 core: CoreInput({centrifugeId: LOCAL_CENTRIFUGE_ID, version: bytes32(0), txLimits: defaultTxLimits()}),
-                adminSafe: adminSafe,
-                opsSafe: adminSafe,
+                protocolSafe: protocolSafe,
+                opsSafe: protocolSafe,
                 adapters: noAdaptersInput()
             }),
             batcher

--- a/test/integration/Deployer.t.sol
+++ b/test/integration/Deployer.t.sol
@@ -781,10 +781,7 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
             wormhole: WormholeInput({shouldDeploy: true, relayer: address(0)}),
             axelar: AxelarInput({shouldDeploy: false, gateway: address(0), gasService: address(0)}),
             layerZero: LayerZeroInput({
-                shouldDeploy: false,
-                endpoint: address(0),
-                delegate: address(0),
-                configParams: new SetConfigParam[](0)
+                shouldDeploy: false, endpoint: address(0), delegate: address(0), configParams: new SetConfigParam[](0)
             }),
             chainlink: ChainlinkInput({shouldDeploy: false, ccipRouter: address(0)}),
             connections: new AdapterConnections[](0)
@@ -800,10 +797,7 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
             wormhole: WormholeInput({shouldDeploy: true, relayer: mockRelayer}),
             axelar: AxelarInput({shouldDeploy: false, gateway: address(0), gasService: address(0)}),
             layerZero: LayerZeroInput({
-                shouldDeploy: false,
-                endpoint: address(0),
-                delegate: address(0),
-                configParams: new SetConfigParam[](0)
+                shouldDeploy: false, endpoint: address(0), delegate: address(0), configParams: new SetConfigParam[](0)
             }),
             chainlink: ChainlinkInput({shouldDeploy: false, ccipRouter: address(0)}),
             connections: new AdapterConnections[](0)
@@ -821,10 +815,7 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
             wormhole: WormholeInput({shouldDeploy: false, relayer: address(0)}),
             axelar: AxelarInput({shouldDeploy: true, gateway: address(0), gasService: validGasService}),
             layerZero: LayerZeroInput({
-                shouldDeploy: false,
-                endpoint: address(0),
-                delegate: address(0),
-                configParams: new SetConfigParam[](0)
+                shouldDeploy: false, endpoint: address(0), delegate: address(0), configParams: new SetConfigParam[](0)
             }),
             chainlink: ChainlinkInput({shouldDeploy: false, ccipRouter: address(0)}),
             connections: new AdapterConnections[](0)
@@ -842,10 +833,7 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
             wormhole: WormholeInput({shouldDeploy: false, relayer: address(0)}),
             axelar: AxelarInput({shouldDeploy: true, gateway: validGateway, gasService: address(0)}),
             layerZero: LayerZeroInput({
-                shouldDeploy: false,
-                endpoint: address(0),
-                delegate: address(0),
-                configParams: new SetConfigParam[](0)
+                shouldDeploy: false, endpoint: address(0), delegate: address(0), configParams: new SetConfigParam[](0)
             }),
             chainlink: ChainlinkInput({shouldDeploy: false, ccipRouter: address(0)}),
             connections: new AdapterConnections[](0)
@@ -866,10 +854,7 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
             wormhole: WormholeInput({shouldDeploy: false, relayer: address(0)}),
             axelar: AxelarInput({shouldDeploy: true, gateway: mockGateway, gasService: mockGasService}),
             layerZero: LayerZeroInput({
-                shouldDeploy: false,
-                endpoint: address(0),
-                delegate: address(0),
-                configParams: new SetConfigParam[](0)
+                shouldDeploy: false, endpoint: address(0), delegate: address(0), configParams: new SetConfigParam[](0)
             }),
             chainlink: ChainlinkInput({shouldDeploy: false, ccipRouter: address(0)}),
             connections: new AdapterConnections[](0)
@@ -890,10 +875,7 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
             wormhole: WormholeInput({shouldDeploy: false, relayer: address(0)}),
             axelar: AxelarInput({shouldDeploy: true, gateway: mockGateway, gasService: mockGasService}),
             layerZero: LayerZeroInput({
-                shouldDeploy: false,
-                endpoint: address(0),
-                delegate: address(0),
-                configParams: new SetConfigParam[](0)
+                shouldDeploy: false, endpoint: address(0), delegate: address(0), configParams: new SetConfigParam[](0)
             }),
             chainlink: ChainlinkInput({shouldDeploy: false, ccipRouter: address(0)}),
             connections: new AdapterConnections[](0)
@@ -908,10 +890,7 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
             wormhole: WormholeInput({shouldDeploy: false, relayer: address(0)}),
             axelar: AxelarInput({shouldDeploy: false, gateway: address(0), gasService: address(0)}),
             layerZero: LayerZeroInput({
-                shouldDeploy: true,
-                endpoint: address(0),
-                delegate: address(0),
-                configParams: new SetConfigParam[](0)
+                shouldDeploy: true, endpoint: address(0), delegate: address(0), configParams: new SetConfigParam[](0)
             }),
             chainlink: ChainlinkInput({shouldDeploy: false, ccipRouter: address(0)}),
             connections: new AdapterConnections[](0)
@@ -927,10 +906,7 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
             wormhole: WormholeInput({shouldDeploy: false, relayer: address(0)}),
             axelar: AxelarInput({shouldDeploy: false, gateway: address(0), gasService: address(0)}),
             layerZero: LayerZeroInput({
-                shouldDeploy: true,
-                endpoint: mockEndpoint,
-                delegate: address(0),
-                configParams: new SetConfigParam[](0)
+                shouldDeploy: true, endpoint: mockEndpoint, delegate: address(0), configParams: new SetConfigParam[](0)
             }),
             chainlink: ChainlinkInput({shouldDeploy: false, ccipRouter: address(0)}),
             connections: new AdapterConnections[](0)
@@ -963,10 +939,7 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
             wormhole: WormholeInput({shouldDeploy: false, relayer: address(0)}),
             axelar: AxelarInput({shouldDeploy: false, gateway: address(0), gasService: address(0)}),
             layerZero: LayerZeroInput({
-                shouldDeploy: false,
-                endpoint: address(0),
-                delegate: address(0),
-                configParams: new SetConfigParam[](0)
+                shouldDeploy: false, endpoint: address(0), delegate: address(0), configParams: new SetConfigParam[](0)
             }),
             chainlink: ChainlinkInput({shouldDeploy: true, ccipRouter: address(0)}),
             connections: new AdapterConnections[](0)
@@ -982,10 +955,7 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
             wormhole: WormholeInput({shouldDeploy: false, relayer: address(0)}),
             axelar: AxelarInput({shouldDeploy: false, gateway: address(0), gasService: address(0)}),
             layerZero: LayerZeroInput({
-                shouldDeploy: false,
-                endpoint: address(0),
-                delegate: address(0),
-                configParams: new SetConfigParam[](0)
+                shouldDeploy: false, endpoint: address(0), delegate: address(0), configParams: new SetConfigParam[](0)
             }),
             chainlink: ChainlinkInput({shouldDeploy: true, ccipRouter: mockCCIPRouter}),
             connections: new AdapterConnections[](0)

--- a/test/integration/Deployer.t.sol
+++ b/test/integration/Deployer.t.sol
@@ -79,7 +79,7 @@ contract FullDeploymentConfigTest is Test, FullDeployer {
         deployFull(
             FullInput({
                 core: CoreInput({centrifugeId: CENTRIFUGE_ID, version: bytes32(0), txLimits: defaultTxLimits()}),
-                adminSafe: ADMIN_SAFE,
+                protocolSafe: ADMIN_SAFE,
                 opsSafe: OPS_SAFE,
                 adapters: AdaptersInput({
                     wormhole: WormholeInput({shouldDeploy: true, relayer: WORMHOLE_RELAYER}),

--- a/test/integration/Deployer.t.sol
+++ b/test/integration/Deployer.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.28;
 import {ISafe} from "../../src/admin/interfaces/ISafe.sol";
 
 import {CoreInput} from "../../script/CoreDeployer.s.sol";
-import {ILayerZeroEndpointV2Like} from "../../script/utils/ILayerZeroEndpointV2Like.sol";
+import {ILayerZeroEndpointV2Like, SetConfigParam} from "../../script/utils/ILayerZeroEndpointV2Like.sol";
 import {
     FullInput,
     FullActionBatcher,
@@ -85,7 +85,10 @@ contract FullDeploymentConfigTest is Test, FullDeployer {
                     wormhole: WormholeInput({shouldDeploy: true, relayer: WORMHOLE_RELAYER}),
                     axelar: AxelarInput({shouldDeploy: true, gateway: AXELAR_GATEWAY, gasService: AXELAR_GAS_SERVICE}),
                     layerZero: LayerZeroInput({
-                        shouldDeploy: true, endpoint: LAYERZERO_ENDPOINT, delegate: LAYERZERO_DELEGATE
+                        shouldDeploy: true,
+                        endpoint: LAYERZERO_ENDPOINT,
+                        delegate: LAYERZERO_DELEGATE,
+                        configParams: new SetConfigParam[](0)
                     }),
                     chainlink: ChainlinkInput({shouldDeploy: true, ccipRouter: CHAINLINK_CCIP_ROUTER}),
                     connections: new AdapterConnections[](0) // TODO: test this
@@ -777,7 +780,12 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
         AdaptersInput memory invalidInput = AdaptersInput({
             wormhole: WormholeInput({shouldDeploy: true, relayer: address(0)}),
             axelar: AxelarInput({shouldDeploy: false, gateway: address(0), gasService: address(0)}),
-            layerZero: LayerZeroInput({shouldDeploy: false, endpoint: address(0), delegate: address(0)}),
+            layerZero: LayerZeroInput({
+                shouldDeploy: false,
+                endpoint: address(0),
+                delegate: address(0),
+                configParams: new SetConfigParam[](0)
+            }),
             chainlink: ChainlinkInput({shouldDeploy: false, ccipRouter: address(0)}),
             connections: new AdapterConnections[](0)
         });
@@ -791,7 +799,12 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
         AdaptersInput memory invalidInput = AdaptersInput({
             wormhole: WormholeInput({shouldDeploy: true, relayer: mockRelayer}),
             axelar: AxelarInput({shouldDeploy: false, gateway: address(0), gasService: address(0)}),
-            layerZero: LayerZeroInput({shouldDeploy: false, endpoint: address(0), delegate: address(0)}),
+            layerZero: LayerZeroInput({
+                shouldDeploy: false,
+                endpoint: address(0),
+                delegate: address(0),
+                configParams: new SetConfigParam[](0)
+            }),
             chainlink: ChainlinkInput({shouldDeploy: false, ccipRouter: address(0)}),
             connections: new AdapterConnections[](0)
         });
@@ -807,7 +820,12 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
         AdaptersInput memory invalidInput = AdaptersInput({
             wormhole: WormholeInput({shouldDeploy: false, relayer: address(0)}),
             axelar: AxelarInput({shouldDeploy: true, gateway: address(0), gasService: validGasService}),
-            layerZero: LayerZeroInput({shouldDeploy: false, endpoint: address(0), delegate: address(0)}),
+            layerZero: LayerZeroInput({
+                shouldDeploy: false,
+                endpoint: address(0),
+                delegate: address(0),
+                configParams: new SetConfigParam[](0)
+            }),
             chainlink: ChainlinkInput({shouldDeploy: false, ccipRouter: address(0)}),
             connections: new AdapterConnections[](0)
         });
@@ -823,7 +841,12 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
         AdaptersInput memory invalidInput = AdaptersInput({
             wormhole: WormholeInput({shouldDeploy: false, relayer: address(0)}),
             axelar: AxelarInput({shouldDeploy: true, gateway: validGateway, gasService: address(0)}),
-            layerZero: LayerZeroInput({shouldDeploy: false, endpoint: address(0), delegate: address(0)}),
+            layerZero: LayerZeroInput({
+                shouldDeploy: false,
+                endpoint: address(0),
+                delegate: address(0),
+                configParams: new SetConfigParam[](0)
+            }),
             chainlink: ChainlinkInput({shouldDeploy: false, ccipRouter: address(0)}),
             connections: new AdapterConnections[](0)
         });
@@ -842,7 +865,12 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
         AdaptersInput memory invalidInput = AdaptersInput({
             wormhole: WormholeInput({shouldDeploy: false, relayer: address(0)}),
             axelar: AxelarInput({shouldDeploy: true, gateway: mockGateway, gasService: mockGasService}),
-            layerZero: LayerZeroInput({shouldDeploy: false, endpoint: address(0), delegate: address(0)}),
+            layerZero: LayerZeroInput({
+                shouldDeploy: false,
+                endpoint: address(0),
+                delegate: address(0),
+                configParams: new SetConfigParam[](0)
+            }),
             chainlink: ChainlinkInput({shouldDeploy: false, ccipRouter: address(0)}),
             connections: new AdapterConnections[](0)
         });
@@ -861,7 +889,12 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
         AdaptersInput memory invalidInput = AdaptersInput({
             wormhole: WormholeInput({shouldDeploy: false, relayer: address(0)}),
             axelar: AxelarInput({shouldDeploy: true, gateway: mockGateway, gasService: mockGasService}),
-            layerZero: LayerZeroInput({shouldDeploy: false, endpoint: address(0), delegate: address(0)}),
+            layerZero: LayerZeroInput({
+                shouldDeploy: false,
+                endpoint: address(0),
+                delegate: address(0),
+                configParams: new SetConfigParam[](0)
+            }),
             chainlink: ChainlinkInput({shouldDeploy: false, ccipRouter: address(0)}),
             connections: new AdapterConnections[](0)
         });
@@ -874,7 +907,12 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
         AdaptersInput memory invalidInput = AdaptersInput({
             wormhole: WormholeInput({shouldDeploy: false, relayer: address(0)}),
             axelar: AxelarInput({shouldDeploy: false, gateway: address(0), gasService: address(0)}),
-            layerZero: LayerZeroInput({shouldDeploy: true, endpoint: address(0), delegate: address(0)}),
+            layerZero: LayerZeroInput({
+                shouldDeploy: true,
+                endpoint: address(0),
+                delegate: address(0),
+                configParams: new SetConfigParam[](0)
+            }),
             chainlink: ChainlinkInput({shouldDeploy: false, ccipRouter: address(0)}),
             connections: new AdapterConnections[](0)
         });
@@ -888,7 +926,12 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
         AdaptersInput memory invalidInput = AdaptersInput({
             wormhole: WormholeInput({shouldDeploy: false, relayer: address(0)}),
             axelar: AxelarInput({shouldDeploy: false, gateway: address(0), gasService: address(0)}),
-            layerZero: LayerZeroInput({shouldDeploy: true, endpoint: mockEndpoint, delegate: address(0)}),
+            layerZero: LayerZeroInput({
+                shouldDeploy: true,
+                endpoint: mockEndpoint,
+                delegate: address(0),
+                configParams: new SetConfigParam[](0)
+            }),
             chainlink: ChainlinkInput({shouldDeploy: false, ccipRouter: address(0)}),
             connections: new AdapterConnections[](0)
         });
@@ -901,7 +944,12 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
         AdaptersInput memory invalidInput = AdaptersInput({
             wormhole: WormholeInput({shouldDeploy: false, relayer: address(0)}),
             axelar: AxelarInput({shouldDeploy: false, gateway: address(0), gasService: address(0)}),
-            layerZero: LayerZeroInput({shouldDeploy: true, endpoint: LAYERZERO_ENDPOINT, delegate: address(0)}),
+            layerZero: LayerZeroInput({
+                shouldDeploy: true,
+                endpoint: LAYERZERO_ENDPOINT,
+                delegate: address(0),
+                configParams: new SetConfigParam[](0)
+            }),
             chainlink: ChainlinkInput({shouldDeploy: false, ccipRouter: address(0)}),
             connections: new AdapterConnections[](0)
         });
@@ -914,7 +962,12 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
         AdaptersInput memory invalidInput = AdaptersInput({
             wormhole: WormholeInput({shouldDeploy: false, relayer: address(0)}),
             axelar: AxelarInput({shouldDeploy: false, gateway: address(0), gasService: address(0)}),
-            layerZero: LayerZeroInput({shouldDeploy: false, endpoint: address(0), delegate: address(0)}),
+            layerZero: LayerZeroInput({
+                shouldDeploy: false,
+                endpoint: address(0),
+                delegate: address(0),
+                configParams: new SetConfigParam[](0)
+            }),
             chainlink: ChainlinkInput({shouldDeploy: true, ccipRouter: address(0)}),
             connections: new AdapterConnections[](0)
         });
@@ -928,7 +981,12 @@ contract FullDeploymentTestAdaptersValidation is FullDeploymentConfigTest {
         AdaptersInput memory invalidInput = AdaptersInput({
             wormhole: WormholeInput({shouldDeploy: false, relayer: address(0)}),
             axelar: AxelarInput({shouldDeploy: false, gateway: address(0), gasService: address(0)}),
-            layerZero: LayerZeroInput({shouldDeploy: false, endpoint: address(0), delegate: address(0)}),
+            layerZero: LayerZeroInput({
+                shouldDeploy: false,
+                endpoint: address(0),
+                delegate: address(0),
+                configParams: new SetConfigParam[](0)
+            }),
             chainlink: ChainlinkInput({shouldDeploy: true, ccipRouter: mockCCIPRouter}),
             connections: new AdapterConnections[](0)
         });

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -270,7 +270,7 @@ contract EndToEndDeployment is Test {
         vm.stopPrank();
     }
 
-    function _deployChain(FullDeployer deploy, uint16 localCentrifugeId, uint16 remoteCentrifugeId, ISafe adminSafe)
+    function _deployChain(FullDeployer deploy, uint16 localCentrifugeId, uint16 remoteCentrifugeId, ISafe protocolSafe)
         internal
         returns (LocalAdapter adapter)
     {
@@ -284,8 +284,8 @@ contract EndToEndDeployment is Test {
                     version: bytes32(abi.encodePacked(localCentrifugeId)),
                     txLimits: defaultTxLimits()
                 }),
-                adminSafe: adminSafe,
-                opsSafe: adminSafe,
+                protocolSafe: protocolSafe,
+                opsSafe: protocolSafe,
                 adapters: noAdaptersInput()
             }),
             batcher

--- a/test/integration/GatewayBatchMemoryExpansion.t.sol
+++ b/test/integration/GatewayBatchMemoryExpansion.t.sol
@@ -31,7 +31,7 @@ contract GatewayBatchMemoryExpansionTest is CentrifugeIntegrationTest {
         target = address(new MockUntrustedTarget());
 
         // Create a pool so messages are valid
-        vm.prank(address(adminSafe));
+        vm.prank(address(protocolSafe));
         opsGuardian.createPool(poolId, address(this), USD_ID);
 
         // Give this test contract authorization to call gateway.handle()

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -43,8 +43,8 @@ contract CentrifugeIntegrationTest is FullDeployer, Test {
         super.deployFull(
             FullInput({
                 core: CoreInput({centrifugeId: LOCAL_CENTRIFUGE_ID, version: bytes32(0), txLimits: defaultTxLimits()}),
-                adminSafe: adminSafe,
-                opsSafe: adminSafe,
+                protocolSafe: protocolSafe,
+                opsSafe: protocolSafe,
                 adapters: noAdaptersInput()
             }),
             batcher
@@ -78,8 +78,8 @@ contract CentrifugeIntegrationTestWithUtils is CentrifugeIntegrationTest {
 
         // Extra deployment
         usdc = new ERC20(6);
-        usdc.rely(address(adminSafe));
-        vm.startPrank(address(adminSafe));
+        usdc.rely(address(protocolSafe));
+        vm.startPrank(address(protocolSafe));
         usdc.file("name", "USD Coin");
         usdc.file("symbol", "USDC");
         vm.stopPrank();
@@ -92,12 +92,12 @@ contract CentrifugeIntegrationTestWithUtils is CentrifugeIntegrationTest {
     }
 
     function _mintUSDC(address receiver, uint256 amount) internal {
-        vm.prank(address(adminSafe));
+        vm.prank(address(protocolSafe));
         usdc.mint(receiver, amount);
     }
 
     function _createPool() internal {
-        vm.prank(address(adminSafe));
+        vm.prank(address(protocolSafe));
         opsGuardian.createPool(POOL_A, FM, USD_ID);
 
         vm.prank(FM);

--- a/test/integration/fork/ForkTestLiveValidation.sol
+++ b/test/integration/fork/ForkTestLiveValidation.sol
@@ -109,7 +109,7 @@ contract ForkTestLiveValidation is ForkTestBase, VMLabeling {
     address public layerZeroAdapter;
 
     // Admin
-    address public adminSafe;
+    address public protocolSafe;
 
     //----------------------------------------------------------------------------------------------
     // FACTORY CONTRACTS
@@ -223,11 +223,11 @@ contract ForkTestLiveValidation is ForkTestBase, VMLabeling {
     }
 
     /// @notice Configure chain-specific settings
-    /// @param adminSafe_ The admin safe address for this chain
+    /// @param protocolSafe_ The admin safe address for this chain
     /// @param centrifugeId_ The centrifuge chain ID
-    function _configureChain(address adminSafe_, uint16 centrifugeId_) public {
+    function _configureChain(address protocolSafe_, uint16 centrifugeId_) public {
         localCentrifugeId = centrifugeId_;
-        adminSafe = adminSafe_;
+        protocolSafe = protocolSafe_;
     }
 
     /// @notice Detects if the deployment is v3.1 or v3.0.1
@@ -367,7 +367,7 @@ contract ForkTestLiveValidation is ForkTestBase, VMLabeling {
 
         // Multichain config
         localCentrifugeId = IntegrationConstants.ETH_CENTRIFUGE_ID;
-        adminSafe = IntegrationConstants.ETH_ADMIN_SAFE; // Default for standalone tests
+        protocolSafe = IntegrationConstants.ETH_ADMIN_SAFE; // Default for standalone tests
     }
 
     /// @notice Load contract addresses from a FullDeployer instance (for pre-migration testing)
@@ -375,7 +375,7 @@ contract ForkTestLiveValidation is ForkTestBase, VMLabeling {
     ///      Use this when validating a freshly deployed v3.1 system in fork (e.g., MigrationV3_1Test)
     ///      Use _initializeContractAddresses() when validating live on-chain state (post-migration)
     /// @param report The FullReport instance that comes from the deployed v3.1 contracts
-    function loadContractsFromDeployer(FullReport memory report, address adminSafe_) public virtual {
+    function loadContractsFromDeployer(FullReport memory report, address protocolSafe_) public virtual {
         // Core system contracts
         root = address(report.root);
         protocolGuardian = address(report.protocolGuardian);
@@ -427,7 +427,7 @@ contract ForkTestLiveValidation is ForkTestBase, VMLabeling {
 
         // Multichain config - from deployed contracts
         localCentrifugeId = report.core.messageDispatcher.localCentrifugeId();
-        adminSafe = adminSafe_;
+        protocolSafe = protocolSafe_;
     }
 
     /// @notice Setup VM labels for debugging
@@ -757,8 +757,8 @@ contract ForkTestLiveValidation is ForkTestBase, VMLabeling {
             if (layerZeroAdapter != address(0)) _validateWard(layerZeroAdapter, opsGuardian);
         }
 
-        if (layerZeroAdapter != address(0) && adminSafe != address(0)) {
-            _validateWard(layerZeroAdapter, adminSafe);
+        if (layerZeroAdapter != address(0) && protocolSafe != address(0)) {
+            _validateWard(layerZeroAdapter, protocolSafe);
         }
 
         // ==================== TOKEN RECOVERER (FullDeployer) ====================
@@ -945,8 +945,8 @@ contract ForkTestLiveValidation is ForkTestBase, VMLabeling {
             assertTrue(opsSafeAddr != address(0), "OpsGuardian opsSafe not configured");
         }
 
-        if (protocolGuardian != address(0) && adminSafe != address(0)) {
-            assertEq(address(ProtocolGuardian(protocolGuardian).safe()), adminSafe, "ProtocolGuardian safe mismatch");
+        if (protocolGuardian != address(0) && protocolSafe != address(0)) {
+            assertEq(address(ProtocolGuardian(protocolGuardian).safe()), protocolSafe, "ProtocolGuardian safe mismatch");
         }
     }
 

--- a/test/integration/fork/LayerZeroDvnForkTest.t.sol
+++ b/test/integration/fork/LayerZeroDvnForkTest.t.sol
@@ -103,7 +103,7 @@ contract LayerZeroDvnForkTest is Test, FullDeployer {
     bytes message;
 
     function setUp() public {
-        adminSafe = ISafe(makeAddr("AdminSafe"));
+        protocolSafe = ISafe(makeAddr("AdminSafe"));
         opsSafe = ISafe(makeAddr("OpsSafe"));
     }
 
@@ -200,7 +200,7 @@ contract LayerZeroDvnForkTest is Test, FullDeployer {
 
         return FullInput({
             core: CoreInput({centrifugeId: localId, version: bytes32("1337"), txLimits: defaultTxLimits()}),
-            adminSafe: adminSafe,
+            protocolSafe: protocolSafe,
             opsSafe: opsSafe,
             adapters: AdaptersInput({
                 wormhole: WormholeInput({shouldDeploy: false, relayer: address(0)}),
@@ -208,7 +208,7 @@ contract LayerZeroDvnForkTest is Test, FullDeployer {
                 layerZero: LayerZeroInput({
                     shouldDeploy: true,
                     endpoint: address(lzEndpoint),
-                    delegate: address(adminSafe),
+                    delegate: address(protocolSafe),
                     configParams: _ulnConfig(dvn1, dvn2, remoteEid)
                 }),
                 chainlink: ChainlinkInput({shouldDeploy: false, ccipRouter: address(0)}),

--- a/test/integration/fork/LayerZeroDvnForkTest.t.sol
+++ b/test/integration/fork/LayerZeroDvnForkTest.t.sol
@@ -195,8 +195,7 @@ contract LayerZeroDvnForkTest is Test, FullDeployer {
             wormholeId: 0,
             axelarId: "",
             chainlinkId: 0,
-            threshold: 1,
-            layerZeroConfigParams: _ulnConfig(dvn1, dvn2, remoteEid)
+            threshold: 1
         });
 
         return FullInput({
@@ -207,7 +206,10 @@ contract LayerZeroDvnForkTest is Test, FullDeployer {
                 wormhole: WormholeInput({shouldDeploy: false, relayer: address(0)}),
                 axelar: AxelarInput({shouldDeploy: false, gateway: address(0), gasService: address(0)}),
                 layerZero: LayerZeroInput({
-                    shouldDeploy: true, endpoint: address(lzEndpoint), delegate: address(adminSafe)
+                    shouldDeploy: true,
+                    endpoint: address(lzEndpoint),
+                    delegate: address(adminSafe),
+                    configParams: _ulnConfig(dvn1, dvn2, remoteEid)
                 }),
                 chainlink: ChainlinkInput({shouldDeploy: false, ccipRouter: address(0)}),
                 connections: connections

--- a/test/integration/fork/LayerZeroDvnForkTest.t.sol
+++ b/test/integration/fork/LayerZeroDvnForkTest.t.sol
@@ -190,12 +190,7 @@ contract LayerZeroDvnForkTest is Test, FullDeployer {
     {
         AdapterConnections[] memory connections = new AdapterConnections[](1);
         connections[0] = AdapterConnections({
-            centrifugeId: remoteId,
-            layerZeroId: remoteEid,
-            wormholeId: 0,
-            axelarId: "",
-            chainlinkId: 0,
-            threshold: 1
+            centrifugeId: remoteId, layerZeroId: remoteEid, wormholeId: 0, axelarId: "", chainlinkId: 0, threshold: 1
         });
 
         return FullInput({

--- a/test/integration/utils/ChainConfigs.sol
+++ b/test/integration/utils/ChainConfigs.sol
@@ -17,7 +17,7 @@ library ChainConfigs {
         uint32 layerZeroEid;
         address usdc;
         address poolAdmin;
-        address adminSafe;
+        address protocolSafe;
         bool hasAxelar;
         bool hasLayerZero;
     }
@@ -34,7 +34,7 @@ library ChainConfigs {
                 layerZeroEid: IntegrationConstants.ETH_LAYERZERO_EID,
                 usdc: IntegrationConstants.ETH_USDC,
                 poolAdmin: IntegrationConstants.ETH_DEFAULT_POOL_ADMIN,
-                adminSafe: IntegrationConstants.ETH_ADMIN_SAFE,
+                protocolSafe: IntegrationConstants.ETH_ADMIN_SAFE,
                 hasAxelar: true,
                 hasLayerZero: true
             }),
@@ -47,7 +47,7 @@ library ChainConfigs {
                 layerZeroEid: IntegrationConstants.BASE_LAYERZERO_EID,
                 usdc: IntegrationConstants.BASE_USDC,
                 poolAdmin: IntegrationConstants.ETH_DEFAULT_POOL_ADMIN,
-                adminSafe: IntegrationConstants.BASE_ADMIN_SAFE,
+                protocolSafe: IntegrationConstants.BASE_ADMIN_SAFE,
                 hasAxelar: true,
                 hasLayerZero: true
             }),
@@ -60,7 +60,7 @@ library ChainConfigs {
                 layerZeroEid: IntegrationConstants.ARBITRUM_LAYERZERO_EID,
                 usdc: IntegrationConstants.ARBITRUM_USDC,
                 poolAdmin: IntegrationConstants.ETH_DEFAULT_POOL_ADMIN,
-                adminSafe: IntegrationConstants.ARBITRUM_ADMIN_SAFE,
+                protocolSafe: IntegrationConstants.ARBITRUM_ADMIN_SAFE,
                 hasAxelar: true,
                 hasLayerZero: true
             }),
@@ -73,7 +73,7 @@ library ChainConfigs {
                 layerZeroEid: IntegrationConstants.AVAX_LAYERZERO_EID,
                 usdc: IntegrationConstants.AVAX_USDC,
                 poolAdmin: IntegrationConstants.ETH_DEFAULT_POOL_ADMIN,
-                adminSafe: IntegrationConstants.AVAX_ADMIN_SAFE,
+                protocolSafe: IntegrationConstants.AVAX_ADMIN_SAFE,
                 hasAxelar: true,
                 hasLayerZero: true
             }),
@@ -86,7 +86,7 @@ library ChainConfigs {
                 layerZeroEid: IntegrationConstants.BNB_LAYERZERO_EID,
                 usdc: IntegrationConstants.BNB_USDC,
                 poolAdmin: IntegrationConstants.ETH_DEFAULT_POOL_ADMIN,
-                adminSafe: IntegrationConstants.BNB_ADMIN_SAFE,
+                protocolSafe: IntegrationConstants.BNB_ADMIN_SAFE,
                 hasAxelar: true,
                 hasLayerZero: true
             }),
@@ -99,7 +99,7 @@ library ChainConfigs {
                 layerZeroEid: 0, // Plume doesn't support LayerZero
                 usdc: IntegrationConstants.PLUME_PUSD, // pUSD instead of USDC until USDC exists
                 poolAdmin: IntegrationConstants.PLUME_POOL_ADMIN,
-                adminSafe: IntegrationConstants.PLUME_ADMIN_SAFE,
+                protocolSafe: IntegrationConstants.PLUME_ADMIN_SAFE,
                 hasAxelar: false,
                 hasLayerZero: false
             })


### PR DESCRIPTION
### Product requirements

* Refactorize `LaunchDeployer` using `EnvConfig`
* Simplify inputs in `FullDeployer`
* extract layer zero `SetConfigParam` from connections and add it to layer zero config (now we have bytecode to do this in the Batcher and I think it scales better)
  * Happy if you can check this @onnovisser 
* Rename `adminSafe` to `protocolSafe`

Already verified with claude that the change in the deployer is equivalent, so the refactor doesn't add, change, or remove any logic.