### PR TITLE
chore: archive spell 006 (v3.0.1 to v3.1.0)

### DIFF
--- a/env/spell/006_migration_v3.1/MigrationSpell.sol
+++ b/env/spell/006_migration_v3.1/MigrationSpell.sol
@@ -1,0 +1,686 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Deployed Address: 0xe97ac43A22B8Df15D53503cf8001F12c6B349327 (all chains via CREATE3)
+// V3.0.1 → V3.1 Full Protocol Migration
+// See README.md in this directory for execution details
+pragma solidity 0.8.28;
+
+import {D18} from "../../src/misc/types/D18.sol";
+import {IERC20} from "../../src/misc/interfaces/IERC20.sol";
+import {CastLib} from "../../src/misc/libraries/CastLib.sol";
+import {IEscrow} from "../../src/misc/interfaces/IEscrow.sol";
+import {IERC7575Share, IERC165} from "../../src/misc/interfaces/IERC7575.sol";
+import {ETH_ADDRESS, IRecoverable} from "../../src/misc/interfaces/IRecoverable.sol";
+
+import {Spoke} from "../../src/core/spoke/Spoke.sol";
+import {PoolId} from "../../src/core/types/PoolId.sol";
+import {AssetId} from "../../src/core/types/AssetId.sol";
+import {HubRegistry} from "../../src/core/hub/HubRegistry.sol";
+import {BalanceSheet} from "../../src/core/spoke/BalanceSheet.sol";
+import {VaultKind} from "../../src/core/spoke/interfaces/IVault.sol";
+import {MultiAdapter} from "../../src/core/messaging/MultiAdapter.sol";
+import {ContractUpdater} from "../../src/core/utils/ContractUpdater.sol";
+import {IAdapter} from "../../src/core/messaging/interfaces/IAdapter.sol";
+import {ShareClassManager} from "../../src/core/hub/ShareClassManager.sol";
+import {IShareToken} from "../../src/core/spoke/interfaces/IShareToken.sol";
+import {PoolEscrow, IPoolEscrow} from "../../src/core/spoke/PoolEscrow.sol";
+import {IVault, VaultKind} from "../../src/core/spoke/interfaces/IVault.sol";
+import {MessageProcessor} from "../../src/core/messaging/MessageProcessor.sol";
+import {MessageDispatcher} from "../../src/core/messaging/MessageDispatcher.sol";
+import {VaultRegistry, VaultDetails} from "../../src/core/spoke/VaultRegistry.sol";
+import {ShareClassId, newShareClassId} from "../../src/core/types/ShareClassId.sol";
+import {PoolEscrowFactory} from "../../src/core/spoke/factories/PoolEscrowFactory.sol";
+import {IVaultFactory} from "../../src/core/spoke/factories/interfaces/IVaultFactory.sol";
+
+import {Root} from "../../src/admin/Root.sol";
+import {TokenRecoverer} from "../../src/admin/TokenRecoverer.sol";
+import {ProtocolGuardian} from "../../src/admin/ProtocolGuardian.sol";
+
+import {FreezeOnly} from "../../src/hooks/FreezeOnly.sol";
+import {FullRestrictions} from "../../src/hooks/FullRestrictions.sol";
+import {FreelyTransferable} from "../../src/hooks/FreelyTransferable.sol";
+import {RedemptionRestrictions} from "../../src/hooks/RedemptionRestrictions.sol";
+
+import {OnOfframpManagerFactory, OnOfframpManager, IOnOfframpManager} from "../../src/managers/spoke/OnOfframpManager.sol";
+
+import {BaseVault} from "../../src/vaults/BaseVaults.sol";
+import {SyncManager} from "../../src/vaults/SyncManager.sol";
+import {VaultRouter} from "../../src/vaults/VaultRouter.sol";
+import {AsyncRequestManager} from "../../src/vaults/AsyncRequestManager.sol";
+import {REASON_REDEEM} from "../../src/vaults/interfaces/IVaultManagers.sol";
+import {BatchRequestManager, EpochId} from "../../src/vaults/BatchRequestManager.sol";
+
+import {RefundEscrowFactory} from "../../src/utils/RefundEscrowFactory.sol";
+
+PoolId constant GLOBAL_POOL = PoolId.wrap(0);
+
+contract MessageDispatcherInfallibleMock {
+    uint16 _localCentrifugeId;
+
+    constructor(uint16 localCentrifugeId_) {
+        _localCentrifugeId = localCentrifugeId_;
+    }
+
+    function localCentrifugeId() external view returns (uint16) {
+        return _localCentrifugeId;
+    }
+    function sendRegisterAsset(uint16 centrifugeId, AssetId assetId, uint8 decimals, address refund) external payable {}
+}
+
+interface GatewayV3Like {
+    function subsidy(PoolId) external view returns (uint96 value, IRecoverable refund);
+    function recoverTokens(address token, address receiver, uint256 amount) external;
+}
+
+interface ShareClassManagerV3Like {
+    function metadata(ShareClassId scId) external view returns (string memory name, string memory symbol, bytes32 salt);
+    function metrics(ShareClassId scId) external view returns (uint128 totalIssuance, D18 navPerShare);
+    function issuance(ShareClassId scId, uint16 centrifugeId) external view returns (uint128);
+    function epochId(ShareClassId scId, AssetId assetId)
+        external
+        view
+        returns (uint32 deposit, uint32 redeem, uint32 issue, uint32 revoke);
+}
+
+struct AssetInfo {
+    address addr;
+    uint256 tokenId;
+}
+
+struct V3Contracts {
+    Root root;
+    address guardian;
+    address tokenRecoverer;
+    address messageDispatcher;
+    address messageProcessor;
+    address gateway;
+    address poolEscrowFactory;
+    address spoke;
+    address balanceSheet;
+    address hubRegistry;
+    address shareClassManager;
+    address asyncVaultFactory;
+    address asyncRequestManager;
+    address syncDepositVaultFactory;
+    address syncManager;
+    address freezeOnly;
+    address fullRestrictions;
+    address freelyTransferable;
+    address redemptionRestrictions;
+    address globalEscrow;
+}
+
+struct GlobalParamsInput {
+    V3Contracts v3;
+    Spoke spoke;
+    BalanceSheet balanceSheet;
+    HubRegistry hubRegistry;
+    MultiAdapter multiAdapter;
+    MessageDispatcher messageDispatcher;
+    MessageProcessor messageProcessor;
+    AsyncRequestManager asyncRequestManager;
+    SyncManager syncManager;
+    ProtocolGuardian protocolGuardian;
+    TokenRecoverer tokenRecoverer;
+    VaultRouter vaultRouter;
+
+    AssetId[] spokeAssetIds;
+    AssetId[] hubAssetIds;
+    address[] vaults;
+}
+
+struct PoolParamsInput {
+    V3Contracts v3;
+
+    MultiAdapter multiAdapter;
+    Spoke spoke;
+    BalanceSheet balanceSheet;
+    VaultRegistry vaultRegistry;
+    HubRegistry hubRegistry;
+    ShareClassManager shareClassManager;
+    AsyncRequestManager asyncRequestManager;
+    SyncManager syncManager;
+    FreezeOnly freezeOnly;
+    FullRestrictions fullRestrictions;
+    FreelyTransferable freelyTransferable;
+    RedemptionRestrictions redemptionRestrictions;
+    OnOfframpManagerFactory onOfframpManagerFactory;
+    BatchRequestManager batchRequestManager;
+    ContractUpdater contractUpdater;
+    RefundEscrowFactory refundEscrowFactory;
+
+    AssetId[] spokeAssetIds;
+    AssetId[] hubAssetIds;
+    address[] vaults;
+    address[] bsManagers;
+    AssetInfo[] assets;
+    OnOfframpManager onOfframpManagerV3;
+    address[] onOfframpReceivers;
+    address[] onOfframpRelayers;
+
+    address[] hubManagers;
+    uint16[] chainsWherePoolIsNotified;
+}
+
+contract MigrationSpell {
+    using CastLib for *;
+
+    address public owner;
+    string public constant description = "Migration from v3.0.1 to v3.1";
+
+    constructor(address owner_) {
+        owner = owner_;
+    }
+
+    function castGlobal(GlobalParamsInput memory input) external {
+        require(owner == msg.sender, "not authorized");
+
+        address[] memory contracts = _authorizedContracts(input);
+        for (uint256 i; i < contracts.length; i++) {
+            input.v3.root.relyContract(address(contracts[i]), address(this));
+        }
+
+        MessageDispatcherInfallibleMock messageDispatcherMock =
+            new MessageDispatcherInfallibleMock(input.multiAdapter.localCentrifugeId());
+        input.spoke.file("sender", address(messageDispatcherMock));
+
+        _missingRootWards(input);
+        _migrateGlobal(input);
+
+        input.spoke.file("sender", address(input.messageDispatcher));
+
+        for (uint256 i; i < contracts.length; i++) {
+            input.v3.root.denyContract(address(contracts[i]), address(this));
+        }
+    }
+
+    function castPool(PoolId poolId, PoolParamsInput memory input) external {
+        require(owner == msg.sender, "not authorized");
+
+        address[] memory contracts = _authorizedContracts(input);
+        for (uint256 i; i < contracts.length; i++) {
+            input.v3.root.relyContract(address(contracts[i]), address(this));
+        }
+
+        _migratePool(poolId, input);
+
+        for (uint256 i; i < contracts.length; i++) {
+            input.v3.root.denyContract(address(contracts[i]), address(this));
+        }
+    }
+
+    /// @notice after migrate all pools, we need to lock the spell
+    function lock(Root rootV3) external {
+        require(owner == msg.sender, "not authorized");
+        owner = address(0);
+
+        rootV3.deny(address(this));
+    }
+
+    function _authorizedContracts(GlobalParamsInput memory input) internal pure returns (address[] memory) {
+        address[] memory contracts = new address[](4);
+        contracts[0] = address(input.spoke);
+        contracts[1] = address(input.hubRegistry);
+        contracts[2] = address(input.v3.gateway);
+        contracts[3] = input.v3.globalEscrow;
+        return contracts;
+    }
+
+    function _authorizedContracts(PoolParamsInput memory input) internal pure returns (address[] memory) {
+        address[] memory contracts = new address[](10);
+        contracts[0] = address(input.spoke);
+        contracts[1] = address(input.balanceSheet);
+        contracts[2] = address(input.vaultRegistry);
+        contracts[3] = address(input.hubRegistry);
+        contracts[4] = address(input.shareClassManager);
+        contracts[5] = address(input.syncManager);
+        contracts[6] = address(input.batchRequestManager);
+        contracts[7] = address(input.contractUpdater);
+        contracts[8] = address(input.multiAdapter);
+        contracts[9] = address(input.v3.gateway);
+        return contracts;
+    }
+
+    /// @dev after deploying with an existing root, the following wards are missing and need to be fixed
+    function _missingRootWards(GlobalParamsInput memory input) internal {
+        input.v3.root.rely(address(input.protocolGuardian));
+        input.v3.root.rely(address(input.tokenRecoverer));
+        input.v3.root.rely(address(input.messageDispatcher));
+        input.v3.root.rely(address(input.messageProcessor));
+        input.v3.root.endorse(address(input.balanceSheet));
+        input.v3.root.endorse(address(input.asyncRequestManager));
+        input.v3.root.endorse(address(input.vaultRouter));
+
+        // Remove access to root from v3 contracts
+        input.v3.root.deny(address(input.v3.guardian));
+        input.v3.root.deny(address(input.v3.tokenRecoverer));
+        input.v3.root.deny(address(input.v3.messageDispatcher));
+        input.v3.root.deny(address(input.v3.messageProcessor));
+    }
+
+    function _migrateGlobal(GlobalParamsInput memory input) internal {
+        // ----- ASSETS -----
+        for (uint256 i; i < input.spokeAssetIds.length; i++) {
+            AssetId assetId = input.spokeAssetIds[i];
+            (address addr, uint256 tokenId) = Spoke(input.v3.spoke).idToAsset(assetId);
+            input.spoke.registerAsset(assetId.centrifugeId(), addr, tokenId, address(0));
+        }
+
+        for (uint256 i; i < input.hubAssetIds.length; i++) {
+            AssetId assetId = input.hubAssetIds[i];
+            if (assetId.centrifugeId() != 0) {
+                uint8 decimals = HubRegistry(input.v3.hubRegistry).decimals(assetId);
+                input.hubRegistry.registerAsset(assetId, decimals);
+            }
+        }
+
+        // ----- GATEWAY -----
+        // Transfer global pool funds from the gateway to msg.sender
+        (uint96 subsidizedFunds,) = GatewayV3Like(input.v3.gateway).subsidy(GLOBAL_POOL);
+        GatewayV3Like(input.v3.gateway).recoverTokens(ETH_ADDRESS, msg.sender, subsidizedFunds);
+
+        // ----- VAULTS -----
+        for (uint256 i; i < input.vaults.length; i++) {
+            BaseVault vault = BaseVault(input.vaults[i]);
+            input.v3.root.relyContract(address(vault), address(this));
+
+            input.v3.root.relyContract(address(vault), address(input.asyncRequestManager));
+            input.v3.root.relyContract(address(input.asyncRequestManager), address(vault));
+
+            input.v3.root.denyContract(address(vault), address(input.v3.asyncRequestManager));
+            input.v3.root.denyContract(address(input.v3.asyncRequestManager), address(vault));
+
+            vault.file("manager", address(input.asyncRequestManager));
+            vault.file("asyncRedeemManager", address(input.asyncRequestManager));
+
+            if (vault.vaultKind() == VaultKind.SyncDepositAsyncRedeem) {
+                input.v3.root.relyContract(address(vault), address(input.syncManager));
+                input.v3.root.relyContract(address(input.syncManager), address(vault));
+
+                input.v3.root.denyContract(address(vault), input.v3.syncManager);
+                input.v3.root.denyContract(address(input.v3.syncManager), address(vault));
+
+                vault.file("syncDepositManager", address(input.syncManager));
+            }
+
+            input.v3.root.denyContract(address(vault), address(this));
+        }
+
+        // ----- GLOBAL_ESCROW SWEEP (ERC20 only, skip shares) -----
+        // Defensive: wrap all external asset calls to prevent malicious assets from blocking migration
+        for (uint256 i; i < input.spokeAssetIds.length; i++) {
+            (address asset, uint256 tokenId) = input.spoke.idToAsset(input.spokeAssetIds[i]);
+            if (tokenId != 0) continue;
+
+            // Skip share tokens as they must be resolved by closing pending orders
+            bool isShare = false;
+            try IERC165(asset).supportsInterface(type(IERC7575Share).interfaceId) returns (bool result) {
+                isShare = result;
+            } catch {}
+            if (isShare) continue;
+
+            // Defensive: balanceOf could revert on malicious assets
+            uint256 balance;
+            try IERC20(asset).balanceOf(input.v3.globalEscrow) returns (uint256 balance_) {
+                balance = balance_;
+            } catch {
+                continue;
+            }
+
+            if (balance > 0) {
+                // Defensive: transfer could revert on malicious assets
+                try IEscrow(input.v3.globalEscrow).authTransferTo(asset, 0, msg.sender, balance) {} catch {}
+            }
+        }
+    }
+
+    function _migratePool(PoolId poolId, PoolParamsInput memory input) internal {
+        ShareClassId scId = newShareClassId(poolId, 1);
+        bool inHub = HubRegistry(input.v3.hubRegistry).exists(poolId);
+        bool inSpoke = Spoke(input.v3.spoke).isPoolActive(poolId);
+        address refund;
+
+        if (inHub) {
+            refund = input.hubManagers[0]; // At least one
+            _migratePoolInHub(poolId, scId, input);
+        }
+
+        if (inSpoke) {
+            refund = address(input.refundEscrowFactory.get(poolId));
+            _migratePoolInSpoke(poolId, scId, input);
+        }
+
+        if (inHub || inSpoke) {
+            // ----- REFUND -----
+            (uint96 subsidizedFunds,) = GatewayV3Like(input.v3.gateway).subsidy(poolId);
+            if (subsidizedFunds > 0) {
+                GatewayV3Like(input.v3.gateway).recoverTokens(ETH_ADDRESS, address(refund), subsidizedFunds);
+            }
+
+            IPoolEscrow poolEscrowV3 = PoolEscrowFactory(input.v3.poolEscrowFactory).escrow(poolId);
+            if (address(poolEscrowV3).balance > 0) {
+                input.v3.root.relyContract(address(poolEscrowV3), address(this));
+                poolEscrowV3.recoverTokens(ETH_ADDRESS, address(refund), address(poolEscrowV3).balance);
+                input.v3.root.denyContract(address(poolEscrowV3), address(this));
+            }
+        }
+    }
+
+    function _migratePoolInHub(PoolId poolId, ShareClassId scId, PoolParamsInput memory input) internal {
+        // ----- MULTIADAPTER -----
+        for (uint256 i; i < input.chainsWherePoolIsNotified.length; i++) {
+            uint16 centrifugeId = input.chainsWherePoolIsNotified[i];
+            if (poolId.centrifugeId() != centrifugeId) {
+                IAdapter[] memory adapters = _getAdapters(input.multiAdapter, centrifugeId, GLOBAL_POOL);
+                if (adapters.length > 0) {
+                    input.multiAdapter
+                        .setAdapters(
+                            centrifugeId,
+                            poolId,
+                            adapters,
+                            input.multiAdapter.threshold(centrifugeId, GLOBAL_POOL),
+                            input.multiAdapter.recoveryIndex(centrifugeId, GLOBAL_POOL)
+                        );
+                }
+            }
+        }
+
+        // ---- HUB_REGISTRY -----
+        AssetId currency = HubRegistry(input.v3.hubRegistry).currency(poolId);
+        input.hubRegistry.registerPool(poolId, input.hubManagers[0], currency);
+
+        for (uint256 i = 1; i < input.hubManagers.length; i++) {
+            input.hubRegistry.updateManager(poolId, input.hubManagers[i], true);
+        }
+
+        bytes memory metadata = HubRegistry(input.v3.hubRegistry).metadata(poolId);
+        input.hubRegistry.setMetadata(poolId, metadata);
+
+        for (uint256 i; i < input.chainsWherePoolIsNotified.length; i++) {
+            input.hubRegistry
+                .setHubRequestManager(poolId, input.chainsWherePoolIsNotified[i], input.batchRequestManager);
+        }
+
+        // ---- SHARE_CLASS_MANAGER -----
+        {
+            (string memory scName, string memory scSymbol, bytes32 scSalt) =
+                ShareClassManagerV3Like(input.v3.shareClassManager).metadata(scId);
+            if (bytes(scName).length > 0) {
+                input.shareClassManager
+                    .addShareClass(
+                        poolId, scName, scSymbol, bytes32(abi.encodePacked(bytes8(poolId.raw()), bytes24(scSalt)))
+                    );
+
+                (, D18 navPerShare) = ShareClassManagerV3Like(input.v3.shareClassManager).metrics(scId);
+                input.shareClassManager.updateSharePrice(poolId, scId, navPerShare, uint64(block.timestamp));
+
+                for (uint256 i; i < input.chainsWherePoolIsNotified.length; i++) {
+                    uint16 centrifugeId = input.chainsWherePoolIsNotified[i];
+                    (uint128 issuance) =
+                        ShareClassManagerV3Like(input.v3.shareClassManager).issuance(scId, centrifugeId);
+                    input.shareClassManager.updateShares(centrifugeId, poolId, scId, issuance, true);
+                }
+            }
+        }
+
+        // ----- BATCH_REQUEST_MANAGER -----
+        for (uint256 i; i < input.hubAssetIds.length; i++) {
+            AssetId assetId = input.hubAssetIds[i];
+            (uint32 deposit, uint32 redeem, uint32 issue, uint32 revoke) =
+                ShareClassManagerV3Like(input.v3.shareClassManager).epochId(scId, assetId);
+
+            if (deposit != 0 || redeem != 0 || issue != 0 || revoke != 0) {
+                EpochId memory newEpochIds = EpochId({deposit: deposit, redeem: redeem, issue: issue, revoke: revoke});
+                input.batchRequestManager.setEpochIds(poolId, scId, assetId, newEpochIds);
+            }
+        }
+    }
+
+    function _migratePoolInSpoke(PoolId poolId, ShareClassId scId, PoolParamsInput memory input) internal {
+        IShareToken shareToken;
+
+        // ----- MULTIADAPTER -----
+        if (input.multiAdapter.localCentrifugeId() != poolId.centrifugeId()) {
+            IAdapter[] memory adapters = _getAdapters(input.multiAdapter, poolId.centrifugeId(), GLOBAL_POOL);
+            if (adapters.length > 0) {
+                input.multiAdapter
+                    .setAdapters(
+                        poolId.centrifugeId(),
+                        poolId,
+                        adapters,
+                        input.multiAdapter.threshold(poolId.centrifugeId(), GLOBAL_POOL),
+                        input.multiAdapter.recoveryIndex(poolId.centrifugeId(), GLOBAL_POOL)
+                    );
+            }
+        }
+
+        // ----- SPOKE -----
+        input.spoke.addPool(poolId);
+        input.spoke.setRequestManager(poolId, input.asyncRequestManager);
+
+        try Spoke(input.v3.spoke).shareToken(poolId, scId) returns (IShareToken shareToken_) {
+            shareToken = shareToken_;
+
+            input.spoke.linkToken(poolId, scId, shareToken);
+
+            (uint64 computedAt, uint64 maxAge,) = Spoke(input.v3.spoke).markersPricePoolPerShare(poolId, scId);
+            if (computedAt != 0) {
+                D18 price = Spoke(input.v3.spoke).pricePoolPerShare(poolId, scId, false);
+                input.spoke.updatePricePoolPerShare(poolId, scId, price, computedAt);
+            }
+            if (maxAge != 0) {
+                input.spoke.setMaxSharePriceAge(poolId, scId, maxAge);
+            }
+
+            for (uint256 i; i < input.spokeAssetIds.length; i++) {
+                AssetId assetId = input.spokeAssetIds[i];
+                (computedAt, maxAge,) = Spoke(input.v3.spoke).markersPricePoolPerAsset(poolId, scId, assetId);
+                if (computedAt != 0) {
+                    D18 price = Spoke(input.v3.spoke).pricePoolPerAsset(poolId, scId, assetId, false);
+                    input.spoke.updatePricePoolPerAsset(poolId, scId, assetId, price, computedAt);
+                }
+                if (maxAge != 0) {
+                    input.spoke.setMaxAssetPriceAge(poolId, scId, assetId, maxAge);
+                }
+            }
+        } catch {}
+
+        // ----- BALANCE_SHEET -----
+        address onOfframpManager;
+        for (uint256 i; i < input.bsManagers.length; i++) {
+            address manager = input.bsManagers[i];
+            if (manager == input.v3.asyncRequestManager) {
+                manager = address(input.asyncRequestManager);
+            } else if (manager == input.v3.syncManager) {
+                manager = address(input.syncManager);
+            } else if (manager == address(input.onOfframpManagerV3)) {
+                onOfframpManager = address(input.onOfframpManagerFactory.newManager(poolId, scId));
+                manager = onOfframpManager;
+            }
+
+            input.balanceSheet.updateManager(poolId, manager, true);
+        }
+
+        // ----- POOL_ESCROW (state) -----
+        // Defensive: wrap all external asset calls to prevent malicious assets from blocking migration
+        {
+            IPoolEscrow poolEscrowV3 = BalanceSheet(input.v3.balanceSheet).escrow(poolId);
+            IPoolEscrow poolEscrow = input.balanceSheet.escrow(poolId);
+            input.v3.root.relyContract(address(poolEscrowV3), address(this));
+            input.v3.root.relyContract(address(poolEscrow), address(this));
+
+            for (uint256 i; i < input.assets.length; i++) {
+                _migratePoolEscrowAsset(
+                    scId, input.assets[i], poolEscrowV3, poolEscrow, input.asyncRequestManager, input.v3.root
+                );
+            }
+
+            input.v3.root.denyContract(address(poolEscrow), address(this));
+            input.v3.root.denyContract(address(poolEscrowV3), address(this));
+        }
+
+        // ----- SHARE_TOKEN -----
+        if (address(shareToken) != address(0)) {
+            input.v3.root.relyContract(address(shareToken), address(input.spoke));
+            input.v3.root.relyContract(address(shareToken), address(input.balanceSheet));
+            input.v3.root.denyContract(address(shareToken), address(input.v3.spoke));
+            input.v3.root.denyContract(address(shareToken), address(input.v3.balanceSheet));
+
+            address hookV3 = shareToken.hook();
+            if (hookV3 != address(0)) {
+                input.v3.root.relyContract(address(shareToken), address(this));
+                if (hookV3 == input.v3.freezeOnly) {
+                    shareToken.file("hook", address(input.freezeOnly));
+                } else if (hookV3 == input.v3.fullRestrictions) {
+                    shareToken.file("hook", address(input.fullRestrictions));
+                } else if (hookV3 == input.v3.freelyTransferable) {
+                    shareToken.file("hook", address(input.freelyTransferable));
+                } else if (hookV3 == input.v3.redemptionRestrictions) {
+                    shareToken.file("hook", address(input.redemptionRestrictions));
+                }
+                input.v3.root.denyContract(address(shareToken), address(this));
+            }
+        }
+
+        // ----- VAULT_REGISTRY -----
+        for (uint256 i; i < input.vaults.length; i++) {
+            IVault vault = IVault(input.vaults[i]);
+            if (vault.poolId() == poolId && vault.scId() == scId) {
+                address factory = (vault.vaultKind() == VaultKind.Async)
+                    ? input.v3.asyncVaultFactory
+                    : input.v3.syncDepositVaultFactory;
+
+                VaultDetails memory details = VaultRegistry(input.v3.spoke).vaultDetails(vault);
+                input.vaultRegistry
+                    .registerVault(
+                        poolId, scId, details.assetId, details.asset, details.tokenId, IVaultFactory(factory), vault
+                    );
+
+                if (details.isLinked) {
+                    input.vaultRegistry.linkVault(poolId, scId, details.assetId, vault);
+                }
+            }
+        }
+
+        // ----- SYNC_MANAGER -----
+        {
+            address valuation = address(SyncManager(input.v3.syncManager).valuation(poolId, scId));
+            if (valuation != address(0)) {
+                input.syncManager.setValuation(poolId, scId, valuation);
+            }
+
+            for (uint256 i; i < input.assets.length; i++) {
+                AssetInfo memory assetInfo = input.assets[i];
+                uint128 maxReserve =
+                    SyncManager(input.v3.syncManager).maxReserve(poolId, scId, assetInfo.addr, assetInfo.tokenId);
+                if (maxReserve > 0) {
+                    input.syncManager.setMaxReserve(poolId, scId, assetInfo.addr, assetInfo.tokenId, maxReserve);
+                }
+            }
+        }
+
+        // ----- ON_OFFRAMP_MANAGER -----
+        if (address(input.onOfframpManagerV3) != address(0)) {
+            for (uint256 i; i < input.assets.length; i++) {
+                AssetInfo memory assetInfo = input.assets[i];
+                AssetId assetId = Spoke(input.v3.spoke).assetToId(assetInfo.addr, assetInfo.tokenId);
+                if (input.onOfframpManagerV3.onramp(assetInfo.addr)) {
+                    bytes memory message = abi.encode(IOnOfframpManager.TrustedCall.Onramp, assetId, true);
+                    input.contractUpdater.trustedCall(poolId, scId, onOfframpManager, message);
+                }
+
+                for (uint256 j; j < input.onOfframpReceivers.length; j++) {
+                    address receiver = input.onOfframpReceivers[j];
+                    if (input.onOfframpManagerV3.offramp(assetInfo.addr, receiver)) {
+                        bytes memory message =
+                            abi.encode(IOnOfframpManager.TrustedCall.Offramp, assetId, receiver.toBytes32(), true);
+                        input.contractUpdater.trustedCall(poolId, scId, onOfframpManager, message);
+                    }
+                }
+            }
+
+            for (uint256 i; i < input.onOfframpRelayers.length; i++) {
+                address relayer = input.onOfframpRelayers[i];
+                if (input.onOfframpManagerV3.relayer(relayer)) {
+                    bytes memory message = abi.encode(IOnOfframpManager.TrustedCall.Relayer, relayer.toBytes32(), true);
+                    input.contractUpdater.trustedCall(poolId, scId, onOfframpManager, message);
+                }
+            }
+        }
+    }
+
+    function _getAdapters(MultiAdapter multiAdapter, uint16 centrifugeId, PoolId poolId)
+        private
+        view
+        returns (IAdapter[] memory adapters)
+    {
+        uint8 adapterCount = multiAdapter.quorum(centrifugeId, poolId);
+        adapters = new IAdapter[](adapterCount);
+        for (uint8 j; j < adapterCount; j++) {
+            adapters[j] = multiAdapter.adapters(centrifugeId, poolId, j);
+        }
+    }
+
+    /// @dev Defensively migrates a single asset from v3 pool escrow to new pool escrow.
+    ///      Wraps external calls in try-catch to prevent malicious assets from blocking migration.
+    function _migratePoolEscrowAsset(
+        ShareClassId scId,
+        AssetInfo memory assetInfo,
+        IPoolEscrow poolEscrowV3,
+        IPoolEscrow poolEscrow,
+        AsyncRequestManager asyncRequestManager,
+        Root rootV3
+    ) private {
+        // Defensive: balanceOf could revert on malicious assets
+        uint256 balance;
+        try IERC20(assetInfo.addr).balanceOf(address(poolEscrowV3)) returns (uint256 balance_) {
+            balance = balance_;
+        } catch {
+            return;
+        }
+
+        bool transferFailed = false;
+
+        if (balance > 0) {
+            bool isShare = false;
+            try IERC165(assetInfo.addr).supportsInterface(type(IERC7575Share).interfaceId) returns (bool result) {
+                isShare = result;
+            } catch {}
+
+            if (isShare) {
+                // NOTE: investment assets can be shares from other pools but we trust hook() and file() calls
+                address shareHook = IShareToken(assetInfo.addr).hook();
+                rootV3.relyContract(address(assetInfo.addr), address(this));
+                IShareToken(assetInfo.addr).file("hook", address(0)); // we don't want any restrictions
+
+                // Defensive: transfer could revert on malicious assets
+                try poolEscrowV3.authTransferTo(assetInfo.addr, assetInfo.tokenId, address(poolEscrow), balance) {}
+                catch {
+                    transferFailed = true;
+                }
+
+                // Cleanup always runs
+                IShareToken(assetInfo.addr).file("hook", shareHook);
+                rootV3.denyContract(address(assetInfo.addr), address(this));
+            } else {
+                // Defensive: transfer could revert on malicious assets
+                try poolEscrowV3.authTransferTo(assetInfo.addr, assetInfo.tokenId, address(poolEscrow), balance) {}
+                catch {
+                    transferFailed = true;
+                }
+            }
+        }
+
+        if (transferFailed) return;
+
+        (uint128 total, uint128 reserved) =
+            PoolEscrow(address(poolEscrowV3)).holding(scId, assetInfo.addr, assetInfo.tokenId);
+
+        if (total > 0 || reserved > 0) {
+            poolEscrow.deposit(scId, assetInfo.addr, assetInfo.tokenId, total);
+            // Migrate old reserved to new REDEEM bucket (all v3.0.1 reservations are from ARM revokedShares)
+            poolEscrow.reserve(
+                scId, assetInfo.addr, assetInfo.tokenId, reserved, address(asyncRequestManager), REASON_REDEEM
+            );
+        }
+    }
+}

