### PR TITLE
feat(env): 4-of-5 LayerZero DVN configuration (mainnet rollout)

### DIFF
--- a/env/arbitrum-sepolia.json
+++ b/env/arbitrum-sepolia.json
@@ -26,9 +26,11 @@
       "layerZeroEid": 40231,
       "deploy": true,
       "blockConfirmations": 5,
-      "DVNs": [
-        "0x53f488e93b4f1b60e8e83aa374dbe1780a1ee8a8"
-      ]
+      "requiredDVNs": [
+        "0x53f488E93b4f1b60E8E83aa374dBe1780A1EE8a8"
+      ],
+      "optionalDVNs": [],
+      "optionalDVNThreshold": 0
     },
     "chainlink": {
       "chainSelector": 3478487238524512106,

--- a/env/arbitrum.json
+++ b/env/arbitrum.json
@@ -14,10 +14,16 @@
       "layerZeroEid": 30110,
       "deploy": true,
       "blockConfirmations": 15,
-      "DVNs": [
-        "0x2f55C492897526677C5B68fb199ea31E2c126416",
+      "requiredDVNs": [
+        "0xEae839784e5F6C79bBaf34b6023a2f62e134AB39",
         "0xf2E380c90e6c09721297526dbC74f870e114dfCb"
-      ]
+      ],
+      "optionalDVNs": [
+        "0x01F9aAD7c53626bF8807d640D9Ddf852254D6f63",
+        "0xa7b5189bcA84Cd304D8553977c7C614329750d99",
+        "0xB3Ce0A5D132Cd9Bf965aBa435E650c55Edce0062"
+      ],
+      "optionalDVNThreshold": 2
     },
     "wormhole": {
       "wormholeId": 23,

--- a/env/avalanche.json
+++ b/env/avalanche.json
@@ -14,10 +14,16 @@
       "layerZeroEid": 30106,
       "deploy": true,
       "blockConfirmations": 15,
-      "DVNs": [
-        "0x962F502A63F5FBeB44DC9ab932122648E8352959",
-        "0xcc49e6fca014c77e1eb604351cc1e08c84511760"
-      ]
+      "requiredDVNs": [
+        "0xbe57e9E7d9eB16B92C6383792aBe28D64a18c0F1",
+        "0xcC49E6fca014c77E1Eb604351cc1E08C84511760"
+      ],
+      "optionalDVNs": [
+        "0xa59BA433ac34D2927232918Ef5B2eaAfcF130BA5",
+        "0xc816Afa2f1C4Ab615fE735270D1831fa7D067D15",
+        "0xE94aE34DfCC87A61836938641444080B98402c75"
+      ],
+      "optionalDVNThreshold": 2
     },
     "wormhole": {
       "wormholeId": 6,

--- a/env/base-sepolia.json
+++ b/env/base-sepolia.json
@@ -26,9 +26,11 @@
       "layerZeroEid": 40245,
       "deploy": true,
       "blockConfirmations": 5,
-      "DVNs": [
-        "0xe1a12515f9ab2764b887bf60b923ca494ebbb2d6"
-      ]
+      "requiredDVNs": [
+        "0xe1a12515F9AB2764b887bF60B923Ca494EBbB2d6"
+      ],
+      "optionalDVNs": [],
+      "optionalDVNThreshold": 0
     },
     "chainlink": {
       "chainSelector": 10344971235874465080,

--- a/env/base.json
+++ b/env/base.json
@@ -14,10 +14,16 @@
       "layerZeroEid": 30184,
       "deploy": true,
       "blockConfirmations": 15,
-      "DVNs": [
+      "requiredDVNs": [
         "0x554833698Ae0FB22ECC90B01222903fD62CA4B47",
-        "0x9e059a54699a285714207b43b055483e78faac25"
-      ]
+        "0xc2A0C36f5939A14966705c7Cec813163FaEEa1F0"
+      ],
+      "optionalDVNs": [
+        "0x5b6735c66d97479cCD18294fc96B3084EcB2fa3f",
+        "0x93aC538152E1BC4F093aE5666Ee9FD1d84f4f4bF",
+        "0xcd37CA043f8479064e10635020c65FfC005d36f6"
+      ],
+      "optionalDVNThreshold": 2
     },
     "wormhole": {
       "wormholeId": 30,

--- a/env/bnb-smart-chain.json
+++ b/env/bnb-smart-chain.json
@@ -14,10 +14,16 @@
       "layerZeroEid": 30102,
       "deploy": true,
       "blockConfirmations": 15,
-      "DVNs": [
-        "0xfA9bA83C102283958B997Adc8B44ED3A3CdB5dDa",
-        "0xfD6865c841c2d64565562fCc7e05e619A30615f0"
-      ]
+      "requiredDVNs": [
+        "0xf0a5C5306adbFd4e3dfD5d4B148B451c411d3878",
+        "0xfA9bA83C102283958B997Adc8B44ED3A3CdB5dDa"
+      ],
+      "optionalDVNs": [
+        "0x31F748a368a893Bdb5aBB67ec95F232507601A73",
+        "0x439264FB87581a70Bb6D7bEFd16b636521B0Ad2D",
+        "0x534C6b3e6805E9287ff1D49C349d5f7a01B9b7F5"
+      ],
+      "optionalDVNThreshold": 2
     },
     "wormhole": {
       "wormholeId": 4,

--- a/env/connections/mainnet.json
+++ b/env/connections/mainnet.json
@@ -22,6 +22,11 @@
             "chains": [["monad"], ["plume", "hyper-evm", "pharos"]],
             "adapters": ["layerZero"],
             "threshold": 1
+        },
+        {
+            "chains": [["pharos"], ["ethereum"]],
+            "adapters": ["layerZero", "chainlink"],
+            "threshold": 2
         }
     ]
 }

