### PR TITLE
ci(registry): PR validation, preview comments, and tightened triggers

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -14,6 +14,16 @@ on:
       - "env/**"
       - "script/registry/**"
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Which registry to regenerate (delta mode only)'
+        required: false
+        default: 'both'
+        type: choice
+        options:
+          - both
+          - mainnet
+          - testnet
 
 env:
   FOUNDRY_PROFILE: ci
@@ -55,12 +65,22 @@ jobs:
       - name: Detect changed environments
         id: changed_environments
         run: |
-          changed=$(node .github/ci-scripts/detect-changed-environments.js)
-          echo "Changed environments: $changed"
-          mainnet_changed=$(echo $changed | jq -r '.mainnet')
-          testnet_changed=$(echo $changed | jq -r '.testnet')
-          echo "mainnet=$mainnet_changed" >> $GITHUB_OUTPUT
-          echo "testnet=$testnet_changed" >> $GITHUB_OUTPUT
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            env_input="${{ inputs.environment }}"
+            case "$env_input" in
+              mainnet) echo "mainnet=true" >> $GITHUB_OUTPUT; echo "testnet=false" >> $GITHUB_OUTPUT ;;
+              testnet) echo "mainnet=false" >> $GITHUB_OUTPUT; echo "testnet=true" >> $GITHUB_OUTPUT ;;
+              *)       echo "mainnet=true" >> $GITHUB_OUTPUT; echo "testnet=true" >> $GITHUB_OUTPUT ;;
+            esac
+            echo "workflow_dispatch: environment=$env_input"
+          else
+            changed=$(node .github/ci-scripts/detect-changed-environments.js)
+            echo "Changed environments: $changed"
+            mainnet_changed=$(echo $changed | jq -r '.mainnet')
+            testnet_changed=$(echo $changed | jq -r '.testnet')
+            echo "mainnet=$mainnet_changed" >> $GITHUB_OUTPUT
+            echo "testnet=$testnet_changed" >> $GITHUB_OUTPUT
+          fi
 
       - name: Determine deployment commits
         id: deployment_commits
@@ -232,8 +252,11 @@ jobs:
     name: Pin registry files to IPFS
     runs-on: ubuntu-latest
     if: |
-      github.event_name == 'push' && github.ref == 'refs/heads/main' && 
-      (needs.generate.outputs.mainnet == 'true' || needs.generate.outputs.testnet == 'true')
+      (needs.generate.outputs.mainnet == 'true' || needs.generate.outputs.testnet == 'true') &&
+      (
+        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+        github.event_name == 'workflow_dispatch'
+      )
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -4,11 +4,15 @@ on:
   pull_request:
     paths:
       - ".github/workflows/registry.yml"
+      - "env/**"
+      - "script/registry/**"
   push:
     branches:
       - main
-  release:
-    types: [published]
+    paths:
+      - ".github/workflows/registry.yml"
+      - "env/**"
+      - "script/registry/**"
   workflow_dispatch:
 
 env:
@@ -24,6 +28,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -43,6 +48,9 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y jq
           cd script/registry && npm install
+
+      - name: Validate env file schemas
+        run: node script/registry/validate-env-schema.js
 
       - name: Detect changed environments
         id: changed_environments
@@ -121,6 +129,95 @@ jobs:
           cp -R out-testnet out
           node script/registry/abi-registry.js testnet
 
+      - name: Validate mainnet registry
+        if: steps.changed_environments.outputs.mainnet == 'true'
+        run: node script/registry/validate-registry.js registry/registry-mainnet.json
+
+      - name: Validate testnet registry
+        if: steps.changed_environments.outputs.testnet == 'true'
+        run: node script/registry/validate-registry.js registry/registry-testnet.json
+
+      - name: Post PR preview comment
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          body="## Registry Preview\n\n"
+          has_content=false
+
+          for env_name in mainnet testnet; do
+            registry_file="registry/registry-${env_name}.json"
+            validation_file="registry/registry-${env_name}.validation.json"
+
+            if [ ! -f "$registry_file" ]; then
+              continue
+            fi
+            has_content=true
+
+            # Extract summary from registry
+            version=$(jq -r '.version // "unknown"' "$registry_file")
+            chain_count=$(jq '.chains | length' "$registry_file")
+            contract_count=$(jq '[.chains[].contracts | length] | add // 0' "$registry_file")
+            abi_count=$(jq '.abis | length' "$registry_file")
+
+            body="${body}### ${env_name}\n\n"
+            body="${body}| Metric | Value |\n|--------|-------|\n"
+            body="${body}| Version | \`${version}\` |\n"
+            body="${body}| Chains with changes | ${chain_count} |\n"
+            body="${body}| Contracts in delta | ${contract_count} |\n"
+            body="${body}| ABIs included | ${abi_count} |\n\n"
+
+            # Include validation findings if sidecar exists
+            if [ -f "$validation_file" ]; then
+              error_count=$(jq '.errors | length' "$validation_file")
+              warning_count=$(jq '.warnings | length' "$validation_file")
+
+              if [ "$error_count" -gt 0 ]; then
+                body="${body}<details><summary>❌ ${error_count} error(s) — will break the indexer</summary>\n\n"
+                body="${body}| Path | Message |\n|------|---------|"
+                while IFS=$'\t' read -r path msg; do
+                  body="${body}\n| \`${path}\` | ${msg} |"
+                done < <(jq -r '.errors[] | [.path, .message] | @tsv' "$validation_file")
+                body="${body}\n\n</details>\n\n"
+              fi
+
+              if [ "$warning_count" -gt 0 ]; then
+                body="${body}<details><summary>⚠️ ${warning_count} warning(s)</summary>\n\n"
+                body="${body}| Path | Message |\n|------|---------|"
+                while IFS=$'\t' read -r path msg; do
+                  body="${body}\n| \`${path}\` | ${msg} |"
+                done < <(jq -r '.warnings[] | [.path, .message] | @tsv' "$validation_file")
+                body="${body}\n\n</details>\n\n"
+              fi
+
+              if [ "$error_count" -eq 0 ] && [ "$warning_count" -eq 0 ]; then
+                body="${body}✅ Passes all indexer requirements\n\n"
+              elif [ "$error_count" -eq 0 ]; then
+                body="${body}✅ Passes all indexer hard requirements\n\n"
+              fi
+            fi
+          done
+
+          if [ "$has_content" = false ]; then
+            body="${body}No registry files were generated (no env changes detected for mainnet or testnet).\n"
+          fi
+
+          body="${body}---\n*Preview only — IPFS upload happens on merge to main.*"
+
+          # Post or update the comment
+          pr_number=${{ github.event.pull_request.number }}
+          existing_comment=$(gh api "repos/${{ github.repository }}/issues/${pr_number}/comments" \
+            --jq '.[] | select(.body | startswith("## Registry Preview")) | .id' | head -1)
+
+          if [ -n "$existing_comment" ]; then
+            printf '%b' "$body" | gh api "repos/${{ github.repository }}/issues/comments/${existing_comment}" \
+              -X PATCH --field "body=@-"
+          else
+            printf '%b' "$body" | gh pr comment "${pr_number}" --body-file -
+          fi
+
       - name: Upload registry artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -135,9 +232,8 @@ jobs:
     name: Pin registry files to IPFS
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'release') ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main' && 
-       (needs.generate.outputs.mainnet == 'true' || needs.generate.outputs.testnet == 'true'))
+      github.event_name == 'push' && github.ref == 'refs/heads/main' && 
+      (needs.generate.outputs.mainnet == 'true' || needs.generate.outputs.testnet == 'true')
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -2,6 +2,8 @@ name: "Registry"
 
 on:
   pull_request:
+    branches:
+      - main
     paths:
       - ".github/workflows/registry.yml"
       - "env/**"

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -14,16 +14,6 @@ on:
       - "env/**"
       - "script/registry/**"
   workflow_dispatch:
-    inputs:
-      environment:
-        description: 'Which registry to regenerate (delta mode only)'
-        required: false
-        default: 'both'
-        type: choice
-        options:
-          - both
-          - mainnet
-          - testnet
 
 env:
   FOUNDRY_PROFILE: ci