--- a/env/spell/006_migration_v3.1/README.md
+++ b/env/spell/006_migration_v3.1/README.md
@@ -1,0 +1,96 @@
+# Spell 006: V3.0.1 to V3.1 Full Protocol Migration
+
+## Overview
+
+| Field             | Value                                                  |
+| ----------------- | ------------------------------------------------------ |
+| **Spell Address** | `0xe97ac43A22B8Df15D53503cf8001F12c6B349327`           |
+| **Deployment**    | CREATE3 deterministic (same address on all chains)     |
+| **Description**   | Full protocol redeployment with atomic state migration |
+| **Source Branch** | `main`                                                 |
+
+## Networks
+
+| Network         | Chain ID  | centrifugeId |
+| --------------- | --------- | ------------ |
+| Ethereum        | 1         | 1            |
+| Base            | 8453      | 2            |
+| Arbitrum        | 42161     | 3            |
+| Avalanche       | 43114     | 5            |
+| BNB Smart Chain | 56        | 7            |
+| Plume           | 161221135 | 6            |
+
+## How This Differs from Spells 001-005
+
+Previous spells were targeted contract updates with hardcoded per-network constants and a single `cast()` entry point. This migration:
+
+- **Redeployed the entire v3.1 protocol** alongside existing v3.0.1 contracts
+- Used **dynamic parameters** queried from the Centrifuge GraphQL API at execution time (no hardcoded per-network values)
+- Has a **multi-phase execution model**: `castGlobal()` once, then `castPool()` per pool, then `lock()`
+- **Identical bytecode** on all chains (same code, same address via CREATE3)
+
+## Execution Flow
+
+```
+1. Deploy fresh v3.1 contracts (via FullDeployer)
+2. Root.rely(migrationSpell)          -- grant spell permissions
+3. migrationSpell.castGlobal(input)   -- migrate global state (assets, vaults, gateway funds, permissions)
+4. for each pool:
+     migrationSpell.castPool(poolId, input)  -- migrate pool-specific state
+5. migrationSpell.lock(root)          -- revoke spell permissions, set owner to address(0)
+```
+
+The executor script that orchestrated this flow is `script/spell/MigrationV3_1.s.sol`.
+
+## Dynamic Parameters
+
+All migration parameters were queried at execution time from the Centrifuge GraphQL API. The query definitions are in `script/spell/MigrationQueries.sol` and include:
+
+- `v3Contracts()` - All v3.0.1 deployed contract addresses
+- `pools()` - All pools across all chains
+- `spokeAssetIds()` / `hubAssetIds()` - Asset registrations
+- `vaults()` - All vault addresses
+- `assets()` - Asset info (address + tokenId)
+- `bsManagers(poolId)` - Balance sheet managers per pool
+- `hubManagers(poolId)` - Hub managers per pool
+- `onOfframpManagerV3(poolId)` - OnOfframp manager per pool
+- `onOfframpReceivers(poolId)` / `onOfframpRelayers(poolId)` - Offramp configurations
+- `chainsWherePoolIsNotified(poolId)` - Cross-chain pool destinations
+
+## Migrated State
+
+### Global (`castGlobal`)
+
+- **Asset registrations**: Spoke assets re-registered on new Spoke; Hub assets re-registered on new HubRegistry
+- **Vault manager assignments**: All vaults pointed to new AsyncRequestManager and SyncManager (deny old, rely new)
+- **Root permissions**: Rely new ProtocolGuardian, TokenRecoverer, MessageDispatcher, MessageProcessor; deny v3.0.1 equivalents
+- **Root endorsements**: Endorse new BalanceSheet, AsyncRequestManager, VaultRouter
+- **Gateway subsidized funds**: Recovered from v3.0.1 Gateway to executor
+- **GlobalEscrow sweep**: All ERC20 balances (excluding share tokens) transferred from v3.0.1 GlobalEscrow to executor
+
+### Per-Pool (`castPool`)
+
+- **MultiAdapter**: Pool-specific adapter configurations copied from GLOBAL_POOL settings
+- **HubRegistry**: Pool registration, managers, metadata, hub request manager assignments
+- **ShareClassManager**: Share class metadata, NAV prices, per-chain issuance
+- **BatchRequestManager**: Epoch IDs (deposit/redeem/issue/revoke) per share class per asset
+- **Spoke**: Pool activation, request manager, share token linking, share/asset prices and max ages
+- **BalanceSheet**: Manager permissions (remapping v3.0.1 managers to v3.1 equivalents)
+- **PoolEscrow**: Asset and share token balances transferred from v3.0.1 escrow to v3.1 escrow, including holding state (total + reserved)
+- **ShareToken**: Ward permissions (rely new Spoke/BalanceSheet, deny old), hook migration (FreezeOnly, FullRestrictions, FreelyTransferable, RedemptionRestrictions)
+- **VaultRegistry**: Vault registrations and linked status
+- **SyncManager**: Valuation addresses and maxReserve settings
+- **OnOfframpManager**: New manager deployed per pool, onramp/offramp/relayer configurations migrated via ContractUpdater trusted calls
+- **Subsidized funds**: Per-pool Gateway subsidies and PoolEscrow ETH balances recovered to refund address
+
+## Defensive Patterns
+
+The spell uses try-catch extensively to prevent malicious or misbehaving assets from blocking the migration:
+- `balanceOf` calls wrapped in try-catch
+- `authTransferTo` calls wrapped in try-catch
+- Share token hooks temporarily removed during transfer, then restored
+- `supportsInterface` checks for share token detection wrapped in try-catch
+
+## Validation
+
+The migration was validated using a comprehensive fork test suite with 20+ validators covering all migrated state categories. The test and validation infrastructure can be found on the `spell-006_v3.1.0` tag under `test/spell/migration/`.


### PR DESCRIPTION
### Product requirements

* Archive the v3.0.1 to v3.1 migration spell (`0xe97ac43A22B8Df15D53503cf8001F12c6B349327`) in `env/spell/` so that integrators and the team have a historical record of the full protocol migration, consistent with spells 001 through 005
* Enable future debugging of on chain state by preserving the exact spell source and a summary of what was migrated

### Design notes

* Uses a subdirectory (`env/spell/006_migration_v3.1/`) instead of the flat per network file pattern because this spell deployed identical bytecode via CREATE3 across all six chains with no per network constants
  * duplicating the same 683 line file six times adds no information
* Includes a `README.md` documenting the execution flow (`castGlobal` / `castPool` / `lock`), the dynamic GraphQL parameter sourcing, all migrated state categories, and the defensive try catch patterns used during migration
* Import paths in the archived `MigrationSpell.sol` are adjusted to resolve from `env/spell/006_migration_v3.1/` relative to the project root
* Validation test suite and migration scripts are available on the `spell-006_v3.1.0` tag under `test/spell/migration/`
