### PR TITLE
feat: simplify env/*.json creation by eliminating JsonRegistry and en…

### DIFF
--- a/docs/architecture/deployers.puml
+++ b/docs/architecture/deployers.puml
@@ -3,7 +3,7 @@ hide empty members
 
 note "Each deployer has associated its own ActionBatcher and Report\nfollowing the same shown pattern" as N1
 
-class JsonRegistry
+class DeploymentMetadata
 class CreateXScript
 
 class CommonDeployer
@@ -27,7 +27,7 @@ class FullDeployer {
 class CommonInput << (S,application) JsonConfig >>
 class AdaptersInput << (S,application) JsonConfig >>
 
-CommonDeployer -up-|> JsonRegistry
+CommonDeployer -up-|> DeploymentMetadata
 CommonDeployer -up-|> CreateXScript
 HubDeployer -up-|> CommonDeployer
 SpokeDeployer -up-|> CommonDeployer

--- a/foundry.toml
+++ b/foundry.toml
@@ -12,7 +12,7 @@ verbosity = 3
 
 ffi = true
 fs_permissions = [
-  { access = "read-write", path = "./env/latest" },
+  { access = "read-write", path = "./broadcast" },
   { access = "read", path = "env" },
   { access = "read-write", path = "snapshots" },
   { access = "read-write", path = "spell-cache" },

--- a/script/BaseDeployer.s.sol
+++ b/script/BaseDeployer.s.sol
@@ -4,11 +4,11 @@ pragma solidity 0.8.28;
 import {ICreateX} from "./utils/ICreateX.sol";
 import {CREATEX_ADDRESS} from "./utils/CreateX.d.sol";
 import {CreateXScript} from "./utils/CreateXScript.sol";
-import {JsonRegistry} from "./utils/JsonRegistry.s.sol";
+import {DeploymentMetadata} from "./utils/DeploymentMetadata.s.sol";
 
 import "forge-std/Script.sol";
 
-contract BaseDeployer is Script, JsonRegistry, CreateXScript {
+contract BaseDeployer is Script, DeploymentMetadata, CreateXScript {
     string internal suffix;
     address public deployer;
 

--- a/script/DeployAdapters.s.sol
+++ b/script/DeployAdapters.s.sol
@@ -22,7 +22,7 @@ contract DeployAdapters is BaseDeployer {
         EnvConfig memory config = Env.load(vm.envString("NETWORK"));
 
         vm.startBroadcast();
-        startDeploymentOutput();
+        initDeploymentMetadata();
 
         _init(vm.envOr("SUFFIX", string("")), msg.sender);
 
@@ -101,7 +101,7 @@ contract DeployAdapters is BaseDeployer {
             chainlinkAdapter.deny(msg.sender);
         }
 
-        saveDeploymentOutput();
         vm.stopBroadcast();
+        saveDeploymentMetadata("DeployAdapters.s.sol");
     }
 }

--- a/script/LaunchDeployer.s.sol
+++ b/script/LaunchDeployer.s.sol
@@ -19,7 +19,7 @@ import "forge-std/Script.sol";
 contract LaunchDeployer is FullDeployer {
     function run() public virtual {
         vm.startBroadcast();
-        startDeploymentOutput();
+        initDeploymentMetadata();
 
         EnvConfig memory config = Env.load(prettyEnvString("NETWORK"));
 
@@ -60,7 +60,7 @@ contract LaunchDeployer is FullDeployer {
             require(msg.sender == 0x926702C7f1af679a8f99A40af8917DDd82fD6F6c, "wrong deployer");
         }
 
-        saveDeploymentOutput();
         vm.stopBroadcast();
+        saveDeploymentMetadata("LaunchDeployer.s.sol");
     }
 }

--- a/script/deploy/README.md
+++ b/script/deploy/README.md
@@ -41,7 +41,7 @@ Any `env/<network>.json` (e.g. `sepolia`, `base-sepolia`, `arbitrum-sepolia`, `p
 ls env/*.json
 ```
 
-(Exclude `env/latest` and the `spell/` directory.)
+(Exclude the `spell/` directory.)
 
 ### Steps
 
@@ -103,14 +103,14 @@ python3 script/deploy/deploy.py anvil deploy:full
 
 ### `update_network_config.py`
 
-Copies contract addresses (and block numbers from broadcast artifacts) from `env/latest/<chain_id>-latest.json` into `env/<network>.json`.
+Reads deployment metadata from `broadcast/<script>/<chain_id>/run-latest.json` and merges contract addresses, block numbers, and versions into `env/<network>.json`.
 
 ```bash
-python3 script/deploy/update_network_config.py <network_name> [--script PATH]
+python3 script/deploy/update_network_config.py <network_name> --script <script_name>
 ```
 
 - `network_name` – e.g. `sepolia`, `plume`.
-- `--script` – Optional path to the deployment script (e.g. `script/LaunchDeployer.s.sol`) to derive block numbers from broadcast artifacts.
+- `--script` – Required. Deployment script name (e.g. `LaunchDeployer`) to locate the broadcast file.
 
 ### `load_secrets.py`
 
@@ -206,4 +206,4 @@ RPC URL is built from `baseRpcUrl` plus the appropriate API key from GCP when th
 
 - Forge/validation logs: `script/deploy/logs/` (e.g. `forge-validate-<network>.log`).
 - Release state (for `release:sepolia`): `script/deploy/logs/release_state.json`.
-- Partial deployment (non verified): `env/latest/${CHAIN_ID}-latest.json`
+- Deployment data: `broadcast/<Script>.s.sol/${CHAIN_ID}/run-latest.json` (includes `deploymentMetadata` key with logical names and versions)

--- a/script/deploy/deploy.py
+++ b/script/deploy/deploy.py
@@ -186,7 +186,7 @@ def main():
             print_section("Running Protocol Deployment")
             already_deployed = False
             if "--resume" in args.forge_args and not args.dry_run:
-                already_deployed = verifier.config_has_latest_contracts()
+                already_deployed = verifier.config_has_latest_contracts("LaunchDeployer")
 
             # Why did we need to build before running forge script?
             # if "--resume" not in args.forge_args and not already_deployed:
@@ -248,7 +248,7 @@ def main():
         elif args.step == "deploy:adapters":
             print_section(f"Deploying adapters only for {args.network}")
             deploy_success = runner.run_deploy("DeployAdapters")
-            # After deploying with forge, also run our verifier to merge env/latest into env/<network>.json
+            # After deploying with forge, also run our verifier to merge deployment metadata into env/<network>.json
             if deploy_success and not args.dry_run:
                 print_section(f"Verifying deployment for {args.network}")
                 verify_success = verifier.verify_contracts("DeployAdapters")

--- a/script/deploy/lib/runner.py
+++ b/script/deploy/lib/runner.py
@@ -25,9 +25,12 @@ from typing import List
 from .formatter import *
 from .load_config import EnvironmentLoader
 from .ledger import LedgerManager
+from .verifier import ContractVerifier
 
 
 class DeploymentRunner:
+    METADATA_SCRIPTS = {"LaunchDeployer", "DeployAdapters"}
+
     def __init__(self, env_loader: EnvironmentLoader, args: argparse.Namespace):
         self.env_loader = env_loader
         self.args = args
@@ -87,6 +90,8 @@ class DeploymentRunner:
             if not self._run_command(base_cmd):
                 return False
             print_success("Forge contracts deployed successfully")
+
+            verify_success = True
             # 2. Verify (only for protocol and adapter scripts, and NOT in dry-run mode)
             if (not self.args.dry_run and 
                 not self.env_loader.network_name.startswith("anvil") and 
@@ -98,13 +103,29 @@ class DeploymentRunner:
                 # This doesn't really work:
                 # cmd.extend(["--skip", "FullActionBatcher", "--skip", "HubActionBatcher", "--skip", "ExtendedSpokeActionBatcher"])
                 print_step(f"Verifying contracts with forge")
-                if not self._run_command(cmd):
-                    return False
-                print_success("Forge contracts verified successfully")
+                verify_success = self._run_command(cmd)
+                if verify_success:
+                    print_success("Forge contracts verified successfully")
             elif self.args.dry_run:
                 print_info("⏭️  Dry-run mode: skipping verification (would broadcast transactions)")
+
+            if script_name in self.METADATA_SCRIPTS and not self._finalize_broadcast_metadata(script_name):
+                return False
+
+            if not verify_success:
+                return False
             
         return True
+
+    def _finalize_broadcast_metadata(self, script_name: str) -> bool:
+        """Collapse temporary deployment metadata into run-latest.json after Forge finishes."""
+        verifier = ContractVerifier(self.env_loader, self.args)
+        if verifier.finalize_broadcast_metadata(script_name):
+            print_success("Deployment metadata finalized in broadcast/run-latest.json")
+            return True
+
+        print_error("Failed to finalize deployment metadata in broadcast/run-latest.json")
+        return False
 
 
     def _setup_auth_args(self) -> List[str]:

--- a/script/deploy/lib/verifier.py
+++ b/script/deploy/lib/verifier.py
@@ -22,11 +22,92 @@ from .load_config import EnvironmentLoader
 class ContractVerifier:
     def __init__(self, env_loader: EnvironmentLoader, args: argparse.Namespace):
         self.env_loader = env_loader
-        self.latest_deployment = env_loader.root_dir / "env" / "latest" / f"{env_loader.chain_id}-latest.json"
         self.args = args
         self.root_dir = env_loader.root_dir
         self.rpc_url = self.env_loader.rpc_url
         self.etherscan_api_key = self.env_loader.etherscan_api_key
+
+    def _get_broadcast_dir(self, deployment_script: str) -> pathlib.Path:
+        """Get the broadcast directory for a deployment script."""
+        if not deployment_script:
+            return None
+
+        script_path = deployment_script.split(":")[0] if ":" in deployment_script else deployment_script
+        script_filename = pathlib.Path(script_path).name
+        if not script_filename.endswith(".s.sol"):
+            script_filename = f"{script_filename}.s.sol"
+
+        return self.root_dir / "broadcast" / script_filename / str(self.env_loader.chain_id)
+
+    def _get_broadcast_file(self, deployment_script: str) -> pathlib.Path:
+        """Get the path to the broadcast run-latest.json file."""
+        broadcast_dir = self._get_broadcast_dir(deployment_script)
+        if not broadcast_dir:
+            return None
+        return broadcast_dir / "run-latest.json"
+
+    def _merge_deployment_metadata(self, deployment_script: str):
+        """Merge the deployment-metadata.json sidecar into run-latest.json, then delete the sidecar.
+        
+        The sidecar is written by the Solidity script during execution because
+        run-latest.json does not exist yet at that point (Forge writes it after
+        the script returns). This method merges the sidecar into the broadcast
+        file so that all deployment info lives in a single file.
+        """
+        broadcast_dir = self._get_broadcast_dir(deployment_script)
+        if not broadcast_dir:
+            return
+
+        sidecar = broadcast_dir / "deployment-metadata.json"
+        broadcast_file = broadcast_dir / "run-latest.json"
+
+        if not sidecar.exists():
+            return  # Already merged or no metadata
+
+        if not broadcast_file.exists():
+            return  # No broadcast file to merge into
+
+        try:
+            with open(sidecar, 'r') as f:
+                metadata = json.load(f)
+            with open(broadcast_file, 'r') as f:
+                broadcast_data = json.load(f)
+
+            broadcast_data['deploymentMetadata'] = metadata
+
+            with open(broadcast_file, 'w') as f:
+                json.dump(broadcast_data, f, indent=2)
+
+            sidecar.unlink()
+            print_step("Merged deployment metadata into broadcast file")
+        except (json.JSONDecodeError, IOError) as e:
+            print_warning(f"Failed to merge deployment metadata into broadcast file: {e}")
+
+    def _load_deployment_metadata(self, deployment_script: str) -> dict:
+        """Load deployment metadata (logical names, addresses, versions) from the broadcast file.
+        
+        If a deployment-metadata.json sidecar exists (written by the Solidity script),
+        it is first merged into run-latest.json and deleted.
+        """
+        # Merge sidecar into broadcast file if it exists
+        self._merge_deployment_metadata(deployment_script)
+
+        broadcast_file = self._get_broadcast_file(deployment_script)
+        if not broadcast_file or not broadcast_file.exists():
+            print_warning(f"Broadcast file not found: {broadcast_file}")
+            return {}
+
+        try:
+            with open(broadcast_file, 'r') as f:
+                data = json.load(f)
+            metadata = data.get('deploymentMetadata')
+            if not metadata:
+                print_warning(f"No deploymentMetadata found in {broadcast_file}")
+                return {}
+            return metadata
+        except (json.JSONDecodeError, IOError) as e:
+            print_warning(f"Failed to parse broadcast file: {e}")
+            return {}
     
     def _get_broadcast_deployment_info(self, deployment_script: str) -> dict:
         """
@@ -44,25 +125,13 @@ class ContractVerifier:
 
         Returns a dict mapping lowercase addresses to { blockNumber, txHash }.
         """
-        # Find the broadcast file
-        # deployment_script can be one of:
-        # - "script/SomeScript.s.sol:ScriptName"
-        # - "script/SomeScript.s.sol"
-        # - "SomeScript.s.sol" (e.g. "LaunchDeployer.s.sol")
-        # - "SomeScript" (e.g. "LaunchDeployer")
         if not deployment_script:
             print_warning("No deployment script provided; skipping broadcast deployment info extraction")
             return {}
 
-        script_path = deployment_script.split(":")[0] if ":" in deployment_script else deployment_script
-        script_filename = pathlib.Path(script_path).name  # e.g., "LaunchDeployer.s.sol" or "LaunchDeployer"
-        if not script_filename.endswith(".s.sol"):
-            script_filename = f"{script_filename}.s.sol"
+        broadcast_file = self._get_broadcast_file(deployment_script)
 
-        broadcast_dir = self.root_dir / "broadcast" / script_filename / str(self.env_loader.chain_id)
-        broadcast_file = broadcast_dir / "run-latest.json"
-
-        if not broadcast_file.exists():
+        if not broadcast_file or not broadcast_file.exists():
             print_warning(f"Broadcast file not found: {broadcast_file}")
             return {}
 
@@ -150,23 +219,19 @@ class ContractVerifier:
             return {}
 
     def verify_contracts(self, deployment_script: str) -> bool:
-        """Verify contracts on Etherscan"""
-        # Always use -latest.json for verification
-        if not self.latest_deployment.exists():
-            print_error(f"Deployment file not found: {self.latest_deployment}")
+        """Verify contracts on Etherscan using deployment metadata from the broadcast file."""
+        metadata = self._load_deployment_metadata(deployment_script)
+        if not metadata:
+            print_error(f"Deployment metadata not found for script: {deployment_script}")
             return False
 
-        contracts_file = self.latest_deployment
-        relative_path = format_path(contracts_file, self.root_dir)
+        broadcast_file = self._get_broadcast_file(deployment_script)
+        relative_path = format_path(broadcast_file, self.root_dir)
         print_step(f"Checking contracts from {relative_path}")
 
         if not self.args.dry_run:
-            with open(contracts_file, 'r') as f:
-                data = json.load(f)
-                contracts = data.get("contracts", {})
-                contract_addresses = { k: v for k, v in contracts.items() }
-
-            if not contract_addresses:
+            contracts = metadata.get("contracts", {})
+            if not contracts:
                 print_error(f"No contracts found in {relative_path}")
                 return False
 
@@ -174,7 +239,8 @@ class ContractVerifier:
             undeployed_contracts = []
             verified_count = 0
             deployed_count = 0
-            for contract_name, contract_address in contract_addresses.items():
+            for contract_name, contract_data in contracts.items():
+                contract_address = contract_data.get('address') if isinstance(contract_data, dict) else contract_data
                 # First check if it is deployed
                 if self._is_contract_deployed(contract_address):
                     print_success(f"{contract_name} ({contract_address}) is deployed")
@@ -191,8 +257,8 @@ class ContractVerifier:
                     unverified_contracts.append(f"{contract_name}:{contract_address}")
                 time.sleep(0.2)  # Rate limiting
 
-            print_info(f"Deployment check complete: {deployed_count}/{len(contract_addresses)} contracts deployed")
-            print_info(f"Verification check complete: {verified_count}/{len(contract_addresses)} contracts verified")
+            print_info(f"Deployment check complete: {deployed_count}/{len(contracts)} contracts deployed")
+            print_info(f"Verification check complete: {verified_count}/{len(contracts)} contracts verified")
 
             if unverified_contracts or undeployed_contracts:
                 print_error("Some contracts failed checks")
@@ -200,8 +266,8 @@ class ContractVerifier:
             else:
                 print_success("All contracts checks passed!")
                 print_info(f"Trying to update network config now...")
-                # Check if -latest.json is old before updating main config
-                if self._is_deployment_old():
+                # Check if metadata is old before updating main config
+                if self._is_deployment_old(deployment_script):
                         print_info("Skipping update of main config file")
                         return True
                 else:
@@ -211,20 +277,22 @@ class ContractVerifier:
 
         return True
 
-    def config_has_latest_contracts(self) -> bool:
-        """Fast check: are contracts from env/latest already merged into env/<network>.json?"""
+    def config_has_latest_contracts(self, deployment_script: str = None) -> bool:
+        """Fast check: are contracts from deployment metadata already merged into env/<network>.json?"""
         try:
-            if not self.latest_deployment.exists():
+            metadata = self._load_deployment_metadata(deployment_script)
+            if not metadata:
                 return False
-            with open(self.latest_deployment, 'r') as f:
-                latest = json.load(f)
             with open(self.env_loader.config_file, 'r') as f:
                 cfg = json.load(f)
-            latest_contracts = latest.get('contracts', {}) or {}
+            latest_contracts = metadata.get('contracts', {}) or {}
             config_contracts = cfg.get('contracts', {}) or {}
-            # Require every contract in latest to exist in config with identical address
-            for name, addr in latest_contracts.items():
-                if name not in config_contracts or config_contracts[name].lower() != addr.lower():
+            # Require every contract in metadata to exist in config with identical address
+            for name, contract_data in latest_contracts.items():
+                addr = contract_data.get('address') if isinstance(contract_data, dict) else contract_data
+                cfg_entry = config_contracts.get(name)
+                cfg_addr = cfg_entry.get('address') if isinstance(cfg_entry, dict) else cfg_entry
+                if not cfg_addr or cfg_addr.lower() != addr.lower():
                     return False
             return True if latest_contracts else False
         except Exception:
@@ -277,10 +345,16 @@ class ContractVerifier:
             return False
 
     def update_network_config(self, deployment_script: str = None):
-        """Update network config with deployment output"""
+        """Update network config with deployment output from the broadcast directory."""
         relative_path = format_path(self.env_loader.config_file, self.root_dir)
         print_step(f"Merging contract addresses to {relative_path}")
         network_config = self.env_loader.config_file
+
+        # Load deployment metadata from broadcast directory
+        metadata = self._load_deployment_metadata(deployment_script)
+        if not metadata:
+            print_error(f"Deployment metadata not found for script: {deployment_script}")
+            return False
 
         # Create a backup of the current config
         backup_config = pathlib.Path(str(network_config) + ".bak")
@@ -305,19 +379,17 @@ class ContractVerifier:
             broadcast_deployment_info = self._get_broadcast_deployment_info(deployment_script)
 
         try:
-            # Load both files
+            # Load network config
             with open(network_config, 'r') as f:
                 config_data = json.load(f)
-            with open(self.latest_deployment, 'r') as f:
-                latest_data = json.load(f)
 
             # Merge the contracts section
             if 'contracts' not in config_data:
                 config_data['contracts'] = {}
 
-            # Update contracts with new deployments
-            contracts_from_latest = latest_data.get('contracts', {})
-            for contract_name, contract_data in contracts_from_latest.items():
+            # Update contracts with new deployments from metadata
+            contracts_from_metadata = metadata.get('contracts', {})
+            for contract_name, contract_data in contracts_from_metadata.items():
                 # Extract address from either format
                 if isinstance(contract_data, dict):
                     contract_address = contract_data.get('address')
@@ -366,10 +438,11 @@ class ContractVerifier:
                     entry['version'] = version_out
                 config_data['contracts'][contract_name] = entry
 
+            # Get deployment timestamp from broadcast file
+            broadcast_file = self._get_broadcast_file(deployment_script)
+            broadcast_stat = broadcast_file.stat()
+            deployment_timestamp = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(broadcast_stat.st_mtime))
 
-            # Get deployment timestamp from latest deployment file
-            latest_stat = self.latest_deployment.stat()
-            deployment_timestamp = time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(latest_stat.st_mtime))
             # Set deployment info
             if 'deploymentInfo' not in config_data:
                 config_data['deploymentInfo'] = {}
@@ -395,17 +468,17 @@ class ContractVerifier:
                 config_data['deploymentInfo'][deployment_step] = {}
             config_data['deploymentInfo'][deployment_step]['suffix'] = os.environ.get("SUFFIX", "")
             
-            # Get startBlock from deployment mechanism (-latest.json file) if available
+            # Get startBlock from deployment metadata if available
             # Only calculate from contract block numbers if not provided by deployment
-            deployment_start_block = latest_data.get('deploymentStartBlock')
+            deployment_start_block = metadata.get('deploymentStartBlock')
             if deployment_start_block is not None:
-                # Use startBlock from deployment mechanism
+                # Use startBlock from deployment metadata
                 config_data['deploymentInfo'][deployment_step]['startBlock'] = int(deployment_start_block)
             else:
                 # Fallback: Calculate from deployed contract block numbers
                 # Collect all block numbers from this deployment (from broadcast artifacts)
                 deployed_block_numbers = []
-                for contract_name, contract_data in contracts_from_latest.items():
+                for contract_name, contract_data in contracts_from_metadata.items():
                     if isinstance(contract_data, dict):
                         contract_address = contract_data.get('address')
                     else:
@@ -497,31 +570,23 @@ class ContractVerifier:
         # If no large gap found, all blocks are likely from the same deployment
         return sorted_blocks[0]
 
-    def _check_deployment_age(self) -> bool:
-        """Check if -latest.json is old and should warn user"""
-        if not self.latest_deployment.exists():
+    def _is_deployment_old(self, deployment_script: str) -> bool:
+        """Check if the broadcast file is old and should warn user.
+           Returns True if deployment is old, False if not (or if user wants to proceed)."""
+        broadcast_file = self._get_broadcast_file(deployment_script)
+        if not broadcast_file or not broadcast_file.exists():
             return False
 
-        latest_file_age = int(time.time() - self.latest_deployment.stat().st_mtime)
-        one_day_in_seconds = 86400
-
-        return latest_file_age > one_day_in_seconds
-
-    def _is_deployment_old(self) -> bool:
-        """Check if -latest.json is old and should warn user
-           Returns True deployment is old, False if not (or if user wants to proceed)"""
-
-        latest_deploy_file = format_path(self.latest_deployment, self.root_dir)
         deploy_config = format_path(self.env_loader.config_file, self.root_dir)
-        latest_file_age = int(time.time() - self.latest_deployment.stat().st_mtime)
+        broadcast_display = format_path(broadcast_file, self.root_dir)
+        file_age = int(time.time() - broadcast_file.stat().st_mtime)
         one_day_in_seconds = 86400
 
-        if latest_file_age < one_day_in_seconds:
+        if file_age < one_day_in_seconds:
             return False
-        # else
 
-        print_warning(f"{latest_deploy_file} is old (age: {latest_file_age // 3600} hours)")
-        print_warning(f"This will replace contracts in {deploy_config} with addresses from {latest_deploy_file}")
+        print_warning(f"{broadcast_display} is old (age: {file_age // 3600} hours)")
+        print_warning(f"This will replace contracts in {deploy_config} with addresses from {broadcast_display}")
 
         while True:
             try:

--- a/script/deploy/lib/verifier.py
+++ b/script/deploy/lib/verifier.py
@@ -46,26 +46,20 @@ class ContractVerifier:
             return None
         return broadcast_dir / "run-latest.json"
 
-    def _merge_deployment_metadata(self, deployment_script: str):
-        """Merge the deployment-metadata.json sidecar into run-latest.json, then delete the sidecar.
-        
-        The sidecar is written by the Solidity script during execution because
-        run-latest.json does not exist yet at that point (Forge writes it after
-        the script returns). This method merges the sidecar into the broadcast
-        file so that all deployment info lives in a single file.
-        """
+    def _merge_deployment_metadata(self, deployment_script: str) -> bool:
+        """Merge the deployment-metadata.json sidecar into run-latest.json, then delete the sidecar."""
         broadcast_dir = self._get_broadcast_dir(deployment_script)
         if not broadcast_dir:
-            return
+            return False
 
         sidecar = broadcast_dir / "deployment-metadata.json"
         broadcast_file = broadcast_dir / "run-latest.json"
 
         if not sidecar.exists():
-            return  # Already merged or no metadata
+            return False
 
         if not broadcast_file.exists():
-            return  # No broadcast file to merge into
+            return False
 
         try:
             with open(sidecar, 'r') as f:
@@ -80,17 +74,42 @@ class ContractVerifier:
 
             sidecar.unlink()
             print_step("Merged deployment metadata into broadcast file")
+            return True
         except (json.JSONDecodeError, IOError) as e:
             print_warning(f"Failed to merge deployment metadata into broadcast file: {e}")
+            return False
+
+    def _broadcast_has_deployment_metadata(self, deployment_script: str) -> bool:
+        """Check whether the broadcast file already contains embedded deployment metadata."""
+        broadcast_file = self._get_broadcast_file(deployment_script)
+        if not broadcast_file or not broadcast_file.exists():
+            return False
+
+        try:
+            with open(broadcast_file, 'r') as f:
+                data = json.load(f)
+            return bool(data.get('deploymentMetadata'))
+        except (json.JSONDecodeError, IOError) as e:
+            print_warning(f"Failed to parse broadcast file: {e}")
+            return False
+
+    def finalize_broadcast_metadata(self, deployment_script: str) -> bool:
+        """Ensure deployment metadata lives in run-latest.json before follow-up tooling reads it."""
+        if not deployment_script:
+            return False
+
+        if self._merge_deployment_metadata(deployment_script):
+            return True
+
+        return self._broadcast_has_deployment_metadata(deployment_script)
 
     def _load_deployment_metadata(self, deployment_script: str) -> dict:
         """Load deployment metadata (logical names, addresses, versions) from the broadcast file.
         
-        If a deployment-metadata.json sidecar exists (written by the Solidity script),
-        it is first merged into run-latest.json and deleted.
+        If a stale deployment-metadata.json sidecar exists, merge it into
+        run-latest.json before reading.
         """
-        # Merge sidecar into broadcast file if it exists
-        self._merge_deployment_metadata(deployment_script)
+        self.finalize_broadcast_metadata(deployment_script)
 
         broadcast_file = self._get_broadcast_file(deployment_script)
         if not broadcast_file or not broadcast_file.exists():

--- a/script/deploy/update_network_config.py
+++ b/script/deploy/update_network_config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copy contract addresses from $CHAIN_ID/run-latest.json to the associated network json file
+# Copy contract addresses from broadcast deployment metadata to the associated network json file
 import pathlib
 import argparse
 from lib.load_config import EnvironmentLoader
@@ -11,8 +11,8 @@ root_dir = pathlib.Path(__file__).parent.parent.parent
 parser = argparse.ArgumentParser(description="Update network configuration.")
 parser.add_argument("network_name")
 parser.add_argument("--script", "-s", 
-                    help="Deployment script path (e.g., script/LaunchDeployer.s.sol) to extract real block numbers from broadcast artifacts",
-                    default=None)
+                    help="Deployment script name (e.g., LaunchDeployer) to locate deployment metadata in broadcast directory",
+                    required=True)
 args_cli = parser.parse_args()
 network_name = args_cli.network_name
 

--- a/script/registry/validate-env-schema.js
+++ b/script/registry/validate-env-schema.js
@@ -71,7 +71,7 @@ function startBlockGapErrors(envLabel, startBlock, contracts) {
     if (gap < threshold) return [];
     return [
         `${envLabel} deploymentInfo.startBlock: startBlock (${startBlock}) lies far before the earliest active contract deployment (min blockNumber ${minBlock}, gap ${gap} blocks ≥ threshold ${threshold}). ` +
-            `Chain-level block listeners use deployment.startBlock (e.g. hourly snapshots); align it when merging env/latest (deploymentStartBlock / broadcast fallback).`,
+            `Chain-level block listeners use deployment.startBlock (e.g. hourly snapshots); align it when merging deployment metadata (deploymentStartBlock / broadcast fallback).`,
     ];
 }
 

--- a/script/utils/DeploymentMetadata.s.sol
+++ b/script/utils/DeploymentMetadata.s.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
+
+/// @title DeploymentMetadata
+/// @notice Accumulates contract metadata (logical name, address, version) during deployment
+///         and writes it as a temporary sidecar file alongside the Forge broadcast output.
+///         The Python tooling then merges this into run-latest.json (under a `deploymentMetadata`
+///         key) and deletes the sidecar, resulting in a single file with all deployment info.
+///         Replaces JsonRegistry by consolidating all deployment info into the broadcast directory.
+contract DeploymentMetadata is Script {
+    string deploymentOutput;
+    uint256 registeredContracts;
+    uint256 deploymentStartBlock;
+
+    function register(string memory name, address target, string memory version) public {
+        string memory contractJson =
+            string(abi.encodePacked('{ "address": "', vm.toString(target), '", "version": "', version, '" }'));
+
+        string memory entry = string(abi.encodePacked('    "', name, '": ', contractJson));
+
+        deploymentOutput = (registeredContracts == 0)
+            ? string(abi.encodePacked(deploymentOutput, entry))
+            : string(abi.encodePacked(deploymentOutput, ",\n", entry));
+
+        registeredContracts += 1;
+    }
+
+    function initDeploymentMetadata() internal {
+        registeredContracts = 0;
+        deploymentOutput = '{\n  "contracts": {\n';
+        deploymentStartBlock = block.number;
+    }
+
+    /// @notice Save deployment metadata alongside the Forge broadcast output.
+    ///         Must be called after vm.stopBroadcast().
+    /// @param scriptName The script filename (e.g., "LaunchDeployer.s.sol")
+    function saveDeploymentMetadata(string memory scriptName) internal {
+        string memory blockJson;
+        if (deploymentStartBlock > 0) {
+            blockJson = string(
+                abi.encodePacked(
+                    '\n  },\n  "deploymentStartBlock": "', vm.toString(deploymentStartBlock), '"\n}'
+                )
+            );
+        } else {
+            blockJson = "\n  }\n}";
+        }
+
+        string memory fullOutput = string(abi.encodePacked(deploymentOutput, blockJson));
+
+        // Write to broadcast/<scriptName>/<chainId>/deployment-metadata.json
+        string memory dir =
+            string(abi.encodePacked("./broadcast/", scriptName, "/", vm.toString(block.chainid), "/"));
+        if (!vm.exists(dir)) {
+            vm.createDir(dir, true);
+        }
+
+        string memory metadataPath = string(abi.encodePacked(dir, "deployment-metadata.json"));
+        vm.writeFile(metadataPath, fullOutput);
+        console.log("Deployment metadata saved to: %s", metadataPath);
+    }
+}

--- a/script/utils/DeploymentMetadata.s.sol
+++ b/script/utils/DeploymentMetadata.s.sol
@@ -7,8 +7,8 @@ import {console} from "forge-std/console.sol";
 /// @title DeploymentMetadata
 /// @notice Accumulates contract metadata (logical name, address, version) during deployment
 ///         and writes it as a temporary sidecar file alongside the Forge broadcast output.
-///         The Python tooling then merges this into run-latest.json (under a `deploymentMetadata`
-///         key) and deletes the sidecar, resulting in a single file with all deployment info.
+///         Forge writes run-latest.json only after the script completes, so the deploy tooling
+///         folds this sidecar into run-latest.json immediately after the command finishes.
 ///         Replaces JsonRegistry by consolidating all deployment info into the broadcast directory.
 contract DeploymentMetadata is Script {
     string deploymentOutput;


### PR DESCRIPTION
…v/latest

Remove the intermediate env/latest/<chainid>-latest.json file and JsonRegistry contract. Deployment metadata (logical names, addresses, versions) is now written as a temporary sidecar alongside the Forge broadcast output, then automatically merged into run-latest.json by the Python tooling. This consolidates all deployment information into a single file.

Changes:
- Add DeploymentMetadata.s.sol replacing JsonRegistry
- Update BaseDeployer to inherit DeploymentMetadata
- Update LaunchDeployer and DeployAdapters to use new metadata flow (saveDeploymentMetadata called after stopBroadcast)
- Refactor verifier.py to read from broadcast/run-latest.json (merges sidecar into broadcast file on first read)
- Make --script required in update_network_config.py
- Update foundry.toml fs_permissions from env/latest to broadcast/
- Update docs and architecture diagrams

Closes #790

