### PR TITLE
ci: add auto labelling

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -4,7 +4,7 @@
 # Labeling rules (all matching labels are applied):
 #
 # Scope labels:
-#   scope:contracts  — any file under src/ (excluding src/interfaces/)
+#   scope:contracts  — any file under src/ (excluding */interfaces/ dirs)
 #   scope:tests      — any file under test/
 #   scope:scripts    — any file under script/ (unless scope:tooling applies)
 #   scope:tooling    — ALL files under script/ AND none contain "broadcast" or "deploy"
@@ -71,15 +71,15 @@ jobs:
               const lower = f.toLowerCase();
               let matched = false;
 
-              // Contract source (excluding interfaces)
-              if (f.startsWith('src/') && !f.startsWith('src/interfaces/')) {
+              // Contract source (excluding interface directories scattered
+              // throughout src/, e.g. src/core/hub/interfaces/, src/misc/interfaces/)
+              if (f.startsWith('src/') && !f.includes('/interfaces/')) {
                 hasContract = true;
                 matched = true;
               }
 
-              // Interface-only files under src/interfaces/ are not contracts,
-              // but they are not "other" either — they live in src/ scope
-              if (f.startsWith('src/interfaces/')) {
+              // Interface-only files are not contracts but still belong to src/
+              if (f.startsWith('src/') && f.includes('/interfaces/')) {
                 matched = true;
               }
 

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,202 @@
+# Auto-label PRs based on changed file paths.
+# Works identically on centrifuge/protocol and centrifuge/protocol-internal.
+#
+# Labeling rules (all matching labels are applied):
+#
+# Scope labels:
+#   scope:contracts  — any file under src/ (excluding src/interfaces/)
+#   scope:tests      — any file under test/
+#   scope:scripts    — any file under script/ (unless scope:tooling applies)
+#   scope:tooling    — ALL files under script/ AND none contain "broadcast" or "deploy"
+#   scope:infra      — .github/, lib/, env/, foundry.toml, slither.config.json,
+#                       remappings.txt, .gitmodules
+#
+# Audit flag:
+#   audit:needed     — if scope:contracts was applied
+#
+# Type labels (at most one, requires ALL files to match):
+#   type:test        — only non-infra files are under test/
+#   type:docs        — only .md files or files under docs/
+#   type:chore       — only infra/config files
+#
+# The workflow only ADDS labels, never removes them.
+
+name: Auto Label PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply labels based on changed files
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+
+            // ── Step 1: Fetch all changed files (paginated) ──
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner, repo, pull_number: prNumber, per_page: 100 }
+            );
+            const filenames = files.map(f => f.filename);
+
+            if (filenames.length === 0) {
+              core.info('No changed files found, skipping.');
+              return;
+            }
+
+            // ── Step 2: Classify each file ──
+            const INFRA_EXACT = new Set([
+              'foundry.toml', 'slither.config.json', 'remappings.txt', '.gitmodules'
+            ]);
+
+            let hasContract = false;
+            let hasTest = false;
+            let hasScript = false;
+            let hasScriptDeploy = false;  // script file with "broadcast" or "deploy" in path
+            let hasInfra = false;
+            let hasDocs = false;
+            let hasOther = false;         // files that don't fit any category above
+
+            for (const f of filenames) {
+              const lower = f.toLowerCase();
+              let matched = false;
+
+              // Contract source (excluding interfaces)
+              if (f.startsWith('src/') && !f.startsWith('src/interfaces/')) {
+                hasContract = true;
+                matched = true;
+              }
+
+              // Interface-only files under src/interfaces/ are not contracts,
+              // but they are not "other" either — they live in src/ scope
+              if (f.startsWith('src/interfaces/')) {
+                matched = true;
+              }
+
+              // Tests
+              if (f.startsWith('test/')) {
+                hasTest = true;
+                matched = true;
+              }
+
+              // Scripts
+              if (f.startsWith('script/')) {
+                hasScript = true;
+                matched = true;
+                if (lower.includes('broadcast') || lower.includes('deploy')) {
+                  hasScriptDeploy = true;
+                }
+              }
+
+              // Infra: .github/, lib/, env/, or specific root config files
+              if (
+                f.startsWith('.github/') ||
+                f.startsWith('lib/') ||
+                f.startsWith('env/') ||
+                INFRA_EXACT.has(f)
+              ) {
+                hasInfra = true;
+                matched = true;
+              }
+
+              // Docs: .md files anywhere or anything under docs/
+              if (f.endsWith('.md') || f.startsWith('docs/')) {
+                hasDocs = true;
+                matched = true;
+              }
+
+              if (!matched) {
+                hasOther = true;
+              }
+            }
+
+            // ── Step 3: Determine scope labels ──
+            const labels = [];
+
+            if (hasContract) {
+              labels.push('scope:contracts');
+            }
+
+            if (hasTest) {
+              labels.push('scope:tests');
+            }
+
+            // scope:tooling vs scope:scripts — mutually exclusive
+            if (hasScript) {
+              const allFilesAreScripts = filenames.every(f => f.startsWith('script/'));
+              if (allFilesAreScripts && !hasScriptDeploy) {
+                labels.push('scope:tooling');
+              } else {
+                labels.push('scope:scripts');
+              }
+            }
+
+            if (hasInfra) {
+              labels.push('scope:infra');
+            }
+
+            // ── Step 4: Audit flag ──
+            if (hasContract) {
+              labels.push('audit:needed');
+            }
+
+            // ── Step 5: Type labels (at most one) ──
+            // type:test — only non-infra files are tests
+            if (hasTest && !hasContract && !hasScript && !hasDocs && !hasOther) {
+              labels.push('type:test');
+            }
+            // type:docs — every file is .md or under docs/
+            else if (hasDocs && !hasContract && !hasTest && !hasScript && !hasInfra && !hasOther) {
+              labels.push('type:docs');
+            }
+            // type:chore — every file is infra/config
+            else if (hasInfra && !hasContract && !hasTest && !hasScript && !hasDocs && !hasOther) {
+              labels.push('type:chore');
+            }
+
+            if (labels.length === 0) {
+              core.info('No labels to apply.');
+              return;
+            }
+
+            // ── Step 6: Deduplicate against existing PR labels ──
+            const { data: prData } = await github.rest.pulls.get({
+              owner, repo, pull_number: prNumber
+            });
+            const existingLabels = new Set(prData.labels.map(l => l.name));
+            const newLabels = labels.filter(l => !existingLabels.has(l));
+
+            if (newLabels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: prNumber, labels: newLabels
+              });
+              core.info(`Added labels: ${newLabels.join(', ')}`);
+            } else {
+              core.info('All labels already present, nothing to add.');
+            }
+
+            // ── Step 7: Comment on first run only ──
+            const MARKER = '<!-- auto-label -->';
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: prNumber, per_page: 100 }
+            );
+            const alreadyCommented = comments.some(c => c.body.includes(MARKER));
+
+            if (!alreadyCommented && newLabels.length > 0) {
+              const labelList = labels.map(l => '`' + l + '`').join(', ');
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: prNumber,
+                body: `${MARKER}\nAuto-labeled: ${labelList}. Please verify and add type/version labels manually.`
+              });
+            }

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -6,10 +6,12 @@
 # Scope labels:
 #   scope:contracts  — any file under src/ (excluding */interfaces/ dirs)
 #   scope:tests      — any file under test/