@@ -65,22 +55,12 @@ jobs:
       - name: Detect changed environments
         id: changed_environments
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            env_input="${{ inputs.environment }}"
-            case "$env_input" in
-              mainnet) echo "mainnet=true" >> $GITHUB_OUTPUT; echo "testnet=false" >> $GITHUB_OUTPUT ;;
-              testnet) echo "mainnet=false" >> $GITHUB_OUTPUT; echo "testnet=true" >> $GITHUB_OUTPUT ;;
-              *)       echo "mainnet=true" >> $GITHUB_OUTPUT; echo "testnet=true" >> $GITHUB_OUTPUT ;;
-            esac
-            echo "workflow_dispatch: environment=$env_input"
-          else
-            changed=$(node .github/ci-scripts/detect-changed-environments.js)
-            echo "Changed environments: $changed"
-            mainnet_changed=$(echo $changed | jq -r '.mainnet')
-            testnet_changed=$(echo $changed | jq -r '.testnet')
-            echo "mainnet=$mainnet_changed" >> $GITHUB_OUTPUT
-            echo "testnet=$testnet_changed" >> $GITHUB_OUTPUT
-          fi
+          changed=$(node .github/ci-scripts/detect-changed-environments.js)
+          echo "Changed environments: $changed"
+          mainnet_changed=$(echo $changed | jq -r '.mainnet')
+          testnet_changed=$(echo $changed | jq -r '.testnet')
+          echo "mainnet=$mainnet_changed" >> $GITHUB_OUTPUT
+          echo "testnet=$testnet_changed" >> $GITHUB_OUTPUT
 
       - name: Determine deployment commits
         id: deployment_commits
@@ -252,11 +232,8 @@ jobs:
     name: Pin registry files to IPFS
     runs-on: ubuntu-latest
     if: |
-      (needs.generate.outputs.mainnet == 'true' || needs.generate.outputs.testnet == 'true') &&
-      (
-        (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-        github.event_name == 'workflow_dispatch'
-      )
+      github.event_name == 'push' && github.ref == 'refs/heads/main' &&
+      (needs.generate.outputs.mainnet == 'true' || needs.generate.outputs.testnet == 'true')
     permissions:
       contents: read
       issues: write

--- a/env/arbitrum-sepolia.json
+++ b/env/arbitrum-sepolia.json
@@ -295,12 +295,6 @@
       "txHash": "0x8ddf1a35eb4387760b1fc90bf766a2d658fc35877506dae649cb80190bd16efe",
       "version": "v3.1"
     },
-    "tokenBridge": {
-      "address": "0xc59317b5F543ac93ACD31900b45a62a6E5B30038",
-      "blockNumber": 225081173,
-      "txHash": "0xeade0c022250b6d69b2ca29a5d217f072bc60bba6d9104ffd77eeaae50a31fc5",
-      "version": "v3.1"
-    },
     "subsidyManager": {
       "address": "0xE5419F74f8875C401C3a2f4C68846d9d410e1677",
       "blockNumber": 237622413,

--- a/env/arbitrum-sepolia.json
+++ b/env/arbitrum-sepolia.json
@@ -319,7 +319,7 @@
       "gitCommit": "24032569",
       "timestamp": "2026-01-28T15:42:39Z",
       "suffix": "rev2",
-      "startBlock": 10142334
+      "startBlock": 237622348
     }
   }
 }

--- a/env/arbitrum.json
+++ b/env/arbitrum.json
@@ -319,7 +319,7 @@
       "gitCommit": "c89c55ff6",
       "timestamp": "2026-01-27T12:10:12Z",
       "suffix": "",
-      "startBlock": 24326077
+      "startBlock": 357982308
     }
   }
 }

--- a/env/base-sepolia.json
+++ b/env/base-sepolia.json
@@ -295,12 +295,6 @@
       "txHash": "0xf58beba2311a9a27c159d1d86f4a4fde2cc39f841043c3d56f0e660b4997673f",
       "version": "v3.1"
     },
-    "tokenBridge": {
-      "address": "0xc59317b5F543ac93ACD31900b45a62a6E5B30038",
-      "blockNumber": 35052204,
-      "txHash": "0x7533f89a3799a19d42b31ac42e9fa87b819518b096f9350400ddeaa2ed13d661",
-      "version": "v3.1"
-    },
     "subsidyManager": {
       "address": "0xE5419F74f8875C401C3a2f4C68846d9d410e1677",
       "blockNumber": 36922370,

--- a/env/sepolia.json
+++ b/env/sepolia.json
@@ -299,12 +299,6 @@
       "txHash": "0x414efa3c46ff68ab5d580a636f02f5e07a3810e9db5a5c98e323f9e6391e679e",
       "version": "v3.1"
     },