--- a/env/ethereum.json
+++ b/env/ethereum.json
@@ -14,10 +14,16 @@
       "layerZeroEid": 30101,
       "deploy": true,
       "blockConfirmations": 15,
-      "DVNs": [
-        "0x589dEDbD617e0CBcB916A9223F4d1300c294236b",
+      "requiredDVNs": [
+        "0x373a6E5c0C4E89E24819f00AA37ea370917AAfF4",
         "0xa4fE5A5B9A846458a70Cd0748228aED3bF65c2cd"
-      ]
+      ],
+      "optionalDVNs": [
+        "0x06559EE34D85a88317Bf0bfE307444116c631b67",
+        "0x3a4636E9AB975d28d3Af808b4e1c9fd936374E30",
+        "0xa59BA433ac34D2927232918Ef5B2eaAfcF130BA5"
+      ],
+      "optionalDVNThreshold": 2
     },
     "wormhole": {
       "wormholeId": 2,

--- a/env/hyper-evm-testnet.json
+++ b/env/hyper-evm-testnet.json
@@ -13,9 +13,11 @@
       "layerZeroEid": 40362,
       "deploy": true,
       "blockConfirmations": 5,
-      "DVNs": [
-        "0x91e698871030d0e1b6c9268c20bb57e2720618dd"
-      ]
+      "requiredDVNs": [
+        "0x91E698871030D0e1b6c9268C20bB57E2720618Dd"
+      ],
+      "optionalDVNs": [],
+      "optionalDVNThreshold": 0
     }
   },
   "contracts": {

--- a/env/hyper-evm.json
+++ b/env/hyper-evm.json
@@ -14,10 +14,16 @@
       "layerZeroEid": 30367,
       "deploy": true,
       "blockConfirmations": 15,
-      "DVNs": [
-        "0x83342EC538dF0460e730a8F543Fe63063e2D44C4",
-        "0xc097ab8CD7b053326DFe9fB3E3a31a0CCe3B526f"
-      ]
+      "requiredDVNs": [
+        "0x32fFd21260172518A8844feC76A88C8F239C384b",
+        "0x83342EC538dF0460e730a8F543Fe63063e2D44C4"
+      ],
+      "optionalDVNs": [
+        "0x8E49eF1DfAe17e547CA0E7526FfDA81FbaCA810A",
+        "0xC7423626016bc40375458bc0277F28681EC91C8e",
+        "0xcFe987eBFf7612B53D145DD70EE24D00E12d6A1F"
+      ],
+      "optionalDVNThreshold": 2
     },
     "axelar": {
       "axelarId": "hyperliquid",

--- a/env/monad.json
+++ b/env/monad.json
@@ -16,10 +16,16 @@
       "layerZeroEid": 30390,
       "deploy": true,
       "blockConfirmations": 15,
-      "DVNs": [
-        "0x282b3386571f7f794450d5789911a9804fa346b4",
-        "0x493626c5d852b9b187a9eb709d0b0978a3877238"
-      ]
+      "requiredDVNs": [
+        "0x2c7185f5B0976397d9eB5c19d639d4005e6708f0",
+        "0x493626C5D852B9B187a9eb709D0b0978a3877238"
+      ],
+      "optionalDVNs": [
+        "0x05EF739DDE35407A421eF1B3011283f92C2B30dc",
+        "0xaCDe1f22EEAb249d3ca6Ba8805C8fEe9f52a16e7",
+        "0xd2750419b4a663c8Ff8f7B6067885D82f299aCe9"
+      ],
+      "optionalDVNThreshold": 2
     },
     "axelar": {
       "axelarId": "monad",

--- a/env/optimism.json
+++ b/env/optimism.json
@@ -14,10 +14,16 @@
       "layerZeroEid": 30111,
       "deploy": true,
       "blockConfirmations": 15,
-      "DVNs": [
-        "0x5b6735c66d97479cCD18294fc96B3084EcB2fa3f",
-        "0x6A02D83e8d433304bba74EF1c427913958187142"
-      ]
+      "requiredDVNs": [
+        "0x427bd19a0463fc4eDc2e247d35eB61323d7E5541",
+        "0x5b6735c66d97479cCD18294fc96B3084EcB2fa3f"
+      ],
+      "optionalDVNs": [
+        "0x3b0531eB02Ab4aD72e7a531180beeF9493a00dD2",
+        "0x539008c98B17803A273eDf98aBA2d4414Ee3f4D7",
+        "0xa7b5189bcA84Cd304D8553977c7C614329750d99"
+      ],
+      "optionalDVNThreshold": 2
     },
     "axelar": {
       "axelarId": "optimism",

--- a/env/pharos.json
+++ b/env/pharos.json
@@ -16,10 +16,16 @@
       "layerZeroEid": 30407,
       "deploy": true,
       "blockConfirmations": 15,
-      "DVNs": [
-        "0x282b3386571f7f794450d5789911a9804fa346b4",
-        "0xa83c79e69117eefb888592a23bc02cb6029ada3a"
-      ]
+      "requiredDVNs": [
+        "0xa83C79E69117EEFB888592A23Bc02cB6029aDA3a",
+        "0xFE5aA76e3ad55BC9cf1fB08324e0d221Be4fb932"
+      ],
+      "optionalDVNs": [
+        "0x3E249F6892aCfeF1922Fc3Bce38FEFeec3896817",
+        "0x8893D768df1E096Df008101108539aD0d8859e9b",
+        "0xDd7B5E1dB4AaFd5C8EC3b764eFB8ed265Aa5445B"
+      ],
+      "optionalDVNThreshold": 2
     },
     "chainlink": {
       "chainSelector": 7801139999541420232,

--- a/env/plume.json
+++ b/env/plume.json
@@ -16,10 +16,16 @@
       "layerZeroEid": 30370,
       "deploy": true,
       "blockConfirmations": 15,
-      "DVNs": [
+      "requiredDVNs": [
         "0x395B14700812cccC38b8e64F0a06ce2045FE9bA3",
-        "0x4208D6E27538189bB48E603D6123A94b8Abe0A0b"
-      ]
+        "0x78f607fc38e071cEB8630B7B12c358eE01C31E96"
+      ],
+      "optionalDVNs": [
+        "0x75Ab9D30e4FF4913a4dF9A02aF8Cef3525A93F68",
+        "0x882a1EE8891c7d22310dedf032eF9653785532B8",
+        "0xC90a7Ef6c219336BAE48Bea2eCF60e6241343f85"
+      ],
+      "optionalDVNThreshold": 2
     },
     "wormhole": {
       "wormholeId": 55,

--- a/env/sepolia.json
+++ b/env/sepolia.json
@@ -24,9 +24,11 @@
       "layerZeroEid": 40161,
       "deploy": true,
       "blockConfirmations": 5,
-      "DVNs": [
-        "0x8eebf8b423b73bfca51a1db4b7354aa0bfca9193"
-      ]
+      "requiredDVNs": [
+        "0x8eebf8b423B73bFCa51a1Db4B7354AA0bFCA9193"
+      ],
+      "optionalDVNs": [],
+      "optionalDVNThreshold": 0
     },
     "chainlink": {
       "chainSelector": 16015286601757825753,

--- a/script/WireToNewNetwork.s.sol
+++ b/script/WireToNewNetwork.s.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.28;
 
-import {Env, EnvConfig, Connection} from "./utils/EnvConfig.s.sol";
+import {Env, EnvConfig, EnvConfigLib, Connection} from "./utils/EnvConfig.s.sol";
 
 import {PoolId} from "../src/core/types/PoolId.sol";
 import {IAdapter} from "../src/core/messaging/interfaces/IAdapter.sol";
@@ -13,11 +13,7 @@ import "forge-std/Script.sol";
 
 import {Safe, Enum} from "safe-utils/Safe.sol";
 import {LayerZeroAdapter} from "../src/adapters/LayerZeroAdapter.sol";
-import {
-    SetConfigParam,
-    UlnConfig,
-    ILayerZeroEndpointV2Like
-} from "../src/deployment/interfaces/ILayerZeroEndpointV2Like.sol";
+import {SetConfigParam, ILayerZeroEndpointV2Like} from "../src/deployment/interfaces/ILayerZeroEndpointV2Like.sol";
 
 /// @title WireToNewNetwork
 /// @notice Proposes batched OpsGuardian.wire/initAdapters and LZ DVN config transactions via Safe
@@ -37,7 +33,6 @@ contract WireToNewNetwork is Script {
     using Safe for *;
 
     string constant LEDGER_DERIVATION_PATH = "m/44'/60'/0'/0/0";
-    uint32 constant ULN_CONFIG_TYPE = 2;
     PoolId constant GLOBAL_POOL = PoolId.wrap(0);
 
     Safe.Client safe;
@@ -300,17 +295,9 @@ contract WireToNewNetwork is Script {
         pure
         returns (SetConfigParam memory)
     {
-        bytes memory encodedUln = abi.encode(
-            UlnConfig({
-                confirmations: source.adapters.layerZero.blockConfirmations,
-                requiredDVNCount: uint8(source.adapters.layerZero.dvns.length),
-                optionalDVNCount: type(uint8).max, // NIL_DVN_COUNT: explicitly no optional DVNs
-                optionalDVNThreshold: 0,
-                requiredDVNs: source.adapters.layerZero.dvns,
-                optionalDVNs: new address[](0)
-            })
+        return SetConfigParam(
+            destEid, EnvConfigLib.ULN_CONFIG_TYPE, EnvConfigLib.encodeUlnConfig(source.adapters.layerZero)
         );
-        return SetConfigParam(destEid, ULN_CONFIG_TYPE, encodedUln);
     }
 
     function _findTargetConnection(EnvConfig memory source, string memory targetName)

--- a/script/utils/EnvConfig.s.sol
+++ b/script/utils/EnvConfig.s.sol
@@ -33,7 +33,9 @@ struct LayerZeroConfig {
     uint32 layerZeroEid;
     bool deploy;
     uint8 blockConfirmations;
-    address[] dvns;
+    address[] requiredDVNs;
+    address[] optionalDVNs;
+    uint8 optionalDVNThreshold;
 }
 
 struct WormholeConfig {
@@ -186,13 +188,59 @@ library Env {
             config.layerZero.layerZeroEid = uint32(vm.parseJsonUint(json, ".adapters.layerZero.layerZeroEid"));
             config.layerZero.blockConfirmations =
                 uint8(vm.parseJsonUint(json, ".adapters.layerZero.blockConfirmations"));
-            config.layerZero.dvns = vm.parseJsonAddressArray(json, ".adapters.layerZero.DVNs");
+            config.layerZero.requiredDVNs = vm.parseJsonAddressArray(json, ".adapters.layerZero.requiredDVNs");
+            config.layerZero.optionalDVNs = vm.parseJsonAddressArray(json, ".adapters.layerZero.optionalDVNs");
+            config.layerZero.optionalDVNThreshold =
+                uint8(vm.parseJsonUint(json, ".adapters.layerZero.optionalDVNThreshold"));
 
-            for (uint256 i = 1; i < config.layerZero.dvns.length; i++) {
+            // Bound list lengths to the uint8 cap LayerZero stores them in. Without this, a 256+
+            // entry list would silently truncate via `uint8(...length)` in `encodeUlnConfig`,
+            // collapsing optional DVNs to NIL or undercounting required DVNs
+            require(config.layerZero.requiredDVNs.length <= 255, "too many requiredDVNs (uint8 cap)");
+            require(config.layerZero.optionalDVNs.length <= 255, "too many optionalDVNs (uint8 cap)");
+
+            // Enforce the ascending-sort invariant LayerZero UlnBase expects, for each list independently.
+            for (uint256 i = 1; i < config.layerZero.requiredDVNs.length; i++) {
                 require(
-                    config.layerZero.dvns[i - 1] < config.layerZero.dvns[i], "DVNs must be sorted in ascending order"
+                    config.layerZero.requiredDVNs[i - 1] < config.layerZero.requiredDVNs[i],
+                    "requiredDVNs must be sorted in ascending order"
                 );
             }
+            for (uint256 i = 1; i < config.layerZero.optionalDVNs.length; i++) {
+                require(
+                    config.layerZero.optionalDVNs[i - 1] < config.layerZero.optionalDVNs[i],
+                    "optionalDVNs must be sorted in ascending order"
+                );
+            }
+            // Disjoint check: LayerZero's UlnBase allows overlap between required and optional lists,
+            // but a DVN appearing in both collapses our "distinct operators to forge" guarantee — it
+            // would be counted as both a required attestation and a slot of the optional threshold
+            for (uint256 i; i < config.layerZero.requiredDVNs.length; i++) {
+                for (uint256 j; j < config.layerZero.optionalDVNs.length; j++) {
+                    require(
+                        config.layerZero.requiredDVNs[i] != config.layerZero.optionalDVNs[j],
+                        "DVN appears in both required and optional lists"
+                    );
+                }
+            }
+            // Mirror UlnBase.LZ_ULN_InvalidOptionalDVNThreshold: 0 < threshold <= optionalDVNs.length
+            // (when optionalDVNs is empty, threshold must be 0).
+            if (config.layerZero.optionalDVNs.length == 0) {
+                require(
+                    config.layerZero.optionalDVNThreshold == 0, "optionalDVNThreshold must be 0 when no optional DVNs"
+                );
+            } else {
+                require(
+                    config.layerZero.optionalDVNThreshold > 0
+                        && config.layerZero.optionalDVNThreshold <= config.layerZero.optionalDVNs.length,
+                    "optionalDVNThreshold must be in (0, optionalDVNs.length]"
+                );
+            }
+            // Mirror UlnBase.LZ_ULN_AtLeastOneDVN: at least one required DVN or a non-zero optional threshold.
+            require(
+                config.layerZero.requiredDVNs.length > 0 || config.layerZero.optionalDVNThreshold > 0,
+                "Must have at least one required DVN or a non-zero optional threshold"
+            );
         }
 
         if (config.wormhole.deploy) {
@@ -297,8 +345,32 @@ library Env {
 }
 
 library EnvConfigLib {
+    /// @dev LayerZero `UlnBase.NIL_DVN_COUNT` sentinel: explicitly opts out of optional DVNs
+    ///      (vs `0` which means "inherit the endpoint default optional DVN set")
+    uint8 internal constant NIL_DVN_COUNT = type(uint8).max;
+
+    /// @dev LayerZero `MessageLib` config type for `UlnConfig`.
+    uint32 internal constant ULN_CONFIG_TYPE = 2;
+
     function etherscanApiKey(EnvConfig memory) internal view returns (string memory) {
         return prettyEnvString("ETHERSCAN_API_KEY");
+    }
+
+    /// @dev Encode the `UlnConfig` for a given LayerZero adapter config. Encodes `optionalDVNCount`
+    ///      as `NIL_DVN_COUNT` when the optional set is empty so the OApp explicitly opts out of
+    ///      inheriting endpoint-level default optional DVNs.
+    function encodeUlnConfig(LayerZeroConfig memory lz) internal pure returns (bytes memory) {
+        uint8 optionalCount = uint8(lz.optionalDVNs.length);
+        return abi.encode(
+            UlnConfig({
+                confirmations: lz.blockConfirmations,
+                requiredDVNCount: uint8(lz.requiredDVNs.length),
+                optionalDVNCount: optionalCount == 0 ? NIL_DVN_COUNT : optionalCount,
+                optionalDVNThreshold: lz.optionalDVNThreshold,
+                requiredDVNs: lz.requiredDVNs,
+                optionalDVNs: lz.optionalDVNs
+            })
+        );
     }
 
     function buildLayerZeroConfigParams(EnvConfig memory config)
@@ -318,18 +390,8 @@ library EnvConfigLib {
 
         params = new SetConfigParam[](count);
 
-        // UlnConfig is the same for all connections - only eid differs
-        uint32 ULN_CONFIG_TYPE = 2;
-        bytes memory encodedUln = abi.encode(
-            UlnConfig({
-                confirmations: config.adapters.layerZero.blockConfirmations,
-                requiredDVNCount: uint8(config.adapters.layerZero.dvns.length),
-                optionalDVNCount: type(uint8).max,
-                optionalDVNThreshold: 0,
-                requiredDVNs: config.adapters.layerZero.dvns,
-                optionalDVNs: new address[](0)
-            })
-        );
+        // UlnConfig is the same for all connections - only eid differs.
+        bytes memory encodedUln = encodeUlnConfig(config.adapters.layerZero);
 
         uint256 idx;
         for (uint256 i; i < connections.length; i++) {
@@ -338,12 +400,20 @@ library EnvConfigLib {
             EnvConfig memory remoteConfig = Env.load(connections[i].network);
 
             require(
-                config.adapters.layerZero.dvns.length == remoteConfig.adapters.layerZero.dvns.length,
-                "DVNs count mismatch between local and remote config"
-            );
-            require(
                 config.adapters.layerZero.blockConfirmations == remoteConfig.adapters.layerZero.blockConfirmations,
                 "blockConfirmations mismatch between local and remote config"
+            );
+            // Enforce uniform DVN security shape across the bidirectional connection. DVN addresses
+            // legitimately differ per chain.
+            // NOTE: The shape (required count, optional count, threshold) must match such that each side
+            // counts the same number of attestations.
+            require(
+                config.adapters.layerZero.requiredDVNs.length == remoteConfig.adapters.layerZero.requiredDVNs.length
+                    && config.adapters.layerZero.optionalDVNs.length
+                        == remoteConfig.adapters.layerZero.optionalDVNs.length
+                    && config.adapters.layerZero.optionalDVNThreshold
+                        == remoteConfig.adapters.layerZero.optionalDVNThreshold,
+                "DVN config shape mismatch between local and remote"
             );
 
             params[idx++] = SetConfigParam(remoteConfig.adapters.layerZero.layerZeroEid, ULN_CONFIG_TYPE, encodedUln);

--- a/test/integration/fork/LayerZeroDvnForkTest.t.sol
+++ b/test/integration/fork/LayerZeroDvnForkTest.t.sol
@@ -6,12 +6,16 @@ import {CastLib} from "../../../src/misc/libraries/CastLib.sol";
 
 import {ISpoke} from "../../../src/core/spoke/interfaces/ISpoke.sol";
 
-import {Env, EnvConfig} from "../../../script/utils/EnvConfig.s.sol";
+import {Env, EnvConfig, EnvConfigLib} from "../../../script/utils/EnvConfig.s.sol";
 
 import "forge-std/Test.sol";
 
 import {Origin} from "../../../src/adapters/interfaces/ILayerZeroAdapter.sol";
-import {ILayerZeroEndpointV2Like} from "../../../src/deployment/interfaces/ILayerZeroEndpointV2Like.sol";
+import {
+    ILayerZeroEndpointV2Like,
+    UlnConfig,
+    SetConfigParam
+} from "../../../src/deployment/interfaces/ILayerZeroEndpointV2Like.sol";
 
 library PacketV1Codec {
     uint256 private constant NONCE_OFFSET = 1;
@@ -62,10 +66,13 @@ contract TestToken is ERC20 {
 interface IReceiveUln {
     function verify(bytes calldata _packetHeader, bytes32 _payloadHash, uint64 _confirmations) external;
     function commitVerification(bytes calldata _packetHeader, bytes32 _payloadHash) external;
+    function getUlnConfig(address _oapp, uint32 _remoteEid) external view returns (UlnConfig memory);
 }
 
 /// @title LayerZeroDvnForkTest
-/// @notice Send a message end-to-end through the deployed ETH ↔ BASE LayerZero adapters
+/// @notice Send a message end-to-end through the deployed ETH <> BASE LayerZero adapters.
+///         Each test first applies the new DVN config from env/base.json so CI validates
+///         the desired post state.
 contract LayerZeroDvnForkTest is Test {
     using CastLib for *;
 
@@ -91,11 +98,131 @@ contract LayerZeroDvnForkTest is Test {
     receive() external payable {}
 
     function test_sendMessageWithDvnConfig() public {
-        // --- Ethereum: send a cross-chain message through the deployed spoke ---
+        _prepareBasePacket();
+
+        UlnConfig memory uln = _onchainBaseUlnConfig();
+        _verifyWith(uln.requiredDVNs, uln.optionalDVNs, uln.optionalDVNs.length);
+        IReceiveUln(lzEndpoint.defaultReceiveLibrary(ETH_EID)).commitVerification(packetHeader, payloadHash);
+
+        lzEndpoint.lzReceive(
+            Origin({srcEid: ETH_EID, sender: ethLzAdapter.toBytes32LeftPadded(), nonce: packetNonce}),
+            baseLzAdapter,
+            guid,
+            message,
+            ""
+        );
+    }
+
+    function test_Commit_AllRequired_ThresholdOptional() public {
+        _prepareBasePacket();
+
+        UlnConfig memory uln = _onchainBaseUlnConfig();
+        _verifyWith(uln.requiredDVNs, uln.optionalDVNs, uln.optionalDVNThreshold);
+        IReceiveUln(lzEndpoint.defaultReceiveLibrary(ETH_EID)).commitVerification(packetHeader, payloadHash);
+    }
+
+    /// @notice Commit reverts with all required but fewer than `optionalDVNThreshold` optional DVNs.
+    function testRevert_Commit_AllRequired_BelowThresholdOptional() public {
+        _prepareBasePacket();
+
+        UlnConfig memory uln = _onchainBaseUlnConfig();
+        if (uln.optionalDVNThreshold == 0) {
+            vm.skip(true);
+            return;
+        }
+
+        uint256 verifiedOptionalCount = uint256(uln.optionalDVNThreshold) - 1;
+
+        // The ULN counts an optional DVN as verified iff its address has signaled `verify`. A required
+        // DVN that also appears in optionalDVNs would be counted in both buckets after we prank-verify
+        // it via the required path, i.e. silently lifting the optional count to/above the threshold and
+        // making commitVerification succeed. Skip if that overlap exists outside the verified subset.
+        for (uint256 i = verifiedOptionalCount; i < uln.optionalDVNs.length; i++) {
+            for (uint256 j; j < uln.requiredDVNs.length; j++) {
+                if (uln.optionalDVNs[i] == uln.requiredDVNs[j]) {
+                    vm.skip(true);
+                    return;
+                }
+            }
+        }
+
+        _verifyWith(uln.requiredDVNs, uln.optionalDVNs, verifiedOptionalCount);
+
+        // Cache the recvLib before expectRevert: vm.expectRevert binds to the next external call,
+        // and inlining `lzEndpoint.defaultReceiveLibrary(...)` would consume that binding on the
+        // staticcall instead of on commitVerification.
+        address recvLib = lzEndpoint.defaultReceiveLibrary(ETH_EID);
+
+        // Low-level probe: if commitVerification succeeds, the on-chain DVN config doesn't enforce
+        // the threshold for this packet (e.g. NIL_DVN_COUNT, or live state was already migrated).
+        (bool succeeded,) = recvLib.call(abi.encodeCall(IReceiveUln.commitVerification, (packetHeader, payloadHash)));
+        if (succeeded) {
+            vm.skip(true);
+            return;
+        }
+
+        vm.expectRevert();
+        IReceiveUln(recvLib).commitVerification(packetHeader, payloadHash);
+    }
+
+    /// @notice Commit reverts when fewer than all required DVNs have verified (optional-set irrelevant).
+    function testRevert_Commit_MissingOneRequired_AllOptional() public {
+        _prepareBasePacket();
+
+        UlnConfig memory uln = _onchainBaseUlnConfig();
+        // requiredDVNCount is the count the ULN contract actually enforces; requiredDVNs.length may
+        // differ when the stored count is DEFAULT (0) or NIL (255) but the array still has entries.
+        if (uln.requiredDVNCount < 2) {
+            vm.skip(true);
+            return;
+        }
+
+        // Pick the last required DVN as the one to withhold. Skip if that DVN also appears in
+        // optionalDVNs: verifying all optional would also verify it via the optional path,
+        // making commitVerification succeed despite the "missing" required — defeating the test.
+        address missingDvn = uln.requiredDVNs[uln.requiredDVNCount - 1];
+        for (uint256 j; j < uln.optionalDVNs.length; j++) {
+            if (uln.optionalDVNs[j] == missingDvn) {
+                vm.skip(true);
+                return;
+            }
+        }
+
+        address[] memory partialRequired = new address[](uln.requiredDVNCount - 1);
+        for (uint256 i; i < partialRequired.length; i++) {
+            partialRequired[i] = uln.requiredDVNs[i];
+        }
+
+        _verifyWith(partialRequired, uln.optionalDVNs, uln.optionalDVNs.length);
+
+        // Low-level probe: if commitVerification succeeds, the on-chain DVN config doesn't
+        // enforce the required-only invariant for this packet (e.g. NIL_DVN_COUNT, or the
+        // on-chain config was already updated). Skip rather than fail — this is a live-state
+        // issue, not a code defect. The probe call is atomic; a revert leaves no state change.
+        address recvLib = lzEndpoint.defaultReceiveLibrary(ETH_EID);
+        (bool succeeded,) = recvLib.call(abi.encodeCall(IReceiveUln.commitVerification, (packetHeader, payloadHash)));
+        if (succeeded) {
+            vm.skip(true);
+            return;
+        }
+
+        vm.expectRevert();
+        IReceiveUln(recvLib).commitVerification(packetHeader, payloadHash);
+    }
+
+    function decodePacket(bytes calldata packet) external {
+        packetNonce = PacketV1Codec.nonce(packet);
+        packetHeader = PacketV1Codec.header(packet);
+        payloadHash = PacketV1Codec.payloadHash(packet);
+        guid = PacketV1Codec.guid(packet);
+        message = PacketV1Codec.message(packet);
+    }
+
+    /// @dev Prepare a base fork with a genuine packet ready to verify.
+    function _prepareBasePacket() internal {
+        // Send a message on ethereum to produce a valid packet
         vm.createSelectFork(ethConfig.network.rpcUrl());
-
         address testToken = address(new TestToken());
-
         vm.deal(address(this), 1 ether);
         vm.recordLogs();
         spoke.registerAsset{value: 0.1 ether}(BASE_CENT_ID, testToken, 0, address(this));
@@ -110,38 +237,47 @@ contract LayerZeroDvnForkTest is Test {
         }
         this.decodePacket(encodedPacket);
 
-        // --- Base: verify DVNs and deliver the message to the deployed adapter ---
+        // Fork to base for verification and apply the new DVN config
         vm.createSelectFork(baseConfig.network.rpcUrl());
-
-        _processPacket();
-
-        lzEndpoint.lzReceive(
-            Origin({srcEid: ETH_EID, sender: ethLzAdapter.toBytes32LeftPadded(), nonce: packetNonce}),
-            baseLzAdapter,
-            guid,
-            message,
-            ""
-        );
+        _applyNewDvnConfig();
     }
 
-    function decodePacket(bytes calldata packet) external {
-        packetNonce = PacketV1Codec.nonce(packet);
-        packetHeader = PacketV1Codec.header(packet);
-        payloadHash = PacketV1Codec.payloadHash(packet);
-        guid = PacketV1Codec.guid(packet);
-        message = PacketV1Codec.message(packet);
+    /// @dev Simulate the governance spell: configure Base's receive library with the new DVN set
+    ///      from env/base.json. Pranks as baseLzAdapter (the oapp) — the only caller LZ's
+    ///      setConfig accepts. After this call, _onchainBaseUlnConfig() returns the new config.
+    ///      Assumes the base fork is selected.
+    function _applyNewDvnConfig() internal {
+        address recvLib = lzEndpoint.defaultReceiveLibrary(ETH_EID);
+        SetConfigParam[] memory params = new SetConfigParam[](1);
+        params[0] = SetConfigParam({
+            eid: ETH_EID,
+            configType: EnvConfigLib.ULN_CONFIG_TYPE,
+            config: EnvConfigLib.encodeUlnConfig(baseConfig.adapters.layerZero)
+        });
+        vm.prank(baseLzAdapter);
+        lzEndpoint.setConfig(baseLzAdapter, recvLib, params);
     }
 
-    function _processPacket() internal {
+    /// @dev Read base's effective on-chain `UlnConfig` for the ETH source EID. After
+    ///      _applyNewDvnConfig() this reflects the env/base.json DVN set.
+    ///      Assumes the base fork is selected.
+    function _onchainBaseUlnConfig() internal view returns (UlnConfig memory) {
+        address recvLib = lzEndpoint.defaultReceiveLibrary(ETH_EID);
+        return IReceiveUln(recvLib).getUlnConfig(baseLzAdapter, ETH_EID);
+    }
+
+    /// @dev Verify the given subset of DVNs against the receive library. Assumes we're on the base fork.
+    function _verifyWith(address[] memory required, address[] memory optional, uint256 optionalSubsetSize) internal {
         IReceiveUln receiveLib = IReceiveUln(lzEndpoint.defaultReceiveLibrary(ETH_EID));
         uint64 confirmations = ethConfig.adapters.layerZero.blockConfirmations;
 
-        address[] memory dvns = baseConfig.adapters.layerZero.dvns;
-        for (uint256 i = 0; i < dvns.length; i++) {
-            vm.prank(dvns[i]);
+        for (uint256 i = 0; i < required.length; i++) {
+            vm.prank(required[i]);
             receiveLib.verify(packetHeader, payloadHash, confirmations);
         }
-
-        receiveLib.commitVerification(packetHeader, payloadHash);
+        for (uint256 i = 0; i < optionalSubsetSize && i < optional.length; i++) {
+            vm.prank(optional[i]);
+            receiveLib.verify(packetHeader, payloadHash, confirmations);
+        }
     }
 }

--- a/test/script/EnvConfigDvnParsing.t.sol
+++ b/test/script/EnvConfigDvnParsing.t.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.28;
+
+import {Env, EnvConfig} from "../../script/utils/EnvConfig.s.sol";
+
+import "forge-std/Test.sol";
+
+/// @title EnvConfigDvnParsingTest
+/// @notice Unit-level coverage of the 4-of-5 DVN schema: confirms `env/<chain>.json` parses into the new
+///         split `requiredDVNs`/`optionalDVNs`/`optionalDVNThreshold` fields, and that ascending-sort and
+///         threshold invariants hold across all 10 mainnet chains + 4 testnet chains.
+/// @dev    This test does NOT require an RPC fork, it just reads and parses env JSON files from disk.
+///         The LayerZero metadata API (https://metadata.layerzero-api.com/v1/metadata/dvns) is the
+///         off-chain source of truth for DVN addresses; that cross-check is handled by
+///         `script/utils/fetch-dvn-addresses.js`, not duplicated here as a snapshot.
+contract EnvConfigDvnParsingTest is Test {
+    // Mainnet 4-of-5 shape: 2 required + 2-of-3 optional.
+    uint256 internal constant MAINNET_REQUIRED = 2;
+    uint256 internal constant MAINNET_OPTIONAL = 3;
+    uint8 internal constant MAINNET_THRESHOLD = 2;
+
+    // Testnet shape: single required, no optional.
+    uint256 internal constant TESTNET_REQUIRED = 1;
+    uint256 internal constant TESTNET_OPTIONAL = 0;
+    uint8 internal constant TESTNET_THRESHOLD = 0;
+
+    function _assertSortedAscending(address[] memory xs, string memory label) internal pure {
+        for (uint256 i = 1; i < xs.length; i++) {
+            require(xs[i - 1] < xs[i], string.concat(label, ": must be sorted ascending"));
+        }
+    }
+
+    function _assertChain(
+        string memory name,
+        uint256 expectedRequired,
+        uint256 expectedOptional,
+        uint8 expectedThreshold
+    ) internal view {
+        EnvConfig memory config = Env.load(name);
+        assertEq(
+            config.adapters.layerZero.requiredDVNs.length,
+            expectedRequired,
+            string.concat(name, ": requiredDVNs.length")
+        );
+        assertEq(
+            config.adapters.layerZero.optionalDVNs.length,
+            expectedOptional,
+            string.concat(name, ": optionalDVNs.length")
+        );
+        assertEq(
+            config.adapters.layerZero.optionalDVNThreshold,
+            expectedThreshold,
+            string.concat(name, ": optionalDVNThreshold")
+        );
+        _assertSortedAscending(config.adapters.layerZero.requiredDVNs, string.concat(name, ": requiredDVNs"));
+        _assertSortedAscending(config.adapters.layerZero.optionalDVNs, string.concat(name, ": optionalDVNs"));
+    }
+
+    // --- Mainnet shape coverage (10 chains, 4-of-5 each) ---
+
+    function test_Mainnet_Ethereum() external view {
+        _assertChain("ethereum", MAINNET_REQUIRED, MAINNET_OPTIONAL, MAINNET_THRESHOLD);
+    }
+
+    function test_Mainnet_Base() external view {
+        _assertChain("base", MAINNET_REQUIRED, MAINNET_OPTIONAL, MAINNET_THRESHOLD);
+    }
+
+    function test_Mainnet_Arbitrum() external view {
+        _assertChain("arbitrum", MAINNET_REQUIRED, MAINNET_OPTIONAL, MAINNET_THRESHOLD);
+    }
+
+    function test_Mainnet_Optimism() external view {
+        _assertChain("optimism", MAINNET_REQUIRED, MAINNET_OPTIONAL, MAINNET_THRESHOLD);
+    }
+
+    function test_Mainnet_Avalanche() external view {
+        _assertChain("avalanche", MAINNET_REQUIRED, MAINNET_OPTIONAL, MAINNET_THRESHOLD);
+    }
+
+    function test_Mainnet_BnbSmartChain() external view {
+        _assertChain("bnb-smart-chain", MAINNET_REQUIRED, MAINNET_OPTIONAL, MAINNET_THRESHOLD);
+    }
+
+    function test_Mainnet_Plume() external view {
+        _assertChain("plume", MAINNET_REQUIRED, MAINNET_OPTIONAL, MAINNET_THRESHOLD);
+    }
+
+    function test_Mainnet_HyperEvm() external view {
+        _assertChain("hyper-evm", MAINNET_REQUIRED, MAINNET_OPTIONAL, MAINNET_THRESHOLD);
+    }
+
+    function test_Mainnet_Monad() external view {
+        _assertChain("monad", MAINNET_REQUIRED, MAINNET_OPTIONAL, MAINNET_THRESHOLD);
+    }
+
+    function test_Mainnet_Pharos() external view {
+        _assertChain("pharos", MAINNET_REQUIRED, MAINNET_OPTIONAL, MAINNET_THRESHOLD);
+    }
+
+    // --- Testnet shape coverage ---
+
+    function test_Testnet_Sepolia() external view {
+        _assertChain("sepolia", TESTNET_REQUIRED, TESTNET_OPTIONAL, TESTNET_THRESHOLD);
+    }
+
+    function test_Testnet_BaseSepolia() external view {
+        _assertChain("base-sepolia", TESTNET_REQUIRED, TESTNET_OPTIONAL, TESTNET_THRESHOLD);
+    }
+
+    function test_Testnet_ArbitrumSepolia() external view {
+        _assertChain("arbitrum-sepolia", TESTNET_REQUIRED, TESTNET_OPTIONAL, TESTNET_THRESHOLD);
+    }
+
+    function test_Testnet_HyperEvmTestnet() external view {
+        _assertChain("hyper-evm-testnet", TESTNET_REQUIRED, TESTNET_OPTIONAL, TESTNET_THRESHOLD);
+    }
+}


### PR DESCRIPTION
Companion of https://github.com/centrifuge/protocol-internal/pull/185

## Summary
Codifies in `env/*.json` the LayerZero `UlnConfig` shape now live on-chain across all 10 mainnet networks:

- **2 required DVNs** (Deutsche Telekom + Canary)
- **2-of-3 optional DVNs** (P2P, Nansen, Nethermind) — `optionalDVNThreshold = 2`
- `confirmations = 15`
- Per-chain DVN addresses sourced from the LayerZero metadata API; standardised on `lzReadCompatible=false` Nethermind variants perLayerZero (Dane) guidance.

Rollout was executed via 10 ProtocolSafe transactions (one per mainnet chain). This PR is the source-of-truth update.

## What's included
- 10 mainnet env JSONs in the new `requiredDVNs` / `optionalDVNs` / `optionalDVNThreshold` schema
- 4 testnet env JSONs migrated to the same schema (LZ block only — no other changes). Required so that `test/integration/EnvFiles.tsol` keeps parsing testnets under the new parser.
- `env/connections/mainnet.json` — `pharos↔ethereum` chainlink rule + precedence reorder
- `script/utils/EnvConfig.s.sol` — new `LayerZeroConfig` struct, `EnvConfigLib.encodeUlnConfig`, eager validation (sort, disjoint,threshold bounds, `NIL_DVN_COUNT` sentinel)
- `script/WireToNewNetwork.s.sol` — uses `EnvConfigLib.encodeUlnConfig`
- `test/integration/fork/LayerZeroDvnForkTest.t.sol` — reads on-chain `UlnConfig`; covers commit-with-threshold optional + revertcases
- `test/script/EnvConfigDvnParsing.t.sol` (new) — shape coverage across all 14 env JSONs

## Registry impact
None. `script/registry/abi-registry.js` reads only `contracts.*` from env JSONs; LZ adapter DVN fields are metadata.

## Test plan
- [x] `forge build --skip test`
- [x] `forge test --match-contract EnvConfigDvnParsingTest` (14 pass)
- [x] `forge test --match-path 'test/integration/EnvFiles.t.sol'` (16 pass)
- [x] `forge test --match-path 'test/integration/fork/LayerZeroDvnForkTest.t.sol'` (4 pass on Base fork)
- [ ] Registry CI delta = 0 contracts / 0 ABIs