+#   scope:invariant  — invariant/fuzz test files (test/**/recon*, echidna.yaml, medusa.json)
 #   scope:scripts    — any file under script/ (unless scope:tooling applies)
-#   scope:tooling    — ALL files under script/ AND none contain "broadcast" or "deploy"
-#   scope:infra      — .github/, lib/, env/, foundry.toml, slither.config.json,
+#   scope:tooling    — ALL files under script/ AND none contain "deploy" in path
+#   scope:infra      — .github/, lib/, foundry.toml, slither.config.json,
 #                       remappings.txt, .gitmodules
+#   scope:env        — any file under env/
 #
 # Audit flag:
 #   audit:needed     — if scope:contracts was applied
@@ -58,14 +60,18 @@ jobs:
             const INFRA_EXACT = new Set([
               'foundry.toml', 'slither.config.json', 'remappings.txt', '.gitmodules'
             ]);
+            // Fuzzer config files at repo root
+            const INVARIANT_EXACT = new Set(['echidna.yaml', 'medusa.json']);
 
             let hasContract = false;
             let hasTest = false;
+            let hasInvariant = false;   // recon/echidna/medusa invariant tests
             let hasScript = false;
-            let hasScriptDeploy = false;  // script file with "broadcast" or "deploy" in path
+            let hasScriptDeploy = false; // script file with "deploy" in path
             let hasInfra = false;
+            let hasEnv = false;
             let hasDocs = false;