-    "tokenBridge": {
-      "address": "0xc59317b5F543ac93ACD31900b45a62a6E5B30038",
-      "blockNumber": 9851723,
-      "txHash": "0x95f3a25f0143cbae6938bd437c3ae3715a5cf6a00bbd5e0c01cbb0171252dc6e",
-      "version": "v3.1"
-    },
     "subsidyManager": {
       "address": "0xE5419F74f8875C401C3a2f4C68846d9d410e1677",
       "blockNumber": 10142075,

--- a/script/registry/README.md
+++ b/script/registry/README.md
@@ -236,14 +236,14 @@ These fields are required by the Ponder/indexer pipeline. Missing any of them wi
 | `chains.<chainId>.contracts.<name>.blockNumber` | Must be a number. When the contract was deployed; used for event listening start. |
 | `abis.<ContractName>` | Must exist for every contract in `chains`. Without ABIs the indexer cannot decode events. |
 
-### Soft fields (warnings only)
+### Other fields (not validated)
 
-These are present in the registry but not strictly required by the indexer. Missing values produce warnings in the PR comment but do not block merging.
+These are present in the registry but not used by the indexer. They are not checked by the validator.
 
 | Field | Notes |
 |-------|-------|
-| `contracts[name].txHash` | Useful for traceability |
-| `deployment.deployedAt` | Metadata only |
-| `deploymentInfo.gitCommit` | Metadata only |
+| `contracts[name].txHash` | Traceability metadata |
+| `deployment.deployedAt` | Deployment timestamp |
+| `deploymentInfo.gitCommit` | Source commit metadata |
 | `previousRegistry.version` | Human-readable; indexer follows `ipfsHash` |
 | `adapters.$adapterName` | `null` when that adapter is not configured for the network |

--- a/script/registry/README.md
+++ b/script/registry/README.md
@@ -20,7 +20,7 @@ Registries use a **delta format**: each version only contains contracts that cha
 | Script | Purpose |
 |--------|---------|
 | `abi-registry.js` | Builds `registry-*.json` from env files, explorer APIs, and Forge build artifacts. Supports delta (default) or full snapshot. |
-| `validate-env-schema.js` | Validates all `env/*.json` files against the expected schema. Fast-fail gate before generation. |
+| `validate-env-schema.js` | Validates all `env/*.json` files against the expected schema, including `deploymentInfo.*.startBlock` vs contract `blockNumber` gap (chain-level indexer listeners). Fast-fail gate before generation. |
 | `validate-registry.js` | Validates a generated registry JSON against indexer hard requirements. Produces a sidecar `.validation.json` report. |
 | `pin-to-ipfs.js` | Pins generated registries to Pinata, outputs CID metadata. |
 | `validate-api-keys.js` | Read-only validation of Pinata and Cloudflare credentials. |
@@ -60,7 +60,7 @@ flowchart TD
 
 **Validation layers:**
 
-1. **`validate-env-schema.js`** (pre-generation) — catches broken JSON, missing `network.chainId`, invalid addresses, structural renames. Fails the workflow immediately.
+1. **`validate-env-schema.js`** (pre-generation) — catches broken JSON, missing `network.chainId`, invalid addresses, structural renames, and **`deploymentInfo.*.startBlock` vs contract `blockNumber` gap**. Fails the workflow immediately.
 2. **`validate-registry.js`** (post-generation) — checks the generated registry against indexer hard requirements. Posts errors/warnings in the PR comment.
 
 **Other workflows:**
@@ -231,7 +231,7 @@ These fields are required by the Ponder/indexer pipeline. Missing any of them wi
 |-------|------|
 | `version` | Non-empty string. Identifies the registry in the ordered version chain. |
 | `previousRegistry.ipfsHash` | Non-null for any registry after the first. Forms the linked list the indexer walks. |
-| `chains.<chainId>.deployment.startBlock` | Must be a number. Tells the indexer which block range this registry covers. |
+| `chains.<chainId>.deployment.startBlock` | Must be a number in the generated registry. Source: `env/*.json` → `deploymentInfo.*.startBlock`. **Gap rule** (not far before min active contract `blockNumber`; indexers use this for chain-level block listeners, e.g. hourly snapshots): enforced in **`validate-env-schema.js`** before generation. Update when merging `env/latest/<chainId>-latest.json` after deploy (`script/utils/JsonRegistry.s.sol` / `script/deploy/lib/verifier.py`). |
 | `chains.<chainId>.contracts.<name>.address` | Non-empty string. The contract address to track. |
 | `chains.<chainId>.contracts.<name>.blockNumber` | Must be a number. When the contract was deployed; used for event listening start. |
 | `abis.<ContractName>` | Must exist for every contract in `chains`. Without ABIs the indexer cannot decode events. |

--- a/script/registry/README.md
+++ b/script/registry/README.md
@@ -19,15 +19,51 @@ Registries use a **delta format**: each version only contains contracts that cha
 
 | Script | Purpose |
 |--------|---------|
-| `abi-registry.js` | Builds `registry-*.json` from env files, explorer APIs, and Forge broadcast artifacts. Supports delta (default) or full snapshot. |
-| `pin-to-ipfs.js` | Pins generated registries to Pinata, writes nightly/mainnet/testnet summaries, outputs CID metadata. |
+| `abi-registry.js` | Builds `registry-*.json` from env files, explorer APIs, and Forge build artifacts. Supports delta (default) or full snapshot. |
+| `validate-env-schema.js` | Validates all `env/*.json` files against the expected schema. Fast-fail gate before generation. |
+| `validate-registry.js` | Validates a generated registry JSON against indexer hard requirements. Produces a sidecar `.validation.json` report. |
+| `pin-to-ipfs.js` | Pins generated registries to Pinata, outputs CID metadata. |
+| `validate-api-keys.js` | Read-only validation of Pinata and Cloudflare credentials. |
 | `.github/ci-scripts/detect-changed-environments.js` | Detects mainnet/testnet env changes to skip unnecessary CI builds. |
 | `.github/ci-scripts/detect-deployment-commit.js` | Returns the git commit that produced the latest env files so ABIs are built from that revision. |
 | `.github/ci-scripts/compute-env-tags.js` | Creates tags (`deploy-${version}-${timestamp}`) when env files change so deployment commits stay reachable after squashing. |
 
-### Pipelines
+### CI Pipeline
 
-- **`registry.yml`** – On env/registry changes: detects changed envs, rebuilds ABIs at deployment commits, generates `registry-mainnet.json` / `registry-testnet.json`, publishes artifacts, pins to IPFS, writes step summaries with CIDs and opens issues when pointers need updates.
+The `registry.yml` workflow only triggers when `env/**`, `script/registry/**`, or the workflow file itself changes. Env file changes are the canonical signal that a registry update is needed.
+
+```
+pull_request  → validate env schemas → generate registry → validate output → post PR comment
+push to main  → same pipeline → pin to IPFS → update Cloudflare DNS
+workflow_dispatch → manual escape hatch (same pipeline)
+```
+
+**Pipeline flow:**
+
+```mermaid
+flowchart TD
+    subgraph pr [Pull Request]
+        A[env file changed] --> B[Validate env schemas]
+        B -->|fail| X1[PR blocked]
+        B -->|pass| C[Detect changed environments]
+        C --> D[Generate registry]
+        D --> E[Validate registry output]
+        E -->|errors| X2[PR blocked]
+        E -->|pass/warnings| F[Post PR comment with preview + findings]
+    end
+    subgraph push [Push to main]
+        G[env file merged] --> H[Same pipeline]
+        H --> I[Pin to IPFS]
+        I --> J[Update Cloudflare]
+    end
+```
+
+**Validation layers:**
+
+1. **`validate-env-schema.js`** (pre-generation) — catches broken JSON, missing `network.chainId`, invalid addresses, structural renames. Fails the workflow immediately.
+2. **`validate-registry.js`** (post-generation) — checks the generated registry against indexer hard requirements. Posts errors/warnings in the PR comment.
+
+**Other workflows:**
 - **`tag-env-updates.yml`** – On any push that touches `env/**/*.json`: runs `compute-env-tags.js` and pushes annotated tags.
 
 ---
@@ -74,6 +110,20 @@ node script/registry/abi-registry.js testnet
 ```
 
 **Env / flags:** `DEPLOYMENT_COMMIT`, `ETHERSCAN_API_KEY` (required), `REGISTRY_MODE=full`, `REGISTRY_SOURCE_URL`; `--full`, `--source-url=<url>`. For pinning: `PINATA_JWT` (1Password, limited access).
+
+### Validating env files and registries locally
+
+```bash
+# Validate all env/*.json files against expected schema
+node script/registry/validate-env-schema.js
+
+# Validate a generated registry against indexer hard requirements
+node script/registry/validate-registry.js registry/registry-mainnet.json
+node script/registry/validate-registry.js registry/registry-testnet.json
+
+# Skip live registry fetch (offline mode)
+SKIP_LIVE_REGISTRY_CHECK=1 node script/registry/validate-registry.js registry/registry-mainnet.json
+```
 
 ### Testing API keys (no changes made)
 
@@ -173,9 +223,27 @@ interface ChainConfig {
 }
 ```
 
-### Nullable fields
+### Indexer hard requirements
 
-- **`contracts[name].blockNumber` / `txHash`** – Filled from broadcast artifacts or explorer APIs. Can be `null` when contract is unverified, chain isn’t on the free Etherscan API (e.g. BNB, Base), or legacy env has no `txHash`.
-- **`deployment.deployedAt`** – `null` if env has no `deploymentInfo.timestamp`.
-- **`deployment.startBlock`** – `null` if env has no `deploymentInfo.startBlock` (expected for future deployments).
-- **`adapters.$adapterName`** – `null` when that adapter isn’t configured for the network.
+These fields are required by the Ponder/indexer pipeline. Missing any of them will fail the `validate-registry.js` check and block the PR.
+
+| Field | Rule |
+|-------|------|
+| `version` | Non-empty string. Identifies the registry in the ordered version chain. |
+| `previousRegistry.ipfsHash` | Non-null for any registry after the first. Forms the linked list the indexer walks. |
+| `chains.<chainId>.deployment.startBlock` | Must be a number. Tells the indexer which block range this registry covers. |
+| `chains.<chainId>.contracts.<name>.address` | Non-empty string. The contract address to track. |
+| `chains.<chainId>.contracts.<name>.blockNumber` | Must be a number. When the contract was deployed; used for event listening start. |
+| `abis.<ContractName>` | Must exist for every contract in `chains`. Without ABIs the indexer cannot decode events. |
+
+### Soft fields (warnings only)
+
+These are present in the registry but not strictly required by the indexer. Missing values produce warnings in the PR comment but do not block merging.
+
+| Field | Notes |
+|-------|-------|
+| `contracts[name].txHash` | Useful for traceability |
+| `deployment.deployedAt` | Metadata only |
+| `deploymentInfo.gitCommit` | Metadata only |
+| `previousRegistry.version` | Human-readable; indexer follows `ipfsHash` |
+| `adapters.$adapterName` | `null` when that adapter is not configured for the network |

--- a/script/registry/abi-registry.js
+++ b/script/registry/abi-registry.js
@@ -48,8 +48,8 @@
  *   }
  *
  * Note: The previousRegistry.ipfsHash is set from SOURCE_IPFS if provided.
