### PR TITLE
Swappable GasService through OpsAdmin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ spell-cache/
 
 script/registry/node_modules
 script/registry/package-lock.json
+
+## Benchmarking
+src/admin/GasService_temp.*.sol

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,6 @@ src/
 │   │   ├── MultiAdapter.sol # Multi-protocol messaging
 │   │   ├── MessageProcessor.sol # Process messages
 │   │   ├── MessageDispatcher.sol # Dispatch messages
-│   │   ├── GasService.sol  # Gas management
 │   │   └── libraries/
 │   │       └── MessageLib.sol
 │   ├── libraries/
@@ -69,6 +68,7 @@ src/
 │   ├── OpsGuardian.sol    # Operational guardian
 │   ├── ProtocolGuardian.sol # Protocol guardian
 │   ├── TokenRecoverer.sol # Token recovery
+│   ├── GasService.sol     # Gas management
 │   └── interfaces/
 ├── managers/              # Automation managers
 │   ├── hub/

--- a/foundry.lock
+++ b/foundry.lock
@@ -10,5 +10,8 @@
       "name": "v0.0.17",
       "rev": "c057d167139dc4878f10ab7133a8c069fa6b1601"
     }
+  },
+  "lib/setup-helpers": {
+    "rev": "0b6c2c1a478a34a8f284ebabd57b951085952cdf"
   }
 }

--- a/script/DeployGasService.s.sol
+++ b/script/DeployGasService.s.sol
@@ -14,10 +14,10 @@ import {Safe, Enum} from "safe-utils/Safe.sol";
 
 /// @title DeployGasService
 /// @notice Deploys a new GasService and proposes an OpsGuardian.setGasService call via the ops Safe.
-/// @dev Set NETWORK env var to the network name (e.g., "ethereum", "base", "arbitrum").
+/// @dev Set NETWORK and VERSION env vars (e.g., "ethereum", "v3.1.1").
 ///
 ///      Example usage:
-///        NETWORK=ethereum forge script script/DeployGasService.s.sol --rpc-url $ETH_RPC_URL --broadcast
+///        NETWORK=ethereum VERSION=v3.1.1 forge script script/DeployGasService.s.sol --rpc-url $ETH_RPC_URL --broadcast
 contract DeployGasService is Script, JsonRegistry {
     using Safe for *;
 
@@ -28,14 +28,10 @@ contract DeployGasService is Script, JsonRegistry {
         startDeploymentOutput();
         vm.startBroadcast();
 
-        string memory network = vm.envString("NETWORK");
-        EnvConfig memory config = Env.load(network);
+        EnvConfig memory config = Env.load(vm.envString("NETWORK"));
 
         GasService gasService = new GasService(config.network.buildBatchLimits());
-
-        string memory json = vm.readFile(string.concat("env/", network, ".json"));
-        string memory currentVersion = vm.parseJsonString(json, ".contracts.gasService.version");
-        register("gasService", address(gasService), _nextVersion(currentVersion));
+        register("gasService", address(gasService), vm.envString("VERSION"));
 
         address opsGuardian = config.contracts.opsGuardian;
         bytes memory data = abi.encodeCall(IOpsGuardian.setGasService, (IGasService(address(gasService))));
@@ -46,37 +42,5 @@ contract DeployGasService is Script, JsonRegistry {
 
         vm.stopBroadcast();
         saveDeploymentOutput();
-    }
-
-    /// @dev Increments the path number. i.e:
-    /// if v3.1   then v3.1.1
-    /// if v3.1.5 then v3.1.6
-    function _nextVersion(string memory current) private pure returns (string memory) {
-        // Normalize: if only one dot (e.g. "v3.1"), treat as "v3.1.0" before incrementing
-        bytes memory b = bytes(current);
-        uint256 dotCount = 0;
-        for (uint256 i = 0; i < b.length; i++) {
-            if (b[i] == ".") dotCount++;
-        }
-        if (dotCount < 2) current = string.concat(current, ".0");
-
-        // Find the last dot and parse the patch number after it
-        b = bytes(current);
-        uint256 lastDot = 0;
-        for (uint256 i = 0; i < b.length; i++) {
-            if (b[i] == ".") lastDot = i;
-        }
-
-        uint256 patch = 0;
-        for (uint256 i = lastDot + 1; i < b.length; i++) {
-            patch = patch * 10 + (uint8(b[i]) - 48);
-        }
-
-        bytes memory prefix = new bytes(lastDot + 1);
-        for (uint256 i = 0; i <= lastDot; i++) {
-            prefix[i] = b[i];
-        }
-
-        return string.concat(string(prefix), vm.toString(patch + 1));
     }
 }

--- a/script/DeployGasService.s.sol
+++ b/script/DeployGasService.s.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.28;
 
 import {Env, EnvConfig} from "./utils/EnvConfig.s.sol";
+import {JsonRegistry} from "./utils/JsonRegistry.s.sol";
 
 import {GasService} from "../src/admin/GasService.sol";
 import {IGasService} from "../src/admin/interfaces/IGasService.sol";
@@ -17,19 +18,24 @@ import {Safe, Enum} from "safe-utils/Safe.sol";
 ///
 ///      Example usage:
 ///        NETWORK=ethereum forge script script/DeployGasService.s.sol --rpc-url $ETH_RPC_URL --broadcast
-contract DeployGasService is Script {
+contract DeployGasService is Script, JsonRegistry {
     using Safe for *;
 
     string constant LEDGER_DERIVATION_PATH = "m/44'/60'/0'/0/0";
     Safe.Client safe;
 
     function run() external {
+        startDeploymentOutput();
         vm.startBroadcast();
 
-        EnvConfig memory config = Env.load(vm.envString("NETWORK"));
+        string memory network = vm.envString("NETWORK");
+        EnvConfig memory config = Env.load(network);
 
         GasService gasService = new GasService(config.network.buildBatchLimits());
-        console.log("GasService deployed at:", address(gasService));
+
+        string memory json = vm.readFile(string.concat("env/", network, ".json"));
+        string memory currentVersion = vm.parseJsonString(json, ".contracts.gasService.version");
+        register("gasService", address(gasService), _nextVersion(currentVersion));
 
         address opsGuardian = config.contracts.opsGuardian;
         bytes memory data = abi.encodeCall(IOpsGuardian.setGasService, (IGasService(address(gasService))));
@@ -39,5 +45,38 @@ contract DeployGasService is Script {
         safe.proposeTransactionWithSignature(opsGuardian, data, msg.sender, signature);
 
         vm.stopBroadcast();
+        saveDeploymentOutput();
+    }
+
+    /// @dev Increments the path number. i.e:
+    /// if v3.1   then v3.1.1
+    /// if v3.1.5 then v3.1.6
+    function _nextVersion(string memory current) private pure returns (string memory) {
+        // Normalize: if only one dot (e.g. "v3.1"), treat as "v3.1.0" before incrementing
+        bytes memory b = bytes(current);
+        uint256 dotCount = 0;
+        for (uint256 i = 0; i < b.length; i++) {
+            if (b[i] == ".") dotCount++;
+        }
+        if (dotCount < 2) current = string.concat(current, ".0");
+
+        // Find the last dot and parse the patch number after it
+        b = bytes(current);
+        uint256 lastDot = 0;
+        for (uint256 i = 0; i < b.length; i++) {
+            if (b[i] == ".") lastDot = i;
+        }
+
+        uint256 patch = 0;
+        for (uint256 i = lastDot + 1; i < b.length; i++) {
+            patch = patch * 10 + (uint8(b[i]) - 48);
+        }
+
+        bytes memory prefix = new bytes(lastDot + 1);
+        for (uint256 i = 0; i <= lastDot; i++) {
+            prefix[i] = b[i];
+        }
+
+        return string.concat(string(prefix), vm.toString(patch + 1));
     }
 }

--- a/script/DeployGasService.s.sol
+++ b/script/DeployGasService.s.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {Env, EnvConfig} from "./utils/EnvConfig.s.sol";
+
+import {GasService} from "../src/core/messaging/GasService.sol";
+import {IGasService} from "../src/core/messaging/interfaces/IGasService.sol";
+import {IOpsGuardian} from "../src/admin/interfaces/IOpsGuardian.sol";
+
+import "forge-std/Script.sol";
+
+import {Safe, Enum} from "safe-utils/Safe.sol";
+
+/// @title DeployGasService
+/// @notice Deploys a new GasService and proposes an OpsGuardian.setGasService call via the ops Safe.
+/// @dev Set NETWORK env var to the network name (e.g., "ethereum", "base", "arbitrum").
+///
+///      Example usage:
+///        NETWORK=ethereum forge script script/DeployGasService.s.sol --rpc-url $ETH_RPC_URL --broadcast
+contract DeployGasService is Script {
+    using Safe for *;
+
+    string constant LEDGER_DERIVATION_PATH = "m/44'/60'/0'/0/0";
+    Safe.Client safe;
+
+    function run() external {
+        vm.startBroadcast();
+
+        EnvConfig memory config = Env.load(vm.envString("NETWORK"));
+
+        GasService gasService = new GasService(config.network.buildBatchLimits());
+        console.log("GasService deployed at:", address(gasService));
+
+        address opsGuardian = config.contracts.opsGuardian;
+        bytes memory data = abi.encodeCall(IOpsGuardian.setGasService, (IGasService(address(gasService))));
+
+        safe.initialize(config.network.opsAdmin);
+        bytes memory signature = safe.sign(opsGuardian, data, Enum.Operation.Call, msg.sender, LEDGER_DERIVATION_PATH);
+        safe.proposeTransactionWithSignature(opsGuardian, data, msg.sender, signature);
+
+        vm.stopBroadcast();
+    }
+}

--- a/script/DeployGasService.s.sol
+++ b/script/DeployGasService.s.sol
@@ -3,9 +3,8 @@ pragma solidity 0.8.28;
 
 import {Env, EnvConfig} from "./utils/EnvConfig.s.sol";
 
-import {GasService} from "../src/core/messaging/GasService.sol";
-import {IGasService} from "../src/core/messaging/interfaces/IGasService.sol";
-
+import {GasService} from "../src/admin/GasService.sol";
+import {IGasService} from "../src/admin/interfaces/IGasService.sol";
 import {IOpsGuardian} from "../src/admin/interfaces/IOpsGuardian.sol";
 
 import "forge-std/Script.sol";

--- a/script/DeployGasService.s.sol
+++ b/script/DeployGasService.s.sol
@@ -5,6 +5,7 @@ import {Env, EnvConfig} from "./utils/EnvConfig.s.sol";
 
 import {GasService} from "../src/core/messaging/GasService.sol";
 import {IGasService} from "../src/core/messaging/interfaces/IGasService.sol";
+
 import {IOpsGuardian} from "../src/admin/interfaces/IOpsGuardian.sol";
 
 import "forge-std/Script.sol";

--- a/script/FullDeployer.s.sol
+++ b/script/FullDeployer.s.sol
@@ -11,7 +11,6 @@ import {Gateway} from "../src/core/messaging/Gateway.sol";
 import {HubHandler} from "../src/core/hub/HubHandler.sol";
 import {HubRegistry} from "../src/core/hub/HubRegistry.sol";
 import {BalanceSheet} from "../src/core/spoke/BalanceSheet.sol";
-import {GasService} from "../src/core/messaging/GasService.sol";
 import {VaultRegistry} from "../src/core/spoke/VaultRegistry.sol";
 import {MultiAdapter} from "../src/core/messaging/MultiAdapter.sol";
 import {ContractUpdater} from "../src/core/utils/ContractUpdater.sol";
@@ -22,6 +21,7 @@ import {MessageDispatcher} from "../src/core/messaging/MessageDispatcher.sol";
 import {PoolEscrowFactory} from "../src/core/spoke/factories/PoolEscrowFactory.sol";
 
 import {Root} from "../src/admin/Root.sol";
+import {GasService} from "../src/admin/GasService.sol";
 import {ISafe} from "../src/admin/interfaces/ISafe.sol";
 import {OpsGuardian} from "../src/admin/OpsGuardian.sol";
 import {TokenRecoverer} from "../src/admin/TokenRecoverer.sol";
@@ -122,11 +122,11 @@ contract FullDeployer is BaseDeployer, Constants {
     TokenRecoverer public tokenRecoverer;
     ProtocolGuardian public protocolGuardian;
     OpsGuardian public opsGuardian;
+    GasService public gasService;
 
     Gateway public gateway;
     MultiAdapter public multiAdapter;
 
-    GasService public gasService;
     MessageProcessor public messageProcessor;
     MessageDispatcher public messageDispatcher;
 
@@ -243,6 +243,13 @@ contract FullDeployer is BaseDeployer, Constants {
             create3(createSalt("root", V3_1), abi.encodePacked(type(Root).creationCode, abi.encode(DELAY, batcher)))
         );
 
+        gasService = GasService(
+            create3(
+                createSalt("gasService", V3_1),
+                abi.encodePacked(type(GasService).creationCode, abi.encode(input.txLimits))
+            )
+        );
+
         // Core
         gateway = Gateway(
             create3(
@@ -266,13 +273,6 @@ contract FullDeployer is BaseDeployer, Constants {
         );
 
         // Messaging
-        gasService = GasService(
-            create3(
-                createSalt("gasService", V3_1),
-                abi.encodePacked(type(GasService).creationCode, abi.encode(input.txLimits))
-            )
-        );
-
         messageProcessor = MessageProcessor(
             create3(
                 createSalt("messageProcessor", V3_1),
@@ -663,7 +663,6 @@ contract FullDeployer is BaseDeployer, Constants {
         return CoreReport(
             gateway,
             multiAdapter,
-            gasService,
             messageProcessor,
             messageDispatcher,
             poolEscrowFactory,
@@ -681,7 +680,8 @@ contract FullDeployer is BaseDeployer, Constants {
             root,
             tokenRecoverer,
             protocolGuardian,
-            opsGuardian
+            opsGuardian,
+            gasService
         );
     }
 

--- a/script/FullDeployer.s.sol
+++ b/script/FullDeployer.s.sol
@@ -391,7 +391,7 @@ contract FullDeployer is BaseDeployer, Constants {
         opsGuardian = OpsGuardian(
             create3(
                 createSalt("opsGuardian", V3_1),
-                abi.encodePacked(type(OpsGuardian).creationCode, abi.encode(ISafe(address(batcher)), hub, multiAdapter))
+                abi.encodePacked(type(OpsGuardian).creationCode, abi.encode(ISafe(address(batcher)), hub, multiAdapter, gateway))
             )
         );
     }

--- a/script/FullDeployer.s.sol
+++ b/script/FullDeployer.s.sol
@@ -391,7 +391,9 @@ contract FullDeployer is BaseDeployer, Constants {
         opsGuardian = OpsGuardian(
             create3(
                 createSalt("opsGuardian", V3_1),
-                abi.encodePacked(type(OpsGuardian).creationCode, abi.encode(ISafe(address(batcher)), hub, multiAdapter, gateway))
+                abi.encodePacked(
+                    type(OpsGuardian).creationCode, abi.encode(ISafe(address(batcher)), hub, multiAdapter, gateway)
+                )
             )
         );
     }

--- a/script/deploy-gas-service.sh
+++ b/script/deploy-gas-service.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Deploys the GasService and propose it using OpsGuardian in all mainnet chains
-# Usage: PROPOSER=<safe_proposer_address> script/deploy-gas-service.sh
+# Usage: PROPOSER=<safe_proposer_address> VERSION=<version> script/deploy-gas-service.sh
 
 set -euo pipefail
 
@@ -9,6 +9,7 @@ set -a; source .env; set +a
 
 # Proposer address (Ledger account that will sign the Safe proposals)
 PROPOSER="${PROPOSER:?Missing PROPOSER env var}"
+VERSION="${VERSION:?Missing VERSION env var}"
 
 for NETWORK_FILE in env/*.json; do
     NETWORK=$(basename "$NETWORK_FILE" .json)
@@ -37,7 +38,7 @@ for NETWORK_FILE in env/*.json; do
     echo "========================================================"
     echo ""
 
-    NETWORK="$NETWORK" forge script script/DeployGasService.s.sol:DeployGasService \
+    NETWORK="$NETWORK" VERSION="$VERSION" forge script script/DeployGasService.s.sol:DeployGasService \
         --rpc-url "$RPC_URL" \
         --sender "$PROPOSER" \
         --broadcast

--- a/script/deploy-gas-service.sh
+++ b/script/deploy-gas-service.sh
@@ -41,6 +41,9 @@ for NETWORK_FILE in env/*.json; do
         --rpc-url "$RPC_URL" \
         --sender "$PROPOSER" \
         --broadcast
+
+    python3 script/deploy/update_network_config.py "$NETWORK" \
+        --script script/DeployGasService.s.sol
 done
 
 echo ""

--- a/script/deploy-gas-service.sh
+++ b/script/deploy-gas-service.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Deploys the GasService and propose it using OpsGuardian in all mainnet chains
+# Usage: PROPOSER=<safe_proposer_address> script/deploy-gas-service.sh
+
+set -euo pipefail
+
+set -a; source .env; set +a
+
+# Proposer address (Ledger account that will sign the Safe proposals)
+PROPOSER="${PROPOSER:?Missing PROPOSER env var}"
+
+for NETWORK_FILE in env/*.json; do
+    NETWORK=$(basename "$NETWORK_FILE" .json)
+    ENV=$(jq -r '.network.environment' "$NETWORK_FILE")
+
+    if [ "$ENV" != "mainnet" ]; then
+        continue
+    fi
+
+    BASE_RPC_URL=$(jq -r '.network.baseRpcUrl' "$NETWORK_FILE")
+
+    # Mirror NetworkConfigLib.rpcUrl() logic
+    if [[ "$BASE_RPC_URL" == *"alchemy"* ]]; then
+        RPC_URL="${BASE_RPC_URL}${ALCHEMY_API_KEY:?Missing ALCHEMY_API_KEY}"
+    elif [[ "$BASE_RPC_URL" == *"plume"* ]]; then
+        RPC_URL="${BASE_RPC_URL}${PLUME_API_KEY:?Missing PLUME_API_KEY}"
+    elif [[ "$BASE_RPC_URL" == *"pharos"* ]]; then
+        RPC_URL="${BASE_RPC_URL}${PHAROS_API_KEY:?Missing PHAROS_API_KEY}"
+    else
+        RPC_URL="$BASE_RPC_URL"
+    fi
+
+    echo ""
+    echo "========================================================"
+    echo " Network: $NETWORK"
+    echo "========================================================"
+    echo ""
+
+    NETWORK="$NETWORK" forge script script/DeployGasService.s.sol:DeployGasService \
+        --rpc-url "$RPC_URL" \
+        --sender "$PROPOSER" \
+        --broadcast
+done
+
+echo ""
+echo "Done. GasService deployed and OpsGuardian.setGasService proposed on all mainnet networks."
+echo ""

--- a/script/utils/EnvConfig.s.sol
+++ b/script/utils/EnvConfig.s.sol
@@ -68,8 +68,8 @@ struct ContractsConfig {
     address tokenRecoverer;
     address protocolGuardian;
     address opsGuardian;
-    // Core
     address gasService;
+    // Core
     address gateway;
     address multiAdapter;
     address messageProcessor;
@@ -221,9 +221,9 @@ library Env {
         config.tokenRecoverer = _parseContractAddress(json, "tokenRecoverer");
         config.protocolGuardian = _parseContractAddress(json, "protocolGuardian");
         config.opsGuardian = _parseContractAddress(json, "opsGuardian");
+        config.gasService = _parseContractAddress(json, "gasService");
 
         // Core
-        config.gasService = _parseContractAddress(json, "gasService");
         config.gateway = _parseContractAddress(json, "gateway");
         config.multiAdapter = _parseContractAddress(json, "multiAdapter");
         config.messageProcessor = _parseContractAddress(json, "messageProcessor");

--- a/script/utils/benchmarks.sh
+++ b/script/utils/benchmarks.sh
@@ -18,8 +18,8 @@ case $1 in
     # Checks if GasService must be updated
     RAYON_NUM_THREADS=1 BENCHMARKING_RUN_ID="$(date +%s)" forge test EndToEnd
 
-    tmp="$(mktemp ./src/core/messaging/GasService_temp.XXXXXXX.sol)"
-    cp ./src/core/messaging/GasService.sol "$tmp"
+    tmp="$(mktemp ./src/admin/GasService_temp.XXXXXXX.sol)"
+    cp ./src/admin/GasService.sol "$tmp"
     trap 'rm -f "$tmp"' EXIT
 
     python3 script/utils/update_gas_service_values.py ./snapshots/MessageGasLimits.json "$tmp"

--- a/script/utils/benchmarks.sh
+++ b/script/utils/benchmarks.sh
@@ -11,7 +11,7 @@ case $1 in
   apply)
     # Computes new benchmarks and updates GasService with those values
     RAYON_NUM_THREADS=1 BENCHMARKING_RUN_ID="$(date +%s)" forge test EndToEnd
-    python3 script/utils/update_gas_service_values.py ./snapshots/MessageGasLimits.json ./src/core/messaging/GasService.sol
+    python3 script/utils/update_gas_service_values.py ./snapshots/MessageGasLimits.json ./src/admin/GasService.sol
     ;;
 
   check)

--- a/script/utils/benchmarks.sh
+++ b/script/utils/benchmarks.sh
@@ -24,7 +24,7 @@ case $1 in
 
     python3 script/utils/update_gas_service_values.py ./snapshots/MessageGasLimits.json "$tmp"
 
-    sdiff -s ./src/core/messaging/GasService.sol "$tmp"
+    sdiff -s ./src/admin/GasService.sol "$tmp"
     ;;
 
   *)

--- a/snapshots/MessageGasLimits.json
+++ b/snapshots/MessageGasLimits.json
@@ -1,5 +1,5 @@
 {
-  "BENCHMARKING_RUN_ID": 1768323786,
+  "BENCHMARKING_RUN_ID": 1774954755,
   "scheduleUpgrade": 93954,
   "cancelUpgrade": 74410,
   "recoverTokens": 150073,

--- a/snapshots/MessageGasLimits.json
+++ b/snapshots/MessageGasLimits.json
@@ -1,5 +1,5 @@
 {
-  "BENCHMARKING_RUN_ID": 1774954755,
+  "BENCHMARKING_RUN_ID": 1775468388,
   "scheduleUpgrade": 93954,
   "cancelUpgrade": 74410,
   "recoverTokens": 150073,

--- a/src/admin/GasService.sol
+++ b/src/admin/GasService.sol
@@ -2,11 +2,11 @@
 pragma solidity 0.8.28;
 
 import {IGasService} from "./interfaces/IGasService.sol";
-import {PROCESS_FAIL_MESSAGE_GAS} from "./interfaces/IGateway.sol";
-import {IMessageProperties} from "./interfaces/IMessageProperties.sol";
-import {MessageLib, MessageType, VaultUpdateKind} from "./libraries/MessageLib.sol";
 
-import {PoolId} from "../types/PoolId.sol";
+import {PoolId} from "../core/types/PoolId.sol";
+import {PROCESS_FAIL_MESSAGE_GAS} from "../core/messaging/interfaces/IGateway.sol";
+import {IMessageProperties} from "../core/messaging/interfaces/IMessageProperties.sol";
+import {MessageLib, MessageType, VaultUpdateKind} from "../core/messaging/libraries/MessageLib.sol";
 
 /// @title  GasService
 /// @notice This contract stores the gas limits (in gas units) for cross-chain message execution.

--- a/src/admin/OpsGuardian.sol
+++ b/src/admin/OpsGuardian.sol
@@ -44,12 +44,13 @@ contract OpsGuardian is IOpsGuardian {
     function file(bytes32 what, address data) external onlySafe {
         if (what == "opsSafe") opsSafe = ISafe(data);
         else if (what == "hub") hub = ICreatePool(data);
-        else if (what == "multiAdapter") multiAdapter = IMultiAdapter(data);
         else if (what == "gateway") gateway = IGateway(data);
+        else if (what == "multiAdapter") multiAdapter = IMultiAdapter(data);
         else revert FileUnrecognizedParam();
         emit File(what, data);
     }
 
+    /// @inheritdoc IOpsGuardian
     function setGasService(IGasService gasService) external onlySafe {
         gateway.file("messageProperties", address(gasService));
         multiAdapter.file("messageProperties", address(gasService));

--- a/src/admin/OpsGuardian.sol
+++ b/src/admin/OpsGuardian.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.28;
 
 import {ISafe} from "./interfaces/ISafe.sol";
 import {ICreatePool} from "./interfaces/ICreatePool.sol";
+import {IGasService} from "./interfaces/IGasService.sol";
 import {IOpsGuardian} from "./interfaces/IOpsGuardian.sol";
 import {IAdapterWiring} from "./interfaces/IAdapterWiring.sol";
 
@@ -10,7 +11,6 @@ import {PoolId} from "../core/types/PoolId.sol";
 import {AssetId} from "../core/types/AssetId.sol";
 import {IAdapter} from "../core/messaging/interfaces/IAdapter.sol";
 import {IGateway} from "../core/messaging/interfaces/IGateway.sol";
-import {IGasService} from "../core/messaging/interfaces/IGasService.sol";
 import {IMultiAdapter} from "../core/messaging/interfaces/IMultiAdapter.sol";
 
 /// @title  OpsGuardian

--- a/src/admin/OpsGuardian.sol
+++ b/src/admin/OpsGuardian.sol
@@ -10,6 +10,8 @@ import {PoolId} from "../core/types/PoolId.sol";
 import {AssetId} from "../core/types/AssetId.sol";
 import {IAdapter} from "../core/messaging/interfaces/IAdapter.sol";
 import {IMultiAdapter} from "../core/messaging/interfaces/IMultiAdapter.sol";
+import {IGasService} from "../core/messaging/interfaces/IGasService.sol";
+import {IGateway} from "../core/messaging/interfaces/IGateway.sol";
 
 /// @title  OpsGuardian
 /// @notice This contract manages operational aspects of the protocol including adapter initialization,
@@ -20,11 +22,13 @@ contract OpsGuardian is IOpsGuardian {
     ISafe public opsSafe;
     ICreatePool public hub;
     IMultiAdapter public multiAdapter;
+    IGateway public gateway;
 
-    constructor(ISafe opsSafe_, ICreatePool hub_, IMultiAdapter multiAdapter_) {
+    constructor(ISafe opsSafe_, ICreatePool hub_, IMultiAdapter multiAdapter_, IGateway gateway_) {
         opsSafe = opsSafe_;
         hub = hub_;
         multiAdapter = multiAdapter_;
+        gateway = gateway_;
     }
 
     modifier onlySafe() {
@@ -41,8 +45,14 @@ contract OpsGuardian is IOpsGuardian {
         if (what == "opsSafe") opsSafe = ISafe(data);
         else if (what == "hub") hub = ICreatePool(data);
         else if (what == "multiAdapter") multiAdapter = IMultiAdapter(data);
+        else if (what == "gateway") gateway = IGateway(data);
         else revert FileUnrecognizedParam();
         emit File(what, data);
+    }
+
+    function setGasService(IGasService gasService) external onlySafe {
+        gateway.file("messageProperties", address(gasService));
+        multiAdapter.file("messageProperties", address(gasService));
     }
 
     //----------------------------------------------------------------------------------------------

--- a/src/admin/OpsGuardian.sol
+++ b/src/admin/OpsGuardian.sol
@@ -9,9 +9,9 @@ import {IAdapterWiring} from "./interfaces/IAdapterWiring.sol";
 import {PoolId} from "../core/types/PoolId.sol";
 import {AssetId} from "../core/types/AssetId.sol";
 import {IAdapter} from "../core/messaging/interfaces/IAdapter.sol";
-import {IMultiAdapter} from "../core/messaging/interfaces/IMultiAdapter.sol";
-import {IGasService} from "../core/messaging/interfaces/IGasService.sol";
 import {IGateway} from "../core/messaging/interfaces/IGateway.sol";
+import {IGasService} from "../core/messaging/interfaces/IGasService.sol";
+import {IMultiAdapter} from "../core/messaging/interfaces/IMultiAdapter.sol";
 
 /// @title  OpsGuardian
 /// @notice This contract manages operational aspects of the protocol including adapter initialization,

--- a/src/admin/interfaces/IGasService.sol
+++ b/src/admin/interfaces/IGasService.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.5.0;
 
-import {IMessageProperties} from "./IMessageProperties.sol";
+import {IMessageProperties} from "../../core/messaging/interfaces/IMessageProperties.sol";
 
 /// @dev Max cost. No messages will take more that this
 uint128 constant MAX_MESSAGE_COST = 3_200_000;

--- a/src/admin/interfaces/IOpsGuardian.sol
+++ b/src/admin/interfaces/IOpsGuardian.sol
@@ -9,6 +9,7 @@ import {PoolId} from "../../core/types/PoolId.sol";
 import {AssetId} from "../../core/types/AssetId.sol";
 import {IAdapter} from "../../core/messaging/interfaces/IAdapter.sol";
 import {IMultiAdapter} from "../../core/messaging/interfaces/IMultiAdapter.sol";
+import {IGateway} from "../../core/messaging/interfaces/IGateway.sol";
 
 interface IOpsGuardian {
     error NotTheAuthorizedSafe();
@@ -36,7 +37,7 @@ interface IOpsGuardian {
     function wire(address adapter, uint16 centrifugeId, bytes memory data) external;
 
     /// @notice Updates a contract parameter
-    /// @param what Accepts a bytes32 representation of 'opsSafe', 'hub', or 'multiAdapter'
+    /// @param what Accepts a bytes32 representation of 'opsSafe', 'hub', 'gateway', or 'multiAdapter'
     /// @param data New value for the parameter
     function file(bytes32 what, address data) external;
 
@@ -56,6 +57,9 @@ interface IOpsGuardian {
 
     /// @notice Hub contract called to register new pools
     function hub() external view returns (ICreatePool);
+
+    /// @notice Gateway contract used to update the GasService
+    function gateway() external view returns (IGateway);
 
     /// @notice MultiAdapter used for first-time adapter initialization and wiring on new networks
     function multiAdapter() external view returns (IMultiAdapter);

--- a/src/admin/interfaces/IOpsGuardian.sol
+++ b/src/admin/interfaces/IOpsGuardian.sol
@@ -6,6 +6,7 @@ import {ISafe} from "./ISafe.sol";
 import {PoolId} from "../../core/types/PoolId.sol";
 import {AssetId} from "../../core/types/AssetId.sol";
 import {IAdapter} from "../../core/messaging/interfaces/IAdapter.sol";
+import {IGasService} from "../../core/messaging/interfaces/IGasService.sol";
 
 interface IOpsGuardian {
     error NotTheAuthorizedSafe();
@@ -36,6 +37,10 @@ interface IOpsGuardian {
     /// @param what Accepts a bytes32 representation of 'opsSafe', 'hub', or 'multiAdapter'
     /// @param data New value for the parameter
     function file(bytes32 what, address data) external;
+
+    /// @notice Updates the gas service
+    /// @param gasService the new gas service to use
+    function setGasService(IGasService gasService) external;
 
     /// @notice Registers a new pool
     /// @param poolId The pool identifier

--- a/src/admin/interfaces/IOpsGuardian.sol
+++ b/src/admin/interfaces/IOpsGuardian.sol
@@ -8,8 +8,8 @@ import {IGasService} from "./IGasService.sol";
 import {PoolId} from "../../core/types/PoolId.sol";
 import {AssetId} from "../../core/types/AssetId.sol";
 import {IAdapter} from "../../core/messaging/interfaces/IAdapter.sol";
-import {IMultiAdapter} from "../../core/messaging/interfaces/IMultiAdapter.sol";
 import {IGateway} from "../../core/messaging/interfaces/IGateway.sol";
+import {IMultiAdapter} from "../../core/messaging/interfaces/IMultiAdapter.sol";
 
 interface IOpsGuardian {
     error NotTheAuthorizedSafe();

--- a/src/admin/interfaces/IOpsGuardian.sol
+++ b/src/admin/interfaces/IOpsGuardian.sol
@@ -2,11 +2,11 @@
 pragma solidity >=0.5.0;
 
 import {ISafe} from "./ISafe.sol";
+import {IGasService} from "./IGasService.sol";
 
 import {PoolId} from "../../core/types/PoolId.sol";
 import {AssetId} from "../../core/types/AssetId.sol";
 import {IAdapter} from "../../core/messaging/interfaces/IAdapter.sol";
-import {IGasService} from "../../core/messaging/interfaces/IGasService.sol";
 
 interface IOpsGuardian {
     error NotTheAuthorizedSafe();

--- a/src/deployment/ActionBatchers.sol
+++ b/src/deployment/ActionBatchers.sol
@@ -230,6 +230,7 @@ contract CoreActionBatcher is Constants {
 
         // Rely opsGuardian
         report.multiAdapter.rely(address(report.opsGuardian));
+        report.gateway.rely(address(report.opsGuardian));
         report.hub.rely(address(report.opsGuardian));
 
         // Rely tokenRecoverer

--- a/src/deployment/ActionBatchers.sol
+++ b/src/deployment/ActionBatchers.sol
@@ -12,7 +12,6 @@ import {Gateway} from "../core/messaging/Gateway.sol";
 import {HubHandler} from "../core/hub/HubHandler.sol";
 import {HubRegistry} from "../core/hub/HubRegistry.sol";
 import {BalanceSheet} from "../core/spoke/BalanceSheet.sol";
-import {GasService} from "../core/messaging/GasService.sol";
 import {AssetId, newAssetId} from "../core/types/AssetId.sol";
 import {VaultRegistry} from "../core/spoke/VaultRegistry.sol";
 import {MultiAdapter} from "../core/messaging/MultiAdapter.sol";
@@ -26,6 +25,7 @@ import {PoolEscrowFactory} from "../core/spoke/factories/PoolEscrowFactory.sol";
 import {MAX_ADAPTER_COUNT} from "../core/messaging/interfaces/IMultiAdapter.sol";
 
 import {Root} from "../admin/Root.sol";
+import {GasService} from "../admin/GasService.sol";
 import {ISafe} from "../admin/interfaces/ISafe.sol";
 import {OpsGuardian} from "../admin/OpsGuardian.sol";
 import {TokenRecoverer} from "../admin/TokenRecoverer.sol";
@@ -64,7 +64,6 @@ import {RefundEscrowFactory} from "../utils/RefundEscrowFactory.sol";
 struct CoreReport {
     Gateway gateway;
     MultiAdapter multiAdapter;
-    GasService gasService;
     MessageProcessor messageProcessor;
     MessageDispatcher messageDispatcher;
     PoolEscrowFactory poolEscrowFactory;
@@ -83,6 +82,7 @@ struct CoreReport {
     TokenRecoverer tokenRecoverer;
     ProtocolGuardian protocolGuardian;
     OpsGuardian opsGuardian;
+    GasService gasService;
 }
 
 struct NonCoreReport {

--- a/test/core/hub/integration/BaseTest.sol
+++ b/test/core/hub/integration/BaseTest.sol
@@ -9,10 +9,10 @@ import {PoolId} from "../../../../src/core/types/PoolId.sol";
 import {AccountId} from "../../../../src/core/types/AccountId.sol";
 import {AssetId, newAssetId} from "../../../../src/core/types/AssetId.sol";
 import {IAdapter} from "../../../../src/core/messaging/interfaces/IAdapter.sol";
-import {MAX_MESSAGE_COST} from "../../../../src/core/messaging/interfaces/IGasService.sol";
 import {IHubRequestManager} from "../../../../src/core/hub/interfaces/IHubRequestManager.sol";
 
 import {ISafe} from "../../../../src/admin/interfaces/ISafe.sol";
+import {MAX_MESSAGE_COST} from "../../../../src/admin/interfaces/IGasService.sol";
 
 import {DeployerInput, FullDeployer, noAdaptersInput, defaultTxLimits} from "../../../../script/FullDeployer.s.sol";
 

--- a/test/core/spoke/integration/BaseTest.sol
+++ b/test/core/spoke/integration/BaseTest.sol
@@ -13,11 +13,11 @@ import {AssetId, newAssetId} from "../../../../src/core/types/AssetId.sol";
 import {VaultKind} from "../../../../src/core/spoke/interfaces/IVault.sol";
 import {IAdapter} from "../../../../src/core/messaging/interfaces/IAdapter.sol";
 import {IShareToken} from "../../../../src/core/spoke/interfaces/IShareToken.sol";
-import {MAX_MESSAGE_COST} from "../../../../src/core/messaging/interfaces/IGasService.sol";
 import {IVaultFactory} from "../../../../src/core/spoke/factories/interfaces/IVaultFactory.sol";
 import {MessageLib, VaultUpdateKind} from "../../../../src/core/messaging/libraries/MessageLib.sol";
 
 import {ISafe} from "../../../../src/admin/interfaces/ISafe.sol";
+import {MAX_MESSAGE_COST} from "../../../../src/admin/interfaces/IGasService.sol";
 
 import {AsyncVault} from "../../../../src/vaults/AsyncVault.sol";
 import {SyncDepositVault} from "../../../../src/vaults/SyncDepositVault.sol";

--- a/test/core/unit/GasService.t.sol
+++ b/test/core/unit/GasService.t.sol
@@ -3,9 +3,10 @@ pragma solidity 0.8.28;
 
 import {BytesLib} from "../../../src/misc/libraries/BytesLib.sol";
 
-import {GasService} from "../../../src/core/messaging/GasService.sol";
-import {MAX_MESSAGE_COST} from "../../../src/core/messaging/interfaces/IGasService.sol";
 import {MessageLib, MessageType, VaultUpdateKind} from "../../../src/core/messaging/libraries/MessageLib.sol";
+
+import {GasService} from "../../../src/admin/GasService.sol";
+import {MAX_MESSAGE_COST} from "../../../src/admin/interfaces/IGasService.sol";
 
 import "forge-std/Test.sol";
 

--- a/test/core/unit/OpsGuardian.t.sol
+++ b/test/core/unit/OpsGuardian.t.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.28;
 import {PoolId} from "../../../src/core/types/PoolId.sol";
 import {AssetId} from "../../../src/core/types/AssetId.sol";
 import {IAdapter} from "../../../src/core/messaging/interfaces/IAdapter.sol";
-import {IMultiAdapter} from "../../../src/core/messaging/interfaces/IMultiAdapter.sol";
 import {IGateway} from "../../../src/core/messaging/interfaces/IGateway.sol";
+import {IMultiAdapter} from "../../../src/core/messaging/interfaces/IMultiAdapter.sol";
 
 import {ISafe} from "../../../src/admin/interfaces/ISafe.sol";
 import {OpsGuardian} from "../../../src/admin/OpsGuardian.sol";

--- a/test/core/unit/OpsGuardian.t.sol
+++ b/test/core/unit/OpsGuardian.t.sol
@@ -10,6 +10,7 @@ import {IMultiAdapter} from "../../../src/core/messaging/interfaces/IMultiAdapte
 import {ISafe} from "../../../src/admin/interfaces/ISafe.sol";
 import {OpsGuardian} from "../../../src/admin/OpsGuardian.sol";
 import {ICreatePool} from "../../../src/admin/interfaces/ICreatePool.sol";
+import {IGasService} from "../../../src/admin/interfaces/IGasService.sol";
 import {IOpsGuardian} from "../../../src/admin/interfaces/IOpsGuardian.sol";
 import {IAdapterWiring} from "../../../src/admin/interfaces/IAdapterWiring.sol";
 
@@ -180,6 +181,41 @@ contract OpsGuardianTestFile is OpsGuardianTest {
         vm.prank(UNAUTHORIZED);
         vm.expectRevert(IOpsGuardian.NotTheAuthorizedSafe.selector);
         opsGuardian.file("opsSafe", makeAddr("address"));
+    }
+}
+
+contract OpsGuardianTestSetGasService is OpsGuardianTest {
+    IGasService immutable gasService = IGasService(makeAddr("gasService"));
+
+    function testSetGasServiceSuccess() public {
+        vm.mockCall(
+            address(gateway),
+            abi.encodeWithSelector(IGateway.file.selector, bytes32("messageProperties"), address(gasService)),
+            abi.encode()
+        );
+        vm.mockCall(
+            address(multiAdapter),
+            abi.encodeWithSelector(IMultiAdapter.file.selector, bytes32("messageProperties"), address(gasService)),
+            abi.encode()
+        );
+
+        vm.expectCall(
+            address(gateway),
+            abi.encodeWithSelector(IGateway.file.selector, bytes32("messageProperties"), address(gasService))
+        );
+        vm.expectCall(
+            address(multiAdapter),
+            abi.encodeWithSelector(IMultiAdapter.file.selector, bytes32("messageProperties"), address(gasService))
+        );
+
+        vm.prank(address(SAFE));
+        opsGuardian.setGasService(gasService);
+    }
+
+    function testSetGasServiceRevertWhenNotSafe() public {
+        vm.prank(UNAUTHORIZED);
+        vm.expectRevert(IOpsGuardian.NotTheAuthorizedSafe.selector);
+        opsGuardian.setGasService(gasService);
     }
 }
 

--- a/test/core/unit/OpsGuardian.t.sol
+++ b/test/core/unit/OpsGuardian.t.sol
@@ -5,6 +5,7 @@ import {PoolId} from "../../../src/core/types/PoolId.sol";
 import {AssetId} from "../../../src/core/types/AssetId.sol";
 import {IAdapter} from "../../../src/core/messaging/interfaces/IAdapter.sol";
 import {IMultiAdapter} from "../../../src/core/messaging/interfaces/IMultiAdapter.sol";
+import {IGateway} from "../../../src/core/messaging/interfaces/IGateway.sol";
 
 import {ISafe} from "../../../src/admin/interfaces/ISafe.sol";
 import {OpsGuardian} from "../../../src/admin/OpsGuardian.sol";
@@ -20,6 +21,7 @@ contract OpsGuardianTest is Test {
     ISafe immutable SAFE = ISafe(address(new IsContract()));
     ICreatePool immutable hub = ICreatePool(address(new IsContract()));
     IMultiAdapter immutable multiAdapter = IMultiAdapter(address(new IsContract()));
+    IGateway immutable gateway = IGateway(address(new IsContract()));
 
     address immutable UNAUTHORIZED = makeAddr("unauthorized");
     address immutable ADMIN = makeAddr("admin");
@@ -33,13 +35,14 @@ contract OpsGuardianTest is Test {
     OpsGuardian opsGuardian;
 
     function setUp() public virtual {
-        opsGuardian = new OpsGuardian(SAFE, hub, multiAdapter);
+        opsGuardian = new OpsGuardian(SAFE, hub, multiAdapter, gateway);
     }
 
     function testOpsGuardian() public view {
         assertEq(address(opsGuardian.opsSafe()), address(SAFE));
         assertEq(address(opsGuardian.hub()), address(hub));
         assertEq(address(opsGuardian.multiAdapter()), address(multiAdapter));
+        assertEq(address(opsGuardian.gateway()), address(gateway));
     }
 }
 
@@ -164,7 +167,7 @@ contract OpsGuardianTestFile is OpsGuardianTest {
     function testFileRevertWhenProtocolSpecificParam() public {
         vm.prank(address(SAFE));
         vm.expectRevert(IOpsGuardian.FileUnrecognizedParam.selector);
-        opsGuardian.file("gateway", makeAddr("address"));
+        opsGuardian.file("sender", makeAddr("address"));
     }
 
     function testFileRevertWhenSafeParam() public {

--- a/test/integration/Deployer.t.sol
+++ b/test/integration/Deployer.t.sol
@@ -102,6 +102,7 @@ contract FullDeploymentTestCore is FullDeploymentConfigTest {
         // permissions set correctly
         vm.assume(nonWard != address(root));
         vm.assume(nonWard != address(protocolGuardian));
+        vm.assume(nonWard != address(opsGuardian));
         vm.assume(nonWard != address(multiAdapter));
         vm.assume(nonWard != address(messageDispatcher));
         vm.assume(nonWard != address(messageProcessor));
@@ -109,6 +110,7 @@ contract FullDeploymentTestCore is FullDeploymentConfigTest {
 
         assertEq(gateway.wards(address(root)), 1);
         assertEq(gateway.wards(address(protocolGuardian)), 1);
+        assertEq(gateway.wards(address(opsGuardian)), 1);
         assertEq(gateway.wards(address(multiAdapter)), 1);
         assertEq(gateway.wards(address(messageDispatcher)), 1);
         assertEq(gateway.wards(address(messageProcessor)), 1);
@@ -438,6 +440,7 @@ contract FullDeploymentTestNonCore is FullDeploymentConfigTest {
         assertEq(address(opsGuardian.opsSafe()), address(OPS_SAFE));
         assertEq(address(opsGuardian.multiAdapter()), address(multiAdapter));
         assertEq(address(opsGuardian.hub()), address(hub));
+        assertEq(address(opsGuardian.gateway()), address(gateway));
     }
 
     function testSubsidyManager(address nonWard) public view {

--- a/test/integration/EndToEnd.t.sol
+++ b/test/integration/EndToEnd.t.sol
@@ -20,7 +20,6 @@ import {Gateway} from "../../src/core/messaging/Gateway.sol";
 import {HubHandler} from "../../src/core/hub/HubHandler.sol";
 import {HubRegistry} from "../../src/core/hub/HubRegistry.sol";
 import {IVault} from "../../src/core/spoke/interfaces/IVault.sol";
-import {GasService} from "../../src/core/messaging/GasService.sol";
 import {PricingLib} from "../../src/core/libraries/PricingLib.sol";
 import {ShareClassId} from "../../src/core/types/ShareClassId.sol";
 import {AssetId, newAssetId} from "../../src/core/types/AssetId.sol";
@@ -29,7 +28,6 @@ import {IAdapter} from "../../src/core/messaging/interfaces/IAdapter.sol";
 import {IGateway} from "../../src/core/messaging/interfaces/IGateway.sol";
 import {ShareClassManager} from "../../src/core/hub/ShareClassManager.sol";
 import {BalanceSheet, WithdrawMode} from "../../src/core/spoke/BalanceSheet.sol";
-import {MAX_MESSAGE_COST} from "../../src/core/messaging/interfaces/IGasService.sol";
 import {IHubRequestManager} from "../../src/core/hub/interfaces/IHubRequestManager.sol";
 import {IMessageHandler} from "../../src/core/messaging/interfaces/IMessageHandler.sol";
 import {MultiAdapter, MAX_ADAPTER_COUNT} from "../../src/core/messaging/MultiAdapter.sol";
@@ -38,9 +36,11 @@ import {IUntrustedContractUpdate} from "../../src/core/utils/interfaces/IContrac
 import {MessageLib, MessageType, VaultUpdateKind} from "../../src/core/messaging/libraries/MessageLib.sol";
 
 import {Root} from "../../src/admin/Root.sol";
+import {GasService} from "../../src/admin/GasService.sol";
 import {ISafe} from "../../src/admin/interfaces/ISafe.sol";
 import {OpsGuardian} from "../../src/admin/OpsGuardian.sol";
 import {ProtocolGuardian} from "../../src/admin/ProtocolGuardian.sol";
+import {MAX_MESSAGE_COST} from "../../src/admin/interfaces/IGasService.sol";
 
 import {MockSnapshotHook} from "../hooks/mocks/MockSnapshotHook.sol";
 

--- a/test/integration/Integration.t.sol
+++ b/test/integration/Integration.t.sol
@@ -10,9 +10,9 @@ import {MockValuation} from "../core/mocks/MockValuation.sol";
 import {PoolId} from "../../src/core/types/PoolId.sol";
 import {AssetId} from "../../src/core/types/AssetId.sol";
 import {ShareClassId} from "../../src/core/types/ShareClassId.sol";
-import {MAX_MESSAGE_COST as GAS} from "../../src/core/messaging/interfaces/IGasService.sol";
 
 import {ISafe} from "../../src/admin/interfaces/ISafe.sol";
+import {MAX_MESSAGE_COST as GAS} from "../../src/admin/interfaces/IGasService.sol";
 
 import {ISyncManager} from "../../src/vaults/interfaces/IVaultManagers.sol";
 

--- a/test/integration/recon-end-to-end/targets/AdminTargets.sol
+++ b/test/integration/recon-end-to-end/targets/AdminTargets.sol
@@ -15,7 +15,8 @@ import {ShareClassId} from "../../../../src/core/types/ShareClassId.sol";
 import {IValuation} from "../../../../src/core/hub/interfaces/IValuation.sol";
 import {JournalEntry} from "../../../../src/core/hub/interfaces/IAccounting.sol";
 import {IShareToken} from "../../../../src/core/spoke/interfaces/IShareToken.sol";
-import {MAX_MESSAGE_COST} from "../../../../src/core/messaging/interfaces/IGasService.sol";
+
+import {MAX_MESSAGE_COST} from "../../../../src/admin/interfaces/IGasService.sol";
 
 import {IBaseVault} from "../../../../src/vaults/interfaces/IBaseVault.sol";
 

--- a/test/integration/recon-end-to-end/targets/DoomsdayTargets.sol
+++ b/test/integration/recon-end-to-end/targets/DoomsdayTargets.sol
@@ -10,7 +10,8 @@ import {AssetId} from "../../../../src/core/types/AssetId.sol";
 import {AccountId} from "../../../../src/core/types/AccountId.sol";
 import {ShareClassId} from "../../../../src/core/types/ShareClassId.sol";
 import {IShareToken} from "../../../../src/core/spoke/interfaces/IShareToken.sol";
-import {MAX_MESSAGE_COST} from "../../../../src/core/messaging/interfaces/IGasService.sol";
+
+import {MAX_MESSAGE_COST} from "../../../../src/admin/interfaces/IGasService.sol";
 
 import {BaseVault} from "../../../../src/vaults/BaseVaults.sol";
 import {IBaseVault} from "../../../../src/vaults/interfaces/IBaseVault.sol";

--- a/test/integration/recon-end-to-end/targets/HubTargets.sol
+++ b/test/integration/recon-end-to-end/targets/HubTargets.sol
@@ -10,8 +10,9 @@ import {AssetId} from "../../../../src/core/types/AssetId.sol";
 import {PoolEscrow} from "../../../../src/core/spoke/PoolEscrow.sol";
 import {ShareClassId} from "../../../../src/core/types/ShareClassId.sol";
 import {IPoolEscrow} from "../../../../src/core/spoke/interfaces/IPoolEscrow.sol";
-import {MAX_MESSAGE_COST} from "../../../../src/core/messaging/interfaces/IGasService.sol";
 import {IHubRequestManager} from "../../../../src/core/hub/interfaces/IHubRequestManager.sol";
+
+import {MAX_MESSAGE_COST} from "../../../../src/admin/interfaces/IGasService.sol";
 
 import {IBaseVault} from "../../../../src/vaults/interfaces/IBaseVault.sol";
 

--- a/test/integration/spell/utils/validation/TestContracts.sol
+++ b/test/integration/spell/utils/validation/TestContracts.sol
@@ -9,7 +9,6 @@ import {Gateway} from "../../../../../src/core/messaging/Gateway.sol";
 import {HubHandler} from "../../../../../src/core/hub/HubHandler.sol";
 import {HubRegistry} from "../../../../../src/core/hub/HubRegistry.sol";
 import {BalanceSheet} from "../../../../../src/core/spoke/BalanceSheet.sol";
-import {GasService} from "../../../../../src/core/messaging/GasService.sol";
 import {VaultRegistry} from "../../../../../src/core/spoke/VaultRegistry.sol";
 import {MultiAdapter} from "../../../../../src/core/messaging/MultiAdapter.sol";
 import {ContractUpdater} from "../../../../../src/core/utils/ContractUpdater.sol";
@@ -20,6 +19,7 @@ import {MessageDispatcher} from "../../../../../src/core/messaging/MessageDispat
 import {PoolEscrowFactory} from "../../../../../src/core/spoke/factories/PoolEscrowFactory.sol";
 
 import {Root} from "../../../../../src/admin/Root.sol";
+import {GasService} from "../../../../../src/admin/GasService.sol";
 import {OpsGuardian} from "../../../../../src/admin/OpsGuardian.sol";
 import {TokenRecoverer} from "../../../../../src/admin/TokenRecoverer.sol";
 import {ProtocolGuardian} from "../../../../../src/admin/ProtocolGuardian.sol";
@@ -78,7 +78,6 @@ function testContractsFromConfig(EnvConfig memory config) pure returns (TestCont
     CoreReport memory core = CoreReport(
         Gateway(c.gateway),
         MultiAdapter(c.multiAdapter),
-        GasService(c.gasService),
         MessageProcessor(c.messageProcessor),
         MessageDispatcher(c.messageDispatcher),
         PoolEscrowFactory(c.poolEscrowFactory),
@@ -96,7 +95,8 @@ function testContractsFromConfig(EnvConfig memory config) pure returns (TestCont
         Root(c.root),
         TokenRecoverer(c.tokenRecoverer),
         ProtocolGuardian(c.protocolGuardian),
-        OpsGuardian(c.opsGuardian)
+        OpsGuardian(c.opsGuardian),
+        GasService(c.gasService)
     );
 
     MainContracts memory main = MainContracts(

--- a/test/integration/utils/IntegrationConstants.sol
+++ b/test/integration/utils/IntegrationConstants.sol
@@ -4,7 +4,8 @@ pragma solidity ^0.8.28;
 import {D18, d18} from "../../../src/misc/types/D18.sol";
 
 import {AccountId} from "../../../src/core/types/AccountId.sol";
-import {MAX_MESSAGE_COST} from "../../../src/core/messaging/interfaces/IGasService.sol";
+
+import {MAX_MESSAGE_COST} from "../../../src/admin/interfaces/IGasService.sol";
 
 /// @title IntegrationConstants
 /// @notice Centralized constants for integration tests


### PR DESCRIPTION
### Product requirements

* We want a way to easily & fast modify gasService values in all chains to react to chain changes.
  * Thread: https://kflabs.slack.com/archives/C07PG2EUR9C/p1768227747451099
  * Task: https://www.notion.so/Feat-Update-GasService-via-Guardian-2e62eac24e17808eb954f8fc2353bfca?source=copy_link

### Design notes

#### Solution A (failed).
I initially allow direct modification to GasService values using OpsAdmin making GasService mutable. But this comes with some issues:
* Extra SLOAD(s).
* We need to do a lot of calls one per (chain,message) tuple.
  * i.e: if some message change its value I need to update it in each chain for all chains O(n*n).
  * I could use "default" values but I would need another SLOAD.
* Some messages with internal diferentiations are not easy to represent for dynamic updates
  * i.e: UpdateVault comes in some flavors: DeployAndLink, Link, Unlink, each of them with different values but same MessageType to index.

#### Solution B
- Hardcode every change in the GasService bytecode in an immutable way (as it is).
- Call `script/deploy-gas-service.sh` to push a safe OpsAdmin propostion to all changes to acept this new GasService.