-            let hasOther = false;         // files that don't fit any category above
+            let hasOther = false;        // files that don't fit any category above
 
             for (const f of filenames) {
               const lower = f.toLowerCase();
@@ -87,25 +93,42 @@ jobs:
               if (f.startsWith('test/')) {
                 hasTest = true;
                 matched = true;
+                // Invariant/fuzz tests live under test/**/recon*
+                if (f.includes('/recon')) {
+                  hasInvariant = true;
+                }
+              }
+
+              // Root-level fuzzer configs (echidna.yaml, medusa.json)
+              if (INVARIANT_EXACT.has(f)) {
+                hasInvariant = true;
+                hasTest = true;
+                matched = true;
               }
 
               // Scripts
               if (f.startsWith('script/')) {
                 hasScript = true;
                 matched = true;
-                if (lower.includes('broadcast') || lower.includes('deploy')) {
+                // broadcast/ is gitignored so only "deploy" matters here
+                if (lower.includes('deploy')) {
                   hasScriptDeploy = true;
                 }
               }
 
-              // Infra: .github/, lib/, env/, or specific root config files
+              // Infra: .github/, lib/, or specific root config files
               if (
                 f.startsWith('.github/') ||
                 f.startsWith('lib/') ||
-                f.startsWith('env/') ||
                 INFRA_EXACT.has(f)
               ) {
                 hasInfra = true;
+                matched = true;
+              }
+
+              // Env: deployment addresses and network configs
+              if (f.startsWith('env/')) {
+                hasEnv = true;
                 matched = true;
               }
 
@@ -131,6 +154,10 @@ jobs:
               labels.push('scope:tests');
             }
 
+            if (hasInvariant) {
+              labels.push('scope:invariant');
+            }
+
             // scope:tooling vs scope:scripts — mutually exclusive
             if (hasScript) {
               const allFilesAreScripts = filenames.every(f => f.startsWith('script/'));
@@ -145,22 +172,26 @@ jobs:
               labels.push('scope:infra');
             }
 
+            if (hasEnv) {
+              labels.push('scope:env');
+            }
+
             // ── Step 4: Audit flag ──
             if (hasContract) {
               labels.push('audit:needed');
             }
 
             // ── Step 5: Type labels (at most one) ──
-            // type:test — only non-infra files are tests
-            if (hasTest && !hasContract && !hasScript && !hasDocs && !hasOther) {
+            // type:test — only non-infra files are tests (includes invariant)
+            if (hasTest && !hasContract && !hasScript && !hasDocs && !hasEnv && !hasOther) {
               labels.push('type:test');
             }
             // type:docs — every file is .md or under docs/
-            else if (hasDocs && !hasContract && !hasTest && !hasScript && !hasInfra && !hasOther) {
+            else if (hasDocs && !hasContract && !hasTest && !hasScript && !hasInfra && !hasEnv && !hasOther) {
               labels.push('type:docs');
             }
             // type:chore — every file is infra/config
-            else if (hasInfra && !hasContract && !hasTest && !hasScript && !hasDocs && !hasOther) {
+            else if (hasInfra && !hasContract && !hasTest && !hasScript && !hasDocs && !hasEnv && !hasOther) {
               labels.push('type:chore');
             }
 


### PR DESCRIPTION
### Product requirements

Same as https://github.com/centrifuge/protocol-internal/pull/172

* Automate PR labeling to reduce manual overhead and enforce consistent use of the new label taxonomy across `centrifuge/protocol` and `centrifuge/protocol-internal`
* Apply scope labels (`scope:contracts`, `scope:tests`, `scope:scripts`, `scope:tooling`, `scope:infra`) based on which file paths are changed
* Flag `audit:needed` whenever contract source code is modified
* Infer type labels (`type:test`, `type:docs`, `type:chore`) when all changed files fall into a single category

### Design notes

* Uses `actions/github-script@v7` with the Octokit API directly; no third party labeling actions
* The workflow only adds labels, never removes them, so manually applied labels are preserved
* `scope:tooling` and `scope:scripts` are mutually exclusive: tooling applies only when every changed file is under `script/` and none contain `broadcast` or `deploy` in the path
* `src/interfaces/` changes are excluded from `scope:contracts` since interface files alone do not require audit
* `env/` directory changes are classified as infra alongside `.github/`, `lib/`, and root config files
* A comment is posted on the PR the first time the workflow runs (tracked via an HTML marker to avoid duplicates on subsequent pushes), summarizing the auto-applied labels so the author can verify
* Repo agnostic: uses `context.repo` so the same workflow file works on both protocol repos without modification
* Labels NOT set by CI (require human judgment): `type:feature`, `type:bug`, `type:refactor`, `type:idea`, `type:migration`, all `version:*` labels, `audit:in-review`/`audit:fix`/`audit:passed`, `breaking`, `hotfix`, `blocked`, `sync:internal`, `sync:public`