- * Otherwise, it's set to null and filled in by pin-to-ipfs.js which queries Pinata for the CID
- * of the previous registry.
+ * Otherwise, it's resolved via DNS dnslink lookup on the live registry hostname
+ * (e.g. _dnslink.registry.centrifuge.io → dnslink=/ipfs/<CID>).
  */
 
 import {
@@ -60,6 +60,7 @@ import {
     existsSync,
 } from "fs";
 import { dirname, join } from "path";
+import { resolveTxt } from "dns/promises";
 
 // Parse CLI arguments
 const args = process.argv.slice(2);
@@ -126,6 +127,50 @@ const REGISTRY_URLS = {
  * IPFS gateway URL (Pinata is used since that's where registries are pinned)
  */
 const IPFS_GATEWAY = "https://gateway.pinata.cloud";
+
+/**
+ * DNS hostnames for dnslink CID resolution.
+ * Cloudflare Web3 hostnames publish a TXT record at _dnslink.<hostname>
+ * with value "dnslink=/ipfs/<CID>".
+ */
+const DNSLINK_HOSTNAMES = {
+    mainnet: "registry.centrifuge.io",
+    testnet: "registry.testnet.centrifuge.io",
+};
+
+/**
+ * Resolves the IPFS CID of the currently live registry via DNS TXT lookup.
+ * This is the source of truth — the dnslink record points to whatever CID
+ * Cloudflare is actually serving.
+ *
+ * @param {string} environment - "mainnet" or "testnet"
+ * @returns {Promise<string|null>} IPFS CID or null if not resolvable
+ */
+async function resolveLiveCid(environment) {
+    const hostname = DNSLINK_HOSTNAMES[environment];
+    if (!hostname) return null;
+
+    const dnslinkHost = `_dnslink.${hostname}`;
+    try {
+        console.log(`  Resolving live CID via DNS: ${dnslinkHost}`);
+        const records = await resolveTxt(dnslinkHost);
+        // records is an array of arrays of strings, e.g. [["dnslink=/ipfs/Qm..."]]
+        for (const record of records) {
+            const txt = record.join("");
+            const match = txt.match(/^dnslink=\/ipfs\/(.+)$/);
+            if (match) {
+                const cid = match[1];
+                console.log(`  ✓ Resolved live CID: ${cid}`);
+                return cid;
+            }
+        }
+        console.warn(`  ⚠ No dnslink record found at ${dnslinkHost}`);
+        return null;
+    } catch (error) {
+        console.warn(`  ⚠ DNS lookup failed for ${dnslinkHost}: ${error.message}`);
+        return null;
+    }
+}
 
 /**
  * Validates that a string is a valid IPFS hash (CID).
@@ -578,6 +623,11 @@ async function main() {
         } else if (!sourceIpfs && !currentRegistry) {
             console.warn(`  ⚠ Could not fetch current registry for comparison`);
         }
+
+        // Resolve the live CID via DNS if not explicitly provided
+        if (!previousIpfsHash && previousVersion) {
+            previousIpfsHash = await resolveLiveCid(selector);
+        }
     } else {
         console.log(`  Skipping registry fetch (full mode - no comparison)`);
         // In full mode, set previousRegistry to null to mark this as the base registry
@@ -728,12 +778,12 @@ async function main() {
         deploymentInfo: {
             gitCommit: resolveDeploymentCommit(deploymentCommitOverride, deploymentCommits),
         },
-        // previousRegistry pointer - ipfsHash filled from SOURCE_IPFS if provided,
-        // otherwise filled by pin-to-ipfs.js via Pinata query
-        // In full mode, set to null to mark this as the base registry
+        // previousRegistry pointer - ipfsHash resolved from SOURCE_IPFS env var,
+        // or via DNS dnslink lookup on the live registry hostname.
+        // In full mode, set to null to mark this as the base registry.
         previousRegistry: previousVersion ? {
             version: previousVersion,
-            ipfsHash: previousIpfsHash || null, // Use provided IPFS hash, or filled by pin-to-ipfs.js via Pinata query
+            ipfsHash: previousIpfsHash || null,
         } : null,
         chains: chains,
     };

--- a/script/registry/abi-registry.js
+++ b/script/registry/abi-registry.js
@@ -235,27 +235,36 @@ async function fetchCurrentRegistry(environment, ipfsHash = null) {
 }
 
 /**
- * Extracts version string from deploymentInfo in env files.
- * Looks for version in deploy:protocol or other deployment entries.
+ * Extracts version string from an env file.
+ * Checks deploymentInfo first, then falls back to contract-level version fields.
  *
  * @param {Object} chain - Chain configuration object from env/*.json
  * @returns {string|null} Version string or null if not found
  */
-function getVersionFromDeploymentInfo(chain) {
+function getVersionFromChain(chain) {
+    // Check deploymentInfo entries first
     const info = chain.deploymentInfo;
-    if (!info || typeof info !== "object") return null;
-
-    // First, check deploy:protocol which is the main deployment
-    if (info["deploy:protocol"]?.version) {
-        return info["deploy:protocol"].version;
-    }
-
-    // Fall back to any entry with a version
-    for (const value of Object.values(info)) {
-        if (value?.version) {
-            return value.version;
+    if (info && typeof info === "object") {
+        if (info["deploy:protocol"]?.version) {
+            return info["deploy:protocol"].version;
+        }
+        for (const value of Object.values(info)) {
+            if (value?.version) {
+                return value.version;
+            }
         }
     }
+
+    // Fall back to contract-level version (all contracts in a deployment share the same version)
+    const contracts = chain.contracts;
+    if (contracts && typeof contracts === "object") {
+        for (const value of Object.values(contracts)) {
+            if (value?.version) {
+                return value.version;
+            }
+        }
+    }
+
     return null;
 }
 
@@ -741,7 +750,7 @@ async function main() {
         if (chainCommit) {
             deploymentCommits.add(chainCommit);
         }
-        const chainVersion = getVersionFromDeploymentInfo(chain);
+        const chainVersion = getVersionFromChain(chain);
         if (chainVersion) {
             versions.add(chainVersion);
         }
@@ -928,6 +937,22 @@ function getDeploymentGitCommit(chain) {
     return null;
 }
 
+// Env contract keys whose capitalized form doesn't match the Forge artifact name.
+// Maps capitalized env key → actual Solidity contract name in out/.
+const ABI_NAME_OVERRIDES = {
+    "NavManager": "NAVManager",
+    "FreezeOnlyHook": "FreezeOnly",
+    "FullRestrictionsHook": "FullRestrictions",
+    "FreelyTransferableHook": "FreelyTransferable",
+    "RedemptionRestrictionsHook": "RedemptionRestrictions",
+};
+
+// Factory base name overrides: when stripping "Factory" suffix produces a name
+// that doesn't match the actual artifact (e.g. TokenFactory → ShareToken, not Token).
+const FACTORY_BASE_OVERRIDES = {
+    "TokenFactory": "ShareToken",
+};
+
 /**
  * Extracts ABIs from Forge build artifacts in ./out/ directory.
  * Only includes ABIs for contracts that are actually deployed (based on env file contracts).
@@ -946,20 +971,20 @@ function packAbis(chains, fullMode = false) {
         );
     }
 
-    // Collect all unique contract names from deployed contracts across chains
-    // Capitalize first letter to match ABI filename (e.g., "hub" → "Hub")
-    // Also include base contracts for factories (e.g., PoolEscrowFactory → PoolEscrow)
+    // Collect all unique contract names from deployed contracts across chains.
+    // Applies name overrides so env keys map to actual Forge artifact names.
     const deployedContracts = new Set();
 
     for (const chain of Object.values(chains)) {
         const contracts = Object.keys(chain.contracts || {});
         for (const name of contracts) {
             const capitalized = name.charAt(0).toUpperCase() + name.slice(1);
-            deployedContracts.add(capitalized);
+            const resolved = ABI_NAME_OVERRIDES[capitalized] || capitalized;
+            deployedContracts.add(resolved);
 
-            // If this is a factory, also include the underlying implementation ABI
             if (capitalized.endsWith("Factory")) {
-                const baseName = capitalized.replace(/Factory$/, "");
+                const baseName = FACTORY_BASE_OVERRIDES[capitalized]
+                    || capitalized.replace(/Factory$/, "");
                 deployedContracts.add(baseName);
             }
         }

--- a/script/registry/abi-registry.js
+++ b/script/registry/abi-registry.js
@@ -235,14 +235,37 @@ async function fetchCurrentRegistry(environment, ipfsHash = null) {
 }
 
 /**
- * Extracts version string from an env file.
- * Checks deploymentInfo first, then falls back to contract-level version fields.
+ * Normalizes a version string for comparison.
+ * Strips leading "v" and splits into numeric segments.
+ * e.g. "v3.1" → [3, 1], "3" → [3]
+ */
+function parseVersion(v) {
+    return v.replace(/^v/i, "").split(".").map(Number);
+}
+
+/**
+ * Compares two version strings. Returns > 0 if a > b, < 0 if a < b, 0 if equal.
+ */
+function compareVersions(a, b) {
+    const pa = parseVersion(a);
+    const pb = parseVersion(b);
+    const len = Math.max(pa.length, pb.length);
+    for (let i = 0; i < len; i++) {
+        const diff = (pa[i] || 0) - (pb[i] || 0);
+        if (diff !== 0) return diff;
+    }
+    return 0;
+}
+
+/**
+ * Extracts the highest version string from an env file.
+ * Checks deploymentInfo first, then collects all contract-level versions
+ * and returns the highest one (e.g. "v3.1" wins over "3").
  *
  * @param {Object} chain - Chain configuration object from env/*.json
  * @returns {string|null} Version string or null if not found
  */
 function getVersionFromChain(chain) {
-    // Check deploymentInfo entries first
     const info = chain.deploymentInfo;
     if (info && typeof info === "object") {
         if (info["deploy:protocol"]?.version) {
@@ -255,14 +278,16 @@ function getVersionFromChain(chain) {
         }
     }
 
-    // Fall back to contract-level version (all contracts in a deployment share the same version)
     const contracts = chain.contracts;
     if (contracts && typeof contracts === "object") {
+        let highest = null;
         for (const value of Object.values(contracts)) {
-            if (value?.version) {
-                return value.version;
+            const v = value?.version;
+            if (v && (!highest || compareVersions(v, highest) > 0)) {
+                highest = v;
             }
         }
+        return highest;
     }
 
     return null;

--- a/script/registry/pin-to-ipfs.js
+++ b/script/registry/pin-to-ipfs.js
@@ -3,9 +3,10 @@
  * @fileoverview Pins delta registry files to IPFS using Pinata SDK.
  * 
  * This script handles the pinning of delta registries and manages the version chain:
- * 1. Queries Pinata for the previous registry's CID using env metadata
- * 2. Injects the CID into the previousRegistry.ipfsHash field
- * 3. Pins the updated registry with version metadata for future lookups
+ * 1. If previousRegistry.ipfsHash is missing, resolves it via DNS dnslink lookup
+ *    (falling back to Pinata metadata query)
+ * 2. Pins the registry with version metadata for future lookups
+ * 3. Outputs CID metadata for downstream steps (Cloudflare DNS update)
  * 
  * Usage:
  *   node script/registry/pin-to-ipfs.js [--force=mainnet|testnet] [--update-previous]
@@ -32,6 +33,7 @@
 import { PinataSDK } from "pinata";
 import { readFileSync, existsSync, writeFileSync } from "fs";
 import { join } from "path";
+import { resolveTxt } from "dns/promises";
 import * as core from "@actions/core";
 
 const pinataJwt = process.env.PINATA_JWT;
@@ -64,6 +66,35 @@ if (pinataJwt) {
         pinataJwt: pinataJwt,
         pinataGateway: pinataGateway,
     });
+}
+
+const DNSLINK_HOSTNAMES = {
+    mainnet: "registry.centrifuge.io",
+    testnet: "registry.testnet.centrifuge.io",
+};
+
+/**
+ * Resolves the IPFS CID of the currently live registry via DNS TXT lookup.
+ *
+ * @param {string} env - "mainnet" or "testnet"
+ * @returns {Promise<string|null>} IPFS CID or null if not resolvable
+ */
+async function resolveLiveCid(env) {
+    const hostname = DNSLINK_HOSTNAMES[env];
+    if (!hostname) return null;
+
+    const dnslinkHost = `_dnslink.${hostname}`;
+    try {
+        const records = await resolveTxt(dnslinkHost);
+        for (const record of records) {
+            const txt = record.join("");
+            const match = txt.match(/^dnslink=\/ipfs\/(.+)$/);
+            if (match) return match[1];
+        }
+        return null;
+    } catch {
+        return null;
+    }
 }
 
 /**
@@ -196,42 +227,34 @@ async function pinFile(filePath, name, existingUrl) {
     // Extract version from the registry content
     const version = newContent.version || newContent.deploymentInfo?.gitCommit || null;
 
-    // Only query Pinata for the previous registry's CID if it's not already set
-    // (e.g., when SOURCE_IPFS was provided in abi-registry.js)
-    let previousRegistryInfo = null;
+    // The ipfsHash is normally resolved at generation time via DNS dnslink lookup
+    // in abi-registry.js. If it's still null, try DNS then Pinata as fallback.
     if (newContent.previousRegistry && !newContent.previousRegistry.ipfsHash) {
-        previousRegistryInfo = await findPreviousRegistryCid(inferredEnv);
+        console.log(`  previousRegistry.ipfsHash not set, resolving via DNS...`);
+        let resolvedCid = await resolveLiveCid(inferredEnv);
+        if (!resolvedCid) {
+            console.log(`  DNS failed, falling back to Pinata...`);
+            const info = await findPreviousRegistryCid(inferredEnv);
+            resolvedCid = info?.cid || null;
+        }
+        if (resolvedCid) {
+            newContent.previousRegistry.ipfsHash = resolvedCid;
+            console.log(`  Injected previousRegistry.ipfsHash: ${resolvedCid}`);
+        }
     } else if (newContent.previousRegistry?.ipfsHash) {
         console.log(`  Using existing previousRegistry.ipfsHash: ${newContent.previousRegistry.ipfsHash}`);
     }
 
-    // Inject the previous registry's CID into the content before pinning (if not already set)
-    if (newContent.previousRegistry && previousRegistryInfo?.cid) {
-        newContent.previousRegistry.ipfsHash = previousRegistryInfo.cid;
-        console.log(`  Injected previousRegistry.ipfsHash: ${previousRegistryInfo.cid}`);
-    }
-
-    // Prepare final content for upload
-    // If we modified the content (injected ipfsHash), we need to stringify and restore chainSelector
-    let finalContent;
-    if (previousRegistryInfo?.cid) {
-        // Content was modified, stringify and restore large numbers
-        let stringified = JSON.stringify(newContent, null, 2);
-
-        // Restore chainSelector values from original (corrupted by JSON.parse exceeding MAX_SAFE_INTEGER)
-        const chainSelectorRegex = /"chainSelector":\s*(\d+)/g;
-        const originalMatches = [...originalContent.matchAll(chainSelectorRegex)];
-        let matchIndex = 0;
-        stringified = stringified.replace(chainSelectorRegex, () => {
-            const originalValue = originalMatches[matchIndex++]?.[1];
-            return originalValue ? `"chainSelector": ${originalValue}` : `"chainSelector": 0`;
-        });
-
-        finalContent = stringified;
-    } else {
-        // Content wasn't modified, use original file content as-is
-        finalContent = originalContent;
-    }
+    // Re-stringify content (may have been modified with injected ipfsHash)
+    // and restore chainSelector values corrupted by JSON.parse exceeding MAX_SAFE_INTEGER
+    let finalContent = JSON.stringify(newContent, null, 2);
+    const chainSelectorRegex = /"chainSelector":\s*(\d+)/g;
+    const originalMatches = [...originalContent.matchAll(chainSelectorRegex)];
+    let matchIndex = 0;
+    finalContent = finalContent.replace(chainSelectorRegex, () => {
+        const originalValue = originalMatches[matchIndex++]?.[1];
+        return originalValue ? `"chainSelector": ${originalValue}` : `"chainSelector": 0`;
+    });
 
     // Use JSON upload API, since registry files are JSON documents.
     // Set the visible file name and metadata via the chainable helpers.
@@ -287,17 +310,24 @@ async function updatePreviousRegistry(filePath) {
         return { updated: false, cid: registry.previousRegistry.ipfsHash };
     }
     
-    // Find previous registry CID from Pinata
-    console.log(`  Looking up previous ${env} registry in Pinata...`);
-    const previousRegistryInfo = await findPreviousRegistryCid(env);
+    // Resolve CID: try DNS first, fall back to Pinata
+    console.log(`  Resolving previous ${env} registry CID via DNS...`);
+    let cid = await resolveLiveCid(env);
+    if (cid) {
+        console.log(`  ✓ Resolved via DNS: ${cid}`);
+    } else if (pinata) {
+        console.log(`  DNS lookup failed, falling back to Pinata...`);
+        const previousRegistryInfo = await findPreviousRegistryCid(env);
+        cid = previousRegistryInfo?.cid || null;
+    }
     
-    if (!previousRegistryInfo?.cid) {
-        console.log(`  ⚠ No previous registry found in Pinata for ${env}`);
+    if (!cid) {
+        console.log(`  ⚠ Could not resolve previous registry CID for ${env}`);
         return { updated: false, cid: null };
     }
     
     // Update the registry
-    registry.previousRegistry.ipfsHash = previousRegistryInfo.cid;
+    registry.previousRegistry.ipfsHash = cid;
     
     // Stringify and restore chainSelector values (preserve large numbers)
     let stringified = JSON.stringify(registry, null, 2);
@@ -313,9 +343,9 @@ async function updatePreviousRegistry(filePath) {
     
     // Write back to file
     writeFileSync(filePath, stringified, "utf8");
-    console.log(`  ✓ Updated previousRegistry.ipfsHash to ${previousRegistryInfo.cid}`);
+    console.log(`  ✓ Updated previousRegistry.ipfsHash to ${cid}`);
     
-    return { updated: true, cid: previousRegistryInfo.cid };
+    return { updated: true, cid };
 }
 
 async function writeStepSummary(results) {

--- a/script/registry/validate-env-schema.js
+++ b/script/registry/validate-env-schema.js
@@ -6,6 +6,12 @@
  * issues (field renames, missing required keys, type mismatches) that would
  * cause abi-registry.js to silently skip chains or crash.
  *
+ * When any contract has a numeric `blockNumber`, requires `deploymentInfo.*.startBlock`
+ * (indexers use it for chain-level block polling). Validates that startBlock is not
+ * wildly earlier than the earliest contract deployment block (gap threshold below).
+ * The generated registry copies this from env (`abi-registry.js`); no duplicate check
+ * in validate-registry.js.
+ *
  * Usage:
  *   node script/registry/validate-env-schema.js
  *
@@ -13,7 +19,7 @@
  */
 
 import { readdirSync, readFileSync } from "fs";
-import { join } from "path";
+import { basename, join } from "path";
 
 const envDir = join(process.cwd(), "env");
 
@@ -25,6 +31,59 @@ const KNOWN_TOP_LEVEL_KEYS = new Set([
     "deploymentInfo",
 ]);
 const ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/;
+
+/** Same scan order as abi-registry.js `getDeploymentStartBlock`. */
+function getDeploymentStartBlockFromEnv(chain) {
+    const info = chain.deploymentInfo;
+    if (!info || typeof info !== "object") return null;
+    for (const value of Object.values(info)) {
+        if (value && typeof value === "object" && typeof value.startBlock === "number") {
+            return value.startBlock;
+        }
+    }
+    return null;
+}
+
+function minActiveContractBlockNumber(contracts) {
+    if (!contracts || typeof contracts !== "object") return null;
+    let min = null;
+    for (const contract of Object.values(contracts)) {
+        if (!contract || typeof contract !== "object") continue;
+        if (contract.address === null) continue;
+        if (typeof contract.blockNumber !== "number") continue;
+        if (min === null || contract.blockNumber < min) min = contract.blockNumber;
+    }
+    return min;
+}
+
+function startBlockGapErrorThreshold(minContractBlock) {
+    return Math.max(5_000_000, Math.floor(minContractBlock * 0.005));
+}
+
+/** @returns {string[]} human-readable errors (empty if ok) */
+function startBlockGapErrors(envLabel, startBlock, contracts) {
+    const minBlock = minActiveContractBlockNumber(contracts);
+    if (minBlock == null || typeof startBlock !== "number" || !Number.isFinite(startBlock)) {
+        return [];
+    }
+    const gap = minBlock - startBlock;
+    const threshold = startBlockGapErrorThreshold(minBlock);
+    if (gap < threshold) return [];
+    return [
+        `${envLabel} deploymentInfo.startBlock: startBlock (${startBlock}) lies far before the earliest active contract deployment (min blockNumber ${minBlock}, gap ${gap} blocks ≥ threshold ${threshold}). ` +
+            `Chain-level block listeners use deployment.startBlock (e.g. hourly snapshots); align it when merging env/latest (deploymentStartBlock / broadcast fallback).`,
+    ];
+}
+
+function hasAnyNumericContractBlockNumber(chain) {
+    if (!chain.contracts || typeof chain.contracts !== "object") return false;
+    for (const value of Object.values(chain.contracts)) {
+        if (typeof value === "object" && value !== null && typeof value.blockNumber === "number") {
+            return true;
+        }
+    }
+    return false;
+}
 
 /**
  * Validates a single env file. Returns an array of error strings (empty = valid).
@@ -117,7 +176,24 @@ function validateEnvFile(filePath) {
             for (const [key, value] of Object.entries(chain.deploymentInfo)) {
                 if (typeof value !== "object" || value === null) {
                     errors.push(`deploymentInfo.${key}: must be an object`);
+                } else if (value.startBlock != null && typeof value.startBlock !== "number") {
+                    errors.push(`deploymentInfo.${key}.startBlock: must be a number`);
                 }
+            }
+        }
+    }
+
+    const envLabel = basename(filePath);
+    if (hasAnyNumericContractBlockNumber(chain)) {
+        const startBlock = getDeploymentStartBlockFromEnv(chain);
+        if (startBlock == null) {
+            errors.push(
+                `${envLabel}: missing deploymentInfo.*.startBlock — required when any contract has blockNumber ` +
+                    `(indexers use it for chain-level block listeners, e.g. hourly snapshots; see script/registry/README.md)`
+            );
+        } else {
+            for (const msg of startBlockGapErrors(envLabel, startBlock, chain.contracts || {})) {
+                errors.push(msg);
             }
         }
     }

--- a/script/registry/validate-env-schema.js
+++ b/script/registry/validate-env-schema.js
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview Validates the schema of all env/*.json files.
+ *
+ * Fast-fail gate that runs before registry generation to catch structural
+ * issues (field renames, missing required keys, type mismatches) that would
+ * cause abi-registry.js to silently skip chains or crash.
+ *
+ * Usage:
+ *   node script/registry/validate-env-schema.js
+ *
+ * Exit code: 0 if all files pass, 1 if any file has errors.
+ */
+
+import { readdirSync, readFileSync } from "fs";
+import { join } from "path";
+
+const envDir = join(process.cwd(), "env");
+
+const VALID_ENVIRONMENTS = new Set(["mainnet", "testnet"]);
+const KNOWN_TOP_LEVEL_KEYS = new Set([
+    "network",
+    "adapters",
+    "contracts",
+    "deploymentInfo",
+]);
+const ADDRESS_REGEX = /^0x[0-9a-fA-F]{40}$/;
+
+/**
+ * Validates a single env file. Returns an array of error strings (empty = valid).
+ */
+function validateEnvFile(filePath) {
+    const errors = [];
+    let raw;
+    let chain;
+
+    try {
+        raw = readFileSync(filePath, "utf8");
+    } catch (err) {
+        errors.push(`Could not read file: ${err.message}`);
+        return errors;
+    }
+
+    try {
+        chain = JSON.parse(raw);
+    } catch (err) {
+        errors.push(`Invalid JSON: ${err.message}`);
+        return errors;
+    }
+
+    if (typeof chain !== "object" || chain === null || Array.isArray(chain)) {
+        errors.push("Root must be a JSON object");
+        return errors;
+    }
+
+    for (const key of Object.keys(chain)) {
+        if (!KNOWN_TOP_LEVEL_KEYS.has(key)) {
+            errors.push(
+                `Unknown top-level key "${key}". ` +
+                `Expected one of: ${Array.from(KNOWN_TOP_LEVEL_KEYS).join(", ")}. ` +
+                `If this is intentional, update validate-env-schema.js.`
+            );
+        }
+    }
+
+    // --- network (required) ---
+    if (!chain.network) {
+        errors.push('Missing required key "network"');
+    } else if (typeof chain.network !== "object" || Array.isArray(chain.network)) {
+        errors.push('"network" must be an object');
+    } else {
+        if (chain.network.chainId == null) {
+            errors.push('"network.chainId" is required');
+        } else if (typeof chain.network.chainId !== "number" || !Number.isInteger(chain.network.chainId)) {
+            errors.push(`"network.chainId" must be an integer, got ${typeof chain.network.chainId}: ${chain.network.chainId}`);
+        }
+
+        if (chain.network.environment != null && !VALID_ENVIRONMENTS.has(chain.network.environment)) {
+            errors.push(
+                `"network.environment" must be "mainnet" or "testnet", got "${chain.network.environment}"`
+            );
+        }
+    }
+
+    // --- contracts (optional but validated if present) ---
+    if (chain.contracts != null) {
+        if (typeof chain.contracts !== "object" || Array.isArray(chain.contracts)) {
+            errors.push('"contracts" must be an object');
+        } else {
+            for (const [name, value] of Object.entries(chain.contracts)) {
+                if (typeof value === "string") {
+                    if (!ADDRESS_REGEX.test(value)) {
+                        errors.push(`contracts.${name}: invalid address format "${value}"`);
+                    }
+                } else if (typeof value === "object" && value !== null) {
+                    const addr = value.address;
+                    if (!addr) {
+                        errors.push(`contracts.${name}: missing "address" field`);
+                    } else if (!ADDRESS_REGEX.test(addr)) {
+                        errors.push(`contracts.${name}: invalid address format "${addr}"`);
+                    }
+                    if (value.blockNumber != null && typeof value.blockNumber !== "number") {
+                        errors.push(`contracts.${name}.blockNumber: must be a number, got ${typeof value.blockNumber}`);
+                    }
+                } else {
+                    errors.push(`contracts.${name}: must be an address string or an object with "address", got ${typeof value}`);
+                }
+            }
+        }
+    }
+
+    // --- deploymentInfo (optional but validated if present) ---
+    if (chain.deploymentInfo != null) {
+        if (typeof chain.deploymentInfo !== "object" || Array.isArray(chain.deploymentInfo)) {
+            errors.push('"deploymentInfo" must be an object');
+        } else {
+            for (const [key, value] of Object.entries(chain.deploymentInfo)) {
+                if (typeof value !== "object" || value === null) {
+                    errors.push(`deploymentInfo.${key}: must be an object`);
+                }
+            }
+        }
+    }
+
+    // --- adapters (optional but validated if present) ---
+    if (chain.adapters != null) {
+        if (typeof chain.adapters !== "object" || Array.isArray(chain.adapters)) {
+            errors.push('"adapters" must be an object');
+        }
+    }
+
+    return errors;
+}
+
+function main() {
+    let files;
+    try {
+        files = readdirSync(envDir).filter((f) => f.endsWith(".json"));
+    } catch (err) {
+        console.error(`Could not read env directory: ${err.message}`);
+        process.exit(1);
+    }
+
+    if (files.length === 0) {
+        console.warn("No env/*.json files found");
+        process.exit(0);
+    }
+
+    let totalErrors = 0;
+    const results = [];
+
+    for (const file of files) {
+        const filePath = join(envDir, file);
+        const errors = validateEnvFile(filePath);
+        if (errors.length > 0) {
+            totalErrors += errors.length;
+            results.push({ file, errors });
+        }
+    }
+
+    if (totalErrors === 0) {
+        console.log(`✓ All ${files.length} env files pass schema validation`);
+        process.exit(0);
+    }
+
+    console.error(`\n✗ ${totalErrors} error(s) in ${results.length} file(s):\n`);
+    for (const { file, errors } of results) {
+        console.error(`  env/${file}:`);
+        for (const err of errors) {
+            console.error(`    - ${err}`);
+        }
+        console.error("");
+    }
+    process.exit(1);
+}
+
+main();

--- a/script/registry/validate-registry.js
+++ b/script/registry/validate-registry.js
@@ -9,7 +9,8 @@
  * Hard requirements (errors — break the indexer):
  *   - version: must be a non-empty string
  *   - previousRegistry.ipfsHash: must be non-null unless no live registry exists
- *   - chains.<chainId>.deployment.startBlock: must be a number
+ *   - chains.<chainId>.deployment.startBlock: must be a number (large gap vs env contract
+ *     blocks is rejected by validate-env-schema.js before abi-registry runs)
  *   - chains.<chainId>.contracts.<name>.address: must be a non-empty string
  *   - chains.<chainId>.contracts.<name>.blockNumber: must be a number
  *   - abis: every contract in chains must have a corresponding ABI entry
@@ -31,7 +32,6 @@
  */
 
 import { readFileSync, writeFileSync } from "fs";
-import { dirname, join } from "path";
 
 const REGISTRY_URLS = {
     mainnet: "https://registry.centrifuge.io",

--- a/script/registry/validate-registry.js
+++ b/script/registry/validate-registry.js
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+/**
+ * @fileoverview Validates a generated registry JSON against indexer hard requirements.
+ *
+ * Runs after abi-registry.js to catch missing or malformed data that would
+ * break the Ponder/indexer pipeline. Produces a structured JSON report
+ * (errors + warnings + summary) written to a sidecar file for the PR comment step.
+ *
+ * Hard requirements (errors — break the indexer):
+ *   - version: must be a non-empty string
+ *   - previousRegistry.ipfsHash: must be non-null unless no live registry exists
+ *   - chains.<chainId>.deployment.startBlock: must be a number
+ *   - chains.<chainId>.contracts.<name>.address: must be a non-empty string
+ *   - chains.<chainId>.contracts.<name>.blockNumber: must be a number
+ *   - abis: every contract in chains must have a corresponding ABI entry
+ *
+ * Soft requirements (warnings — shown but don't fail CI):
+ *   - txHash per contract
+ *   - deployment.deployedAt per chain
+ *   - deploymentInfo.gitCommit
+ *   - previousRegistry.version
+ *   - zero chains in a delta registry
+ *
+ * Usage:
+ *   node script/registry/validate-registry.js registry/registry-mainnet.json
+ *   node script/registry/validate-registry.js registry/registry-testnet.json
+ *
+ * Environment Variables:
+ *   SKIP_LIVE_REGISTRY_CHECK=1  Skip fetching the live registry URL (for offline/local use)
+ *
+ * Output:
+ *   - Structured report to stdout (JSON)
+ *   - Sidecar file: <input>.validation.json (same directory as input)
+ *   - Exit code: 1 if any errors, 0 if only warnings or clean
+ */
+
+import { readFileSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+
+const REGISTRY_URLS = {
+    mainnet: "https://registry.centrifuge.io",
+    testnet: "https://registry.testnet.centrifuge.io",
+};
+
+const skipLiveCheck = process.env.SKIP_LIVE_REGISTRY_CHECK === "1";
+
+async function fetchLiveRegistry(environment) {
+    if (skipLiveCheck) {
+        console.log("  Skipping live registry check (SKIP_LIVE_REGISTRY_CHECK=1)");
+        return null;
+    }
+
+    const url = REGISTRY_URLS[environment];
+    if (!url) return null;
+
+    try {
+        console.log(`  Fetching live registry from ${url}...`);
+        const response = await fetch(url);
+        if (!response.ok) {
+            console.log(`  Live registry returned ${response.status} — treating as no existing registry`);
+            return null;
+        }
+        const data = await response.json();
+        if (data && typeof data.version === "string") {
+            console.log(`  Live registry found: version ${data.version}`);
+            return data;
+        }
+        console.log("  Live registry response is not a valid registry (no version field)");
+        return null;
+    } catch (err) {
+        console.warn(`  Could not fetch live registry: ${err.message}`);
+        return null;
+    }
+}
+
+async function validate(registryPath) {
+    const errors = [];
+    const warnings = [];
+
+    let raw;
+    let registry;
+    try {
+        raw = readFileSync(registryPath, "utf8");
+        registry = JSON.parse(raw);
+    } catch (err) {
+        errors.push({ path: "(file)", message: `Cannot read/parse registry: ${err.message}` });
+        return { errors, warnings, summary: {} };
+    }
+
+    // --- version ---
+    if (!registry.version || typeof registry.version !== "string") {
+        errors.push({ path: "version", message: `Must be a non-empty string, got ${JSON.stringify(registry.version)}` });
+    }
+
+    // --- previousRegistry.ipfsHash ---
+    const liveRegistry = await fetchLiveRegistry(registry.network);
+    if (liveRegistry) {
+        if (!registry.previousRegistry?.ipfsHash) {
+            errors.push({
+                path: "previousRegistry.ipfsHash",
+                message: `A live registry exists (version ${liveRegistry.version}) but this registry has no previousRegistry.ipfsHash — it would be an orphan in the linked list`,
+            });
+        }
+    }
+    if (registry.previousRegistry && !registry.previousRegistry.version) {
+        warnings.push({ path: "previousRegistry.version", message: "Missing — human-readable only, indexer follows ipfsHash" });
+    }
+
+    // --- deploymentInfo.gitCommit ---
+    if (!registry.deploymentInfo?.gitCommit) {
+        warnings.push({ path: "deploymentInfo.gitCommit", message: "Missing — metadata only" });
+    }
+
+    // --- chains ---
+    const chains = registry.chains || {};
+    const chainIds = Object.keys(chains);
+
+    if (chainIds.length === 0) {
+        warnings.push({ path: "chains", message: "Delta registry has zero chains — nothing changed?" });
+    }
+
+    const allContractNames = new Set();
+    let totalContracts = 0;
+
+    for (const chainId of chainIds) {
+        const chain = chains[chainId];
+
+        // deployment.startBlock
+        const startBlock = chain.deployment?.startBlock;
+        if (startBlock == null) {
+            errors.push({ path: `chains.${chainId}.deployment.startBlock`, message: "Required by indexer, got null/undefined" });
+        } else if (typeof startBlock !== "number") {
+            errors.push({ path: `chains.${chainId}.deployment.startBlock`, message: `Must be a number, got ${typeof startBlock}: ${JSON.stringify(startBlock)}` });
+        }
+
+        // deployment.deployedAt
+        if (chain.deployment?.deployedAt == null) {
+            warnings.push({ path: `chains.${chainId}.deployment.deployedAt`, message: "Missing — metadata only" });
+        }
+
+        // contracts
+        const contracts = chain.contracts || {};
+        for (const [name, contract] of Object.entries(contracts)) {
+            totalContracts++;
+            const capitalizedName = name.charAt(0).toUpperCase() + name.slice(1);
+            allContractNames.add(capitalizedName);
+
+            if (capitalizedName.endsWith("Factory")) {
+                allContractNames.add(capitalizedName.replace(/Factory$/, ""));
+            }
+
+            // address
+            if (!contract.address || typeof contract.address !== "string") {
+                errors.push({ path: `chains.${chainId}.contracts.${name}.address`, message: `Must be a non-empty string, got ${JSON.stringify(contract.address)}` });
+            }
+
+            // blockNumber
+            if (contract.blockNumber == null) {
+                errors.push({ path: `chains.${chainId}.contracts.${name}.blockNumber`, message: "Required by indexer, got null/undefined" });
+            } else if (typeof contract.blockNumber !== "number") {
+                errors.push({ path: `chains.${chainId}.contracts.${name}.blockNumber`, message: `Must be a number, got ${typeof contract.blockNumber}: ${JSON.stringify(contract.blockNumber)}` });
+            }
+
+            // txHash
+            if (!contract.txHash) {
+                warnings.push({ path: `chains.${chainId}.contracts.${name}.txHash`, message: "Missing — useful for traceability" });
+            }
+        }
+    }
+
+    // --- abis completeness ---
+    const abis = registry.abis || {};
+    const abiNames = new Set(Object.keys(abis));
+
+    for (const needed of allContractNames) {
+        if (!abiNames.has(needed)) {
+            errors.push({ path: `abis.${needed}`, message: `Missing ABI — contract appears in chains but has no ABI entry` });
+        }
+    }
+
+    const summary = {
+        chains: chainIds.length,
+        contracts: totalContracts,
+        abis: abiNames.size,
+        errors: errors.length,
+        warnings: warnings.length,
+    };
+
+    return { errors, warnings, summary };
+}
+
+async function main() {
+    const registryPath = process.argv[2];
+    if (!registryPath) {
+        console.error("Usage: node validate-registry.js <path-to-registry.json>");
+        process.exit(1);
+    }
+
+    console.log(`Validating registry: ${registryPath}`);
+    const report = await validate(registryPath);
+
+    // Write sidecar file for the PR comment step
+    const sidecarPath = registryPath.replace(/\.json$/, ".validation.json");
+    writeFileSync(sidecarPath, JSON.stringify(report, null, 2));
+    console.log(`\nValidation report written to ${sidecarPath}`);
+
+    // Print summary
+    console.log(`\n=== Validation Summary ===`);
+    console.log(`  Chains: ${report.summary.chains}`);
+    console.log(`  Contracts: ${report.summary.contracts}`);
+    console.log(`  ABIs: ${report.summary.abis}`);
+    console.log(`  Errors: ${report.summary.errors}`);
+    console.log(`  Warnings: ${report.summary.warnings}`);
+
+    if (report.errors.length > 0) {
+        console.error(`\n✗ ${report.errors.length} error(s) — these will break the indexer:\n`);
+        for (const err of report.errors) {
+            console.error(`  [ERROR] ${err.path}: ${err.message}`);
+        }
+    }
+
+    if (report.warnings.length > 0) {
+        console.warn(`\n⚠ ${report.warnings.length} warning(s):\n`);
+        for (const warn of report.warnings) {
+            console.warn(`  [WARN]  ${warn.path}: ${warn.message}`);
+        }
+    }
+
+    if (report.errors.length === 0) {
+        console.log("\n✓ Registry passes all indexer hard requirements");
+    }
+
+    // Print the full JSON report to stdout for programmatic consumption
+    console.log("\n" + JSON.stringify(report));
+
+    process.exit(report.errors.length > 0 ? 1 : 0);
+}
+
+main();

--- a/script/registry/validate-registry.js
+++ b/script/registry/validate-registry.js
@@ -119,6 +119,18 @@ async function validate(registryPath) {
         warnings.push({ path: "chains", message: "Delta registry has zero chains — nothing changed?" });
     }
 
+    // Same overrides as abi-registry.js packAbis — keeps validator in sync
+    const ABI_NAME_OVERRIDES = {
+        "NavManager": "NAVManager",
+        "FreezeOnlyHook": "FreezeOnly",
+        "FullRestrictionsHook": "FullRestrictions",
+        "FreelyTransferableHook": "FreelyTransferable",
+        "RedemptionRestrictionsHook": "RedemptionRestrictions",
+    };
+    const FACTORY_BASE_OVERRIDES = {
+        "TokenFactory": "ShareToken",
+    };
+
     const allContractNames = new Set();
     let totalContracts = 0;
 
@@ -143,10 +155,13 @@ async function validate(registryPath) {
         for (const [name, contract] of Object.entries(contracts)) {
             totalContracts++;
             const capitalizedName = name.charAt(0).toUpperCase() + name.slice(1);
-            allContractNames.add(capitalizedName);
+            const resolvedName = ABI_NAME_OVERRIDES[capitalizedName] || capitalizedName;
+            allContractNames.add(resolvedName);
 
             if (capitalizedName.endsWith("Factory")) {
-                allContractNames.add(capitalizedName.replace(/Factory$/, ""));
+                const baseName = FACTORY_BASE_OVERRIDES[capitalizedName]
+                    || capitalizedName.replace(/Factory$/, "");
+                allContractNames.add(baseName);
             }
 
             // address

--- a/script/registry/validate-registry.js
+++ b/script/registry/validate-registry.js
@@ -15,10 +15,6 @@
  *   - abis: every contract in chains must have a corresponding ABI entry
  *
  * Soft requirements (warnings — shown but don't fail CI):
- *   - txHash per contract
- *   - deployment.deployedAt per chain
- *   - deploymentInfo.gitCommit
- *   - previousRegistry.version
  *   - zero chains in a delta registry
  *
  * Usage:
@@ -102,15 +98,6 @@ async function validate(registryPath) {
             });
         }
     }
-    if (registry.previousRegistry && !registry.previousRegistry.version) {
-        warnings.push({ path: "previousRegistry.version", message: "Missing — human-readable only, indexer follows ipfsHash" });
-    }
-
-    // --- deploymentInfo.gitCommit ---
-    if (!registry.deploymentInfo?.gitCommit) {
-        warnings.push({ path: "deploymentInfo.gitCommit", message: "Missing — metadata only" });
-    }
-
     // --- chains ---
     const chains = registry.chains || {};
     const chainIds = Object.keys(chains);
@@ -145,11 +132,6 @@ async function validate(registryPath) {
             errors.push({ path: `chains.${chainId}.deployment.startBlock`, message: `Must be a number, got ${typeof startBlock}: ${JSON.stringify(startBlock)}` });
         }
 
-        // deployment.deployedAt
-        if (chain.deployment?.deployedAt == null) {
-            warnings.push({ path: `chains.${chainId}.deployment.deployedAt`, message: "Missing — metadata only" });
-        }
-
         // contracts
         const contracts = chain.contracts || {};
         for (const [name, contract] of Object.entries(contracts)) {
@@ -176,10 +158,6 @@ async function validate(registryPath) {
                 errors.push({ path: `chains.${chainId}.contracts.${name}.blockNumber`, message: `Must be a number, got ${typeof contract.blockNumber}: ${JSON.stringify(contract.blockNumber)}` });
             }
 
-            // txHash
-            if (!contract.txHash) {
-                warnings.push({ path: `chains.${chainId}.contracts.${name}.txHash`, message: "Missing — useful for traceability" });
-            }
         }
     }
 


### PR DESCRIPTION
## Summary

- **Validate env file schemas on PRs** — a fast-fail gate (`validate-env-schema.js`) catches broken JSON, missing `network.chainId`, invalid addresses, and structural renames before registry generation even starts.
- **Validate generated registry against indexer requirements** — a post-generation gate (`validate-registry.js`) checks the 6 hard requirements the Ponder indexer needs: `version`, `previousRegistry.ipfsHash`, `startBlock`, `address`, `blockNumber`, and ABI completeness. Errors block the PR; warnings are shown but don't block.
- **PR preview comment** — every PR touching `env/**` gets a comment with the registry summary (version, chains, contracts, ABIs) plus any validation errors/warnings, so reviewers can see exactly what would be published.
- **Tightened triggers** — the workflow now only runs when `env/**`, `script/registry/**`, or the workflow file itself changes. The `release` trigger is removed (env file merges to main are the canonical signal). This keeps the GHA log clean.

### Pipeline flow

```mermaid
flowchart TD
    A[env file changed] --> B[Validate env schemas]
    B -->|fail| X1[PR blocked]
    B -->|pass| C[Detect changed environments]
    C --> D[Generate registry]
    D --> E[Validate registry output]
    E -->|errors| X2[PR blocked]
    E -->|pass/warnings| F[Post PR comment]
    F --> G{Merged to main?}
    G -->|no| H[Done]
    G -->|yes| I[Pin to IPFS]
    I --> J[Update Cloudflare DNS]
```

### Indexer hard requirements (enforced by `validate-registry.js`)

| Field | Rule |
|-------|------|
| `version` | Non-empty string |
| `previousRegistry.ipfsHash` | Non-null if a live registry exists |
| `chains.<chainId>.deployment.startBlock` | Must be a number |
| `chains.<chainId>.contracts.<name>.address` | Non-empty string |
| `chains.<chainId>.contracts.<name>.blockNumber` | Must be a number |
| `abis.<ContractName>` | Must exist for every contract in chains